### PR TITLE
Fix small typo in cmake.outputLogEncoding setting's description

### DIFF
--- a/package.json
+++ b/package.json
@@ -885,7 +885,7 @@
         "cmake.outputLogEncoding": {
           "type": "string",
           "default": "auto",
-          "description": "Encoding of the output from external commonds(eg.cmake -- build)",
+          "description": "Encoding of the output from external commands (eg.cmake -- build)",
           "scope": "window"
         },
         "cmake.enableTraceLogging": {


### PR DESCRIPTION
<!-- Thanks for your contribution! To make things easier, please fill out the template below. -->

<!-- Please delete any unused sections. -->

<!-- Delete the following heading if there is no corresponding issue -->


### This changes documentation.

The following changes are proposed:
Correct a spelling error.
## The purpose of this change
Correct a spelling error.

