### PR TITLE
Recalculate total for ctest for every run

### DIFF
--- a/src/ctest.ts
+++ b/src/ctest.ts
@@ -329,7 +329,7 @@ export class CTestDriver implements vscode.Disposable {
   set testResults(v: CTestResults|null) {
     this._testResults = v;
     if (v) {
-      const total = this.tests.length;
+      const total = v.Site.Testing.Test.length;
       const passing = v.Site.Testing.Test.reduce((acc, test) => acc + (test.Status === 'passed' ? 1 : 0), 0);
       this._resultsChangedEmitter.fire({passing, total});
     } else {


### PR DESCRIPTION
### This changes ctest pass rate

The following changes are proposed:

- Total for ctest shouldn't be based off total of tests parsed but rather how many tests are run as you can use ctest args to limit how many tests are fun

## The purpose of this change

For example, if I have 100 tests, but I run my ctest for only one test, it shouldn't show the status as failing and that 1/100 tests passing, but rather that it is passing and 1/1 tests passing.
