### PR TITLE
CTest controller is updated on reconfig (related to issue #212).

### DIFF
--- a/src/cmake-tools.ts
+++ b/src/cmake-tools.ts
@@ -529,6 +529,7 @@ export class CMakeTools implements vscode.Disposable, api.CMakeToolsAPI {
                 if (retc === 0) {
                   await this._refreshCompileDatabase(drv.expansionOptions);
                 }
+                await this._ctestController.reloadTests(drv);
                 this._onReconfiguredEmitter.fire();
                 return retc;
               } finally {


### PR DESCRIPTION
## This change relates to item #212

### This changes visible behavior.

### The following changes are proposed:

#### src/cmake-tools.ts
* CMakeTools.configure executes CTestDriver.reloadTests

## The purpose of this change

The Run CTest button in the status bar is not updated when a reconfiguration happens. This change makes sure that the the Run CTest button visible in the status bar after a configuration action has been performed.