### PR TITLE
activate the extension if CMakeLists.txt exists in subfolders

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "onCommand:cmake.stop",
     "onCommand:cmake.outline.configure",
     "onCommand:cmake.outline.build",
-    "workspaceContains:CMakeLists.txt",
+    "workspaceContains:**/CMakeLists.txt",
     "workspaceContains:.vscode/cmake-kits.json"
   ],
   "main": "./out/src/extension",


### PR DESCRIPTION
<!-- Thanks for your contribution! To make things easier, please fill out the template below. -->

<!-- Please delete any unused sections. -->

<!-- Delete the following heading if there is no corresponding issue -->
## This change addresses item #533 

### This changes activation policy

The following changes are proposed:

Activate CMake Tools when a CMakeLists.txt is found anywhere in the workspace folder.

## The purpose of this change

Improve auto-configuration for newly opened folders
