### PR TITLE
Only replace last instance of 'gcc' with 'gdb' when searching for gdb executable.

### DIFF
--- a/src/debugger.ts
+++ b/src/debugger.ts
@@ -165,7 +165,7 @@ export async function getDebugConfigurationFromCache(cache: CMakeCache, target: 
 
   const debugger_name = platform == 'darwin' ? 'lldb' : 'gdb';
   const description = DEBUG_GEN[debugger_name];
-  const gcc_compiler_regex = /([cg]\+\+|g?cc)+/gi;
+  const gcc_compiler_regex = /([cg]\+\+|g?cc)(?=\.exe$|$)/gi;
   const gdb_debugger_path = compiler_path.replace(gcc_compiler_regex, description.miMode);
   if (gdb_debugger_path.search(new RegExp(description.miMode)) != -1) {
     return description.createConfig(gdb_debugger_path, target);


### PR DESCRIPTION
## This change addresses how cmake tools finds the debugger executable

The current regular expression `/([cg]\+\+|g?cc)+/gi` replaces every instance of the word `gcc` with `gdb` when trying to find the gdb executable. Consequently, if the path includes the word `gcc`, the debugger executable is not found.

Example of substitution:
> `gcc-arm-none-eabi-win32/main/bin/arm-none-eabi-gcc.exe` -> `gdb-arm-none-eabi-win32/main/bin/arm-none-eabi-gdb.exe`
> `myGCC.exe/directory/arm-none-eabi-gcc.exe` -> `mygdb.exe/directory/arm-none-eabi-gdb.exe`
> `/opt/gcc-4.8/bin/arm-none-eabi-gcc` -> `/opt/gdb-4.8/bin/arm-none-eabi-gdb`

The improved regular expression `/([cg]\+\+|g?cc)(?=\.exe$|$)/gi` only replaces the instance of word `gcc` at the end of the string or if it is followed by `.exe`.

Example of substitution:
> `gcc-arm-none-eabi-win32/main/bin/arm-none-eabi-gcc.exe` -> `gcc-arm-none-eabi-win32/main/bin/arm-none-eabi-gdb.exe`
> `myGCC.exe/directory/arm-none-eabi-gcc.exe` -> `myGCC.exe/directory/arm-none-eabi-gdb.exe`
> `/opt/gcc-4.8/bin/arm-none-eabi-gcc` -> `/opt/gcc-4.8/bin/arm-none-eabi-gdb`