### PR TITLE
Support usage of environment variables for toolchainFile in kits

### DIFF
--- a/src/kit.ts
+++ b/src/kit.ts
@@ -741,7 +741,7 @@ export function descriptionForKit(kit: Kit) {
 
 /**
  * Process parameters of the kit and perform any desired transformations.
- * 
+ *
  * Right now, this resolves environment variables used in the tool chain file. This logic could be expanded elsewhere to enable environment variable resolution elsewhere.
  *
  * May no longer be necessary if we can leverage some part of https://github.com/Microsoft/vscode/issues/2809 should it be completed and shipped.
@@ -751,11 +751,9 @@ export function descriptionForKit(kit: Kit) {
 export function processKit(kit: Kit) {
 	if (kit.toolchainFile) {
 		// map ${foo} -> process.env[foo] to resolve corresponding environment variables
-		const re = /\$\{(\w+)\}/;
-		const resolvedToolchainFile = kit.toolchainFile.replace(re, function(str, p1, offset, s) {
-			return process.env[p1];
-		});
-		kit.toolchainFile = resolvedToolchainFile;
+		kit.toolchainFile = kit.toolchainFile.replace(/\$\{(\w+)\}/, (_str: string, p1: string, ..._args) => {
+      return process.env[p1] as string;
+    });
 	}
 
 	return kit;

--- a/src/kit.ts
+++ b/src/kit.ts
@@ -749,14 +749,14 @@ export function descriptionForKit(kit: Kit) {
  * @param kit A kit json structure
  */
 export function processKit(kit: Kit) {
-	if (kit.toolchainFile) {
-		// map ${foo} -> process.env[foo] to resolve corresponding environment variables
-		kit.toolchainFile = kit.toolchainFile.replace(/\$\{(\w+)\}/, (_str: string, p1: string, ..._args) => {
+  if (kit.toolchainFile) {
+    // map ${foo} -> process.env[foo] to resolve corresponding environment variables
+    kit.toolchainFile = kit.toolchainFile.replace(/\$\{(\w+)\}/, (_str: string, p1: string, ..._args) => {
       return process.env[p1] as string;
     });
-	}
+  }
 
-	return kit;
+  return kit;
 }
 
 export async function readKitsFile(filepath: string): Promise<Kit[]> {

--- a/test/unit-tests/kitmanager.test.ts
+++ b/test/unit-tests/kitmanager.test.ts
@@ -19,8 +19,13 @@ suite('Kits test', async () => {
       'CompilerKit 2',
       'CompilerKit 3 with PreferedGenerator',
       'ToolchainKit 1',
+      'ToolchainKit 2',
       'VSCode Kit 1',
       'VSCode Kit 2',
     ]);
+
+    // ${CMAKE_TOOLS_TEST_SOME_ENV_VAR}/toolchain.cmake -> Test/toolchain.cmake if our env var mapping works.
+    process.env["CMAKE_TOOLS_TEST_SOME_ENV_VAR"] = "Test";
+    expect(kits.filter(k => "ToolchainKit 2" == k.name)[0].toolchainFile).to.eq("Test/toolchain.cmake");
   });
 });

--- a/test/unit-tests/kitmanager.test.ts
+++ b/test/unit-tests/kitmanager.test.ts
@@ -9,8 +9,12 @@ function getTestResourceFilePath(filename: string): string {
   return path.normalize(path.join(here, '../../../test/unit-tests', filename));
 }
 
-
+// for safety, ensure we reset the state of the process.env after every test since we're manipulating it in this suite.
+const env = {...process.env};
 suite('Kits test', async () => {
+  teardown(() => {
+    process.env = env;
+  });
   test('Test load of kit from test file', async () => {
     const kits = await readKitsFile(getTestResourceFilePath('test_kit.json'));
     const names = kits.map(k => k.name);
@@ -23,9 +27,12 @@ suite('Kits test', async () => {
       'VSCode Kit 1',
       'VSCode Kit 2',
     ]);
-
+  });
+  test('Test use of env var in toolchain kit specified from test file', async () => {
     // ${CMAKE_TOOLS_TEST_SOME_ENV_VAR}/toolchain.cmake -> Test/toolchain.cmake if our env var mapping works.
-    process.env["CMAKE_TOOLS_TEST_SOME_ENV_VAR"] = "Test";
+    process.env.CMAKE_TOOLS_TEST_SOME_ENV_VAR = "Test";
+    const kits = await readKitsFile(getTestResourceFilePath('test_kit.json'));
+
     expect(kits.filter(k => "ToolchainKit 2" == k.name)[0].toolchainFile).to.eq("Test/toolchain.cmake");
   });
 });

--- a/test/unit-tests/test_kit.json
+++ b/test/unit-tests/test_kit.json
@@ -26,7 +26,7 @@
     },
     {
         "name": "ToolchainKit 2",
-        "toolchainFile": "${SOMEENVVAR}/toolchain.cmake"
+        "toolchainFile": "${CMAKE_TOOLS_TEST_SOME_ENV_VAR}/toolchain.cmake"
     },
     {
         "name": "VSCode Kit 1",

--- a/test/unit-tests/test_kit.json
+++ b/test/unit-tests/test_kit.json
@@ -25,6 +25,10 @@
         "toolchainFile": "toolchain.cmake"
     },
     {
+        "name": "ToolchainKit 2",
+        "toolchainFile": "${SOMEENVVAR}/toolchain.cmake"
+    },
+    {
         "name": "VSCode Kit 1",
         "visualStudio": "Visual Studio 2015",
         "visualStudioArchitecture": "x86"


### PR DESCRIPTION
### This changes kit handling to support environment variables (${SOME_ENV_VAR} pattern) for toolchainFile setting

The following changes are proposed:

- Add a processKit method to post-process kits from the .json spec 
- Leverage processKit method to resolve environment variables used for the toolchainFile setting.
- Add unit test to ensure it works.

## The purpose of this change
Scratching one of my itches using this extension. I wanted to use an env var to specify where my vcpkg toolchain is installed, rather than hardcode it. This does what I want, but feel free to suggest a better way if you can think of one.