### PR TITLE
Expand kit environment variables.

### DIFF
--- a/src/driver.ts
+++ b/src/driver.ts
@@ -301,7 +301,7 @@ export abstract class CMakeDriver implements vscode.Disposable {
   private async _setKit(kit: Kit): Promise<void> {
     this._kit = Object.seal({...kit});
     log.debug('CMakeDriver Kit set to', kit.name);
-    this._kitEnvironmentVariables = await effectiveKitEnvironment(kit);
+    this._kitEnvironmentVariables = await effectiveKitEnvironment(kit, this.expansionOptions);
   }
 
   protected abstract doSetKit(needsClean: boolean, cb: () => Promise<void>): Promise<void>;


### PR DESCRIPTION
<!-- Thanks for your contribution! To make things easier, please fill out the template below. -->

<!-- Please delete any unused sections. -->

<!-- Delete the following heading if there is no corresponding issue -->
## This change addresses item #460

### This changes visible behavior

The following changes are proposed:

- `environmentVariables` of kits are expanded.
- This allows appending or prepending to `PATH`, among other things.

## Other Notes/Information

This does not add `prependPath` or `appendPath` as mentioned in the issue.
