### PR TITLE
Discover all Visual Studio Installs.

### DIFF
--- a/src/kit.ts
+++ b/src/kit.ts
@@ -374,7 +374,7 @@ export async function vsInstallations(): Promise<VSInstallation[]> {
   for (const inst of vs_installs) {
     const majorVersion = parseInt(inst.installationVersion);
       if (majorVersion >= 15) {
-      inst.instanceId = `VisualStudio.${majorVersion}.0`;
+      inst.instanceId = `${inst.displayName}`;
     }
     if (inst_ids.indexOf(inst.instanceId) < 0) {
       installs.push(inst);


### PR DESCRIPTION
It is possible to have multiple versions of Visual Studio. For example
Professional and Enterprise. Previously only one version could be
registered, potentially causing problems.

Closes: #611
Test: Scanning of kits succeed, with reasonable (but longer) display name.

## This change addresses item #611]

### This changes visible behavior

The following changes are proposed:

Now shows the complete name of Visual Studio in discovered kits

## The purpose of this change

Fix a bug when there are multiple installations of visual studio, but making only one available.