### PR TITLE
Fix kits to allow for multiple VS SKUs+Preview in Kits

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -941,13 +941,14 @@ class ExtensionManager implements vscode.Disposable {
     }
     log.debug('Opening kit selection QuickPick');
     // Generate the quickpick items from our known kits
-    const items = this._allKits.map(
-        (kit): KitItem => ({
+    const itemPromises = this._allKits.map(
+        async (kit): Promise<KitItem> => ({
           label: kit.name !== '__unspec__' ? kit.name : '[Unspecified]',
-          description: descriptionForKit(kit),
+          description: await descriptionForKit(kit),
           kit,
         }),
     );
+    const items = await Promise.all(itemPromises);
     const chosen_kit = await vscode.window.showQuickPick(items, {placeHolder: 'Select a Kit'});
     if (chosen_kit === undefined) {
       log.debug('User cancelled Kit selection');


### PR DESCRIPTION
<!-- Thanks for your contribution! To make things easier, please fill out the template below. -->

<!-- Please delete any unused sections. -->

<!-- Delete the following heading if there is no corresponding issue -->
## This change addresses item #611

### This changes visible behavior
The following changes are proposed:
Clean up naming of compilers, and discover all kits on PC

## Other Notes/Information
We may want another change that forces a rescan of kits so that we don't have to support the old schema indefinitely
<!-- Write whatever you feel is relevant -->
Replaces PR #613 