### PR TITLE
Add new commands, cmake.buildType and cmake.buildDirectory

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,8 @@
     "onCommand:cmake.launchTarget",
     "onCommand:cmake.launchTargetPath",
     "onCommand:cmake.launchTargetDirectory",
+    "onCommand:cmake.buildType",
+    "onCommand:cmake.buildDirectory",
     "onCommand:cmake.tasksBuildCommand",
     "onCommand:cmake.quickStart",
     "onCommand:cmake.resetState",

--- a/src/api.ts
+++ b/src/api.ts
@@ -290,6 +290,16 @@ export interface CMakeToolsAPI extends Disposable {
   launchTargetDirectory(): Thenable<string|null>;
 
   /**
+   * Get the selected build type
+   */
+  currentBuildType(): Thenable<string|null>;
+
+  /**
+   * Get the build directory.
+   */
+  buildDirectory(): Thenable<string|null>;
+
+  /**
    * Get the build command string for the active target
    */
   tasksBuildCommand(): Thenable<string|null>;

--- a/src/cmake-tools.ts
+++ b/src/cmake-tools.ts
@@ -974,6 +974,28 @@ export class CMakeTools implements vscode.Disposable, api.CMakeToolsAPI {
     return path.dirname(targetPath);
   }
 
+  /**
+   * Implementation of `cmake.buildType`
+   */
+  async currentBuildType(): Promise<string|null> {
+    if (this.buildType == 'Unconfigured') {
+      return null;
+    }
+    return this.buildType;
+  }
+
+  /**
+   * Implementation of `cmake.buildDirectory`
+   */
+  async buildDirectory(): Promise<string|null> {
+    const binaryDir = await this.binaryDir;
+    if (binaryDir) {
+      return binaryDir;
+    } else {
+      return null;
+    }
+  }
+
   async prepareLaunchTargetExecutable(name?: string): Promise<api.ExecutableTarget|null> {
     let chosen: api.ExecutableTarget;
     if (name) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1069,6 +1069,10 @@ class ExtensionManager implements vscode.Disposable {
 
   launchTargetDirectory() { return this.withCMakeTools(null, cmt => cmt.launchTargetDirectory()); }
 
+  buildType() { return this.withCMakeTools(null, cmt => cmt.currentBuildType()); }
+
+  buildDirectory() { return this.withCMakeTools(null, cmt => cmt.buildDirectory()); }
+
   tasksBuildCommand() { return this.withCMakeTools(null, cmt => cmt.tasksBuildCommand()); }
 
   debugTarget(name?: string) { return this.withCMakeTools(null, cmt => cmt.debugTarget(name)); }
@@ -1131,12 +1135,33 @@ async function setup(context: vscode.ExtensionContext, progress: ProgressHandle)
 
   // List of functions that will be bound commands
   const funs: (keyof ExtensionManager)[] = [
-    'editKits',          'scanForKits',        'selectKit',        'setKitByName',          'cleanConfigure',
-    'configure',         'build',              'setVariant',       'install',               'editCache',
-    'clean',             'cleanRebuild',       'buildWithTarget',  'setDefaultTarget',      'ctest',
-    'stop',              'quickStart',         'launchTargetPath', 'launchTargetDirectory', 'debugTarget',
-    'launchTarget',      'selectLaunchTarget', 'resetState',       'viewLog',               'compileFile',
-    'tasksBuildCommand'
+    'editKits',
+    'scanForKits',
+    'selectKit',
+    'setKitByName',
+    'cleanConfigure',
+    'configure',
+    'build',
+    'setVariant',
+    'install',
+    'editCache',
+    'clean',
+    'cleanRebuild',
+    'buildWithTarget',
+    'setDefaultTarget',
+    'ctest',
+    'stop',
+    'quickStart',
+    'launchTargetPath',
+    'launchTargetDirectory',
+    'buildType',
+    'buildDirectory',
+    'debugTarget',
+    'launchTarget',
+    'selectLaunchTarget',
+    'resetState',
+    'viewLog',
+    'compileFile',
     // 'toggleCoverageDecorations', // XXX: Should coverage decorations be revived?
   ];
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1162,6 +1162,7 @@ async function setup(context: vscode.ExtensionContext, progress: ProgressHandle)
     'resetState',
     'viewLog',
     'compileFile',
+    'tasksBuildCommand'
     // 'toggleCoverageDecorations', // XXX: Should coverage decorations be revived?
   ];
 


### PR DESCRIPTION
## This change addresses items #564 and #334

- `${command:cmake.buildType}` can be used to get the selected build type.
- `${command:cmake.buildDirectory}` can be used to get the current build directory.
