### PR TITLE
Improve stability of CMake generator selection

### DIFF
--- a/src/cmake-tools.ts
+++ b/src/cmake-tools.ts
@@ -344,6 +344,7 @@ export class CMakeTools implements vscode.Disposable, api.CMakeToolsAPI {
         try {
           this._statusMessage.set('Reloading...');
           await drv.setKit(kit, this.getPreferredGenerators());
+          this.workspaceContext.state.activeKitName = kit.name;
           this._statusMessage.set('Ready');
         } catch (error) {
           vscode.window.showErrorMessage(`Unable to set kit "${error}".`);
@@ -352,7 +353,6 @@ export class CMakeTools implements vscode.Disposable, api.CMakeToolsAPI {
           this._activeKit = null;
         }
       }
-      this.workspaceContext.state.activeKitName = kit.name;
     }
   }
 

--- a/src/cmake-tools.ts
+++ b/src/cmake-tools.ts
@@ -17,8 +17,8 @@ import * as vscode from 'vscode';
 
 import * as api from './api';
 import {ExecutionOptions, ExecutionResult} from './api';
-import {BadHomeDirectoryError, CodeModelContent, NoGeneratorError} from './cms-client';
-import {CMakeServerClientDriver} from './cms-driver';
+import {BadHomeDirectoryError, CodeModelContent} from './cms-client';
+import {CMakeServerClientDriver, NoGeneratorError} from './cms-driver';
 import {CTestDriver} from './ctest';
 import {BasicTestResults} from './ctest';
 import {CMakeBuildConsumer} from './diagnostics/build';

--- a/src/cmake-tools.ts
+++ b/src/cmake-tools.ts
@@ -208,7 +208,7 @@ export class CMakeTools implements vscode.Disposable, api.CMakeToolsAPI {
     }
   }
 
-  private getPreferedGenerators(): CMakeGenerator[] {
+  private getPreferredGenerators(): CMakeGenerator[] {
     // User can override generator with a setting
     const user_generator = this.workspaceContext.config.generator;
     if (user_generator) {
@@ -235,7 +235,7 @@ export class CMakeTools implements vscode.Disposable, api.CMakeToolsAPI {
     }
 
     let drv: CMakeDriver;
-    const preferedGenerators = this.getPreferedGenerators();
+    const preferedGenerators = this.getPreferredGenerators();
     if (this.workspaceContext.config.useCMakeServer) {
       if (cmake.isServerModeSupported) {
         drv = await CMakeServerClientDriver.create(cmake, this.workspaceContext, kit, preferedGenerators);
@@ -339,17 +339,18 @@ export class CMakeTools implements vscode.Disposable, api.CMakeToolsAPI {
     this._activeKit = kit;
     if (kit) {
       log.debug('Injecting new Kit into CMake driver');
-      const drv = await this.getCMakeDriverInstance();
+      const drv = await this._cmakeDriver;  // Use only an existing driver, do not create one
       if (drv) {
         try {
           this._statusMessage.set('Reloading...');
-          await drv.setKit(kit, this.getPreferedGenerators());
+          await drv.setKit(kit, this.getPreferredGenerators());
+          this._statusMessage.set('Ready');
         } catch (error) {
           vscode.window.showErrorMessage(`Unable to set kit "${error}".`);
           this._statusMessage.set(`Error on switch of kit (${error.message})`);
           this._cmakeDriver = Promise.resolve(null);
+          this._activeKit = null;
         }
-        this._statusMessage.set('Ready');
       }
       this.workspaceContext.state.activeKitName = kit.name;
     }

--- a/src/cmake-tools.ts
+++ b/src/cmake-tools.ts
@@ -420,6 +420,7 @@ export class CMakeTools implements vscode.Disposable, api.CMakeToolsAPI {
             vscode.window.showErrorMessage(
                 `Unable to determine what CMake generator to use. ` +
                 `Please install or configure a preferred generator, or update settings.json or your Kit configuration.`);
+            log.error(`Unable to determine what CMake generator should be used.`);
           } else {
             throw e;
           }

--- a/src/cms-client.ts
+++ b/src/cms-client.ts
@@ -321,7 +321,7 @@ export interface ClientInit {
   environment: NodeJS.ProcessEnv;
   sourceDir: string;
   binaryDir: string;
-  generator: CMakeGenerator | null;
+  generator: CMakeGenerator;
 }
 
 interface ClientInitPrivate extends ClientInit {
@@ -349,9 +349,6 @@ export class ServerError extends Error implements ErrorMessage {
     super(e.errorMessage);
   }
   toString(): string { return `[cmake-server] ${this.errorMessage}`; }
-}
-
-export class NoGeneratorError extends Error {
 }
 
 export class BadHomeDirectoryError extends Error {
@@ -619,9 +616,6 @@ export class CMakeServerClient {
             } else {
               // Do clean configure, all parameters are required.
               const generator = params.generator;
-              if (!generator) {
-                throw new NoGeneratorError();
-              }
               hsparams.sourceDirectory = params.sourceDir;
               hsparams.generator = generator.name;
               hsparams.platform = generator.platform;

--- a/src/cms-client.ts
+++ b/src/cms-client.ts
@@ -321,7 +321,8 @@ export interface ClientInit {
   environment: NodeJS.ProcessEnv;
   sourceDir: string;
   binaryDir: string;
-  pickGenerator: () => Promise<CMakeGenerator|null>;
+  tmpdir: string;
+  generator: CMakeGenerator | null;
 }
 
 interface ClientInitPrivate extends ClientInit {
@@ -572,7 +573,7 @@ export class CMakeServerClient {
         environment: params.environment,
         onProgress: params.onProgress,
         onDirty: params.onDirty,
-        pickGenerator: params.pickGenerator,
+        generator: params.generator,
         onCrash: async retc => {
           if (!resolved) {
             reject(new StartupError(retc));
@@ -618,7 +619,7 @@ export class CMakeServerClient {
               }
             } else {
               // Do clean configure, all parameters are required.
-              const generator = await params.pickGenerator();
+              const generator = params.generator;
               if (!generator) {
                 throw new NoGeneratorError();
               }

--- a/src/cms-client.ts
+++ b/src/cms-client.ts
@@ -321,7 +321,6 @@ export interface ClientInit {
   environment: NodeJS.ProcessEnv;
   sourceDir: string;
   binaryDir: string;
-  tmpdir: string;
   generator: CMakeGenerator | null;
 }
 
@@ -627,7 +626,9 @@ export class CMakeServerClient {
               hsparams.generator = generator.name;
               hsparams.platform = generator.platform;
               hsparams.toolset = generator.toolset || config.toolset || undefined;
-              log.info(`Configuring using the "${generator.name}" CMake generator`);
+              log.info(`Configuring using the "${hsparams.generator}" CMake generator with plattform ` +
+                      `"${hsparams.platform}" and toolset `,
+                      JSON.stringify(hsparams.toolset || {}));
             }
 
             await client.sendRequest('handshake', hsparams);

--- a/src/cms-driver.ts
+++ b/src/cms-driver.ts
@@ -8,7 +8,7 @@ import {CacheEntryProperties, ExecutableTarget, RichTarget} from './api';
 import * as cache from './cache';
 import * as cms from './cms-client';
 import {CMakeDriver} from './driver';
-import {Kit} from './kit';
+import {Kit, CMakeGenerator} from './kit';
 import {createLogger} from './logging';
 import * as proc from './proc';
 import rollbar from './rollbar';
@@ -264,7 +264,7 @@ export class CMakeServerClientDriver extends CMakeDriver {
       onProgress: async prog => {
         this._progressEmitter.fire(prog);
       },
-      generator: await this.getBestGenerator(),
+      generator: this.generator,
     });
   }
 
@@ -273,7 +273,7 @@ export class CMakeServerClientDriver extends CMakeDriver {
 
   async doInit(): Promise<void> { await this._restartClient(); }
 
-  static async create(cmake: CMakeExecutable, wsc: DirectoryContext, kit: Kit|null): Promise<CMakeServerClientDriver> {
-    return this.createDerived(new CMakeServerClientDriver(cmake, wsc), kit);
+  static async create(cmake: CMakeExecutable, wsc: DirectoryContext, kit: Kit|null, preferedGenerators: CMakeGenerator[]): Promise<CMakeServerClientDriver> {
+    return this.createDerived(new CMakeServerClientDriver(cmake, wsc), kit, preferedGenerators);
   }
 }

--- a/src/cms-driver.ts
+++ b/src/cms-driver.ts
@@ -16,6 +16,10 @@ import {DirectoryContext} from './workspace';
 
 const log = createLogger('cms-driver');
 
+export class NoGeneratorError extends Error {
+  message: string = 'No usable generator found.';
+}
+
 export class CMakeServerClientDriver extends CMakeDriver {
   private constructor(cmake: CMakeExecutable, private readonly _ws: DirectoryContext) {
     super(cmake, _ws);
@@ -249,6 +253,10 @@ export class CMakeServerClientDriver extends CMakeDriver {
   }
 
   private async _startNewClient() {
+    if (!this.generator) {
+      throw new NoGeneratorError();
+    }
+
     return cms.CMakeServerClient.start(this._ws.config, {
       binaryDir: this.binaryDir,
       sourceDir: this.sourceDir,

--- a/src/cms-driver.ts
+++ b/src/cms-driver.ts
@@ -264,7 +264,7 @@ export class CMakeServerClientDriver extends CMakeDriver {
       onProgress: async prog => {
         this._progressEmitter.fire(prog);
       },
-      pickGenerator: () => this.getBestGenerator(),
+      generator: await this.getBestGenerator(),
     });
   }
 

--- a/src/driver.ts
+++ b/src/driver.ts
@@ -307,11 +307,7 @@ export abstract class CMakeDriver implements vscode.Disposable {
     if(kit.preferredGenerator)
       preferredGenerators.push( kit.preferredGenerator);
 
-    if(preferredGenerators.length == 1) {
-      this._generator = preferredGenerators[0];
-    } else {
-      this._generator = await this.findBestGenerator(preferredGenerators);
-    }
+    this._generator = await this.findBestGenerator(preferredGenerators);
   }
 
   protected abstract doSetKit(needsClean: boolean, cb: () => Promise<void>): Promise<void>;

--- a/src/driver.ts
+++ b/src/driver.ts
@@ -288,7 +288,7 @@ export abstract class CMakeDriver implements vscode.Disposable {
    * Change the current kit. This lets the driver reload, if necessary.
    * @param kit The new kit
    */
-  async setKit(kit: Kit): Promise<void> {
+  async setKit(kit: Kit, preferredGenerators: CMakeGenerator[]): Promise<void> {
     log.info(`Switching to kit: ${kit.name}`);
 
     const opts = this.expansionOptions;
@@ -296,17 +296,30 @@ export abstract class CMakeDriver implements vscode.Disposable {
     const newBinaryDir = util.lightNormalizePath(await expand.expandString(this.ws.config.buildDirectory, opts));
 
     const needs_clean = this.binaryDir === newBinaryDir && kitChangeNeedsClean(kit, this._kit);
-    await this.doSetKit(needs_clean, async () => { await this._setKit(kit); });
+    await this.doSetKit(needs_clean, async () => { await this._setKit(kit, preferredGenerators); });
   }
 
-  private async _setKit(kit: Kit): Promise<void> {
+  private async _setKit(kit: Kit, preferredGenerators: CMakeGenerator[]): Promise<void> {
     this._kit = Object.seal({...kit});
     log.debug('CMakeDriver Kit set to', kit.name);
-    this._kitEnvironmentVariables = await effectiveKitEnvironment(kit, this.expansionOptions);
+    this._kitEnvironmentVariables = await effectiveKitEnvironment(kit);
+
+    if(kit.preferredGenerator)
+      preferredGenerators.push( kit.preferredGenerator);
+
+    if(preferredGenerators.length == 1) {
+      this._generator = preferredGenerators[0];
+    } else {
+      this._generator = await this.findBestGenerator(preferredGenerators);
+    }
   }
 
   protected abstract doSetKit(needsClean: boolean, cb: () => Promise<void>): Promise<void>;
 
+  protected get generator () : CMakeGenerator | null {
+    return this._generator;
+  }
+  protected _generator: CMakeGenerator | null = null;
   /**
    * The CMAKE_BUILD_TYPE to use
    */
@@ -488,33 +501,13 @@ export abstract class CMakeDriver implements vscode.Disposable {
     }
   }
 
-  getPreferredGenerators(): CMakeGenerator[] {
-    const user_preferred = this.ws.config.preferredGenerators.map(g => ({name: g}));
-    if (this._kit && this._kit.preferredGenerator) {
-      // The kit has a preferred generator attached as well
-      user_preferred.push(this._kit.preferredGenerator);
-    }
-    return user_preferred;
-  }
-
   /**
    * Picks the best generator to use on the current system
    */
-  async getBestGenerator(): Promise<CMakeGenerator|null> {
-    // User can override generator with a setting
-    const user_generator = this.ws.config.generator;
-    if (user_generator) {
-      log.debug(`Using generator from user configuration: ${user_generator}`);
-      return {
-        name: user_generator,
-        platform: this.ws.config.platform || undefined,
-        toolset: this.ws.config.toolset || undefined,
-      };
-    }
+  async findBestGenerator(preferredGenerators: CMakeGenerator[]): Promise<CMakeGenerator|null> {
     log.debug('Trying to detect generator supported by system');
     const platform = process.platform;
-    const candidates = this.getPreferredGenerators();
-    for (const gen of candidates) {
+    for (const gen of preferredGenerators) {
       const gen_name = gen.name;
       const generator_present = await (async(): Promise<boolean> => {
         if (gen_name == 'Ninja') {
@@ -791,10 +784,10 @@ export abstract class CMakeDriver implements vscode.Disposable {
    */
   abstract get cmakeCacheEntries(): Map<string, api.CacheEntryProperties>;
 
-  private async _baseInit(kit: Kit|null) {
+  private async _baseInit(kit: Kit|null, preferedGenerators: CMakeGenerator[]) {
     if (kit) {
       // Load up kit environment before starting any drivers.
-      await this._setKit(kit);
+      await this._setKit(kit, preferedGenerators);
     }
     await this._refreshExpansions();
     await this.doInit();
@@ -805,8 +798,8 @@ export abstract class CMakeDriver implements vscode.Disposable {
    * Asynchronous initialization. Should be called by base classes during
    * their initialization.
    */
-  static async createDerived<T extends CMakeDriver>(inst: T, kit: Kit|null): Promise<T> {
-    await inst._baseInit(kit);
+  static async createDerived<T extends CMakeDriver>(inst: T, kit: Kit|null, preferedGenerators: CMakeGenerator[]): Promise<T> {
+    await inst._baseInit(kit, preferedGenerators);
     return inst;
   }
 }

--- a/src/kit.ts
+++ b/src/kit.ts
@@ -567,7 +567,7 @@ async function tryCreateNewVCEnvironment(inst: VSInstallation, arch: string, pr?
         platform: VsArchitectures[arch] as string || undefined,
       };
     }
-    log.debug(` Selected Preferred Generator Name: ${generatorName}`);
+    log.debug(` Selected Preferred Generator Name: ${generatorName}`, JSON.stringify(kit.preferredGenerator));
   }
 
   return kit;

--- a/src/legacy-driver.ts
+++ b/src/legacy-driver.ts
@@ -10,7 +10,7 @@ import * as vscode from 'vscode';
 import * as api from './api';
 import {CMakeCache} from './cache';
 import {CMakeDriver} from './driver';
-import {Kit} from './kit';
+import {Kit, CMakeGenerator} from './kit';
 // import * as proc from './proc';
 import * as logging from './logging';
 import {fs} from './pr';
@@ -47,7 +47,7 @@ export class LegacyCMakeDriver extends CMakeDriver {
     args.push('-H' + util.lightNormalizePath(this.sourceDir));
     const bindir = util.lightNormalizePath(this.binaryDir);
     args.push('-B' + bindir);
-    const gen = await this.getBestGenerator();
+    const gen = this.generator;
     if (gen) {
       args.push(`-G${gen.name}`);
       if (gen.toolset) {
@@ -90,9 +90,9 @@ export class LegacyCMakeDriver extends CMakeDriver {
     });
   }
 
-  static async create(cmake: CMakeExecutable, ws: DirectoryContext, kit: Kit|null): Promise<LegacyCMakeDriver> {
+  static async create(cmake: CMakeExecutable, ws: DirectoryContext, kit: Kit|null, preferedGenerators: CMakeGenerator[]): Promise<LegacyCMakeDriver> {
     log.debug('Creating instance of LegacyCMakeDriver');
-    return this.createDerived(new LegacyCMakeDriver(cmake, ws), kit);
+    return this.createDerived(new LegacyCMakeDriver(cmake, ws), kit, preferedGenerators);
   }
 
   get targets() { return []; }

--- a/src/logging.ts
+++ b/src/logging.ts
@@ -114,7 +114,7 @@ export interface Stringable {
 
 let _LOGGER: Promise<NodeJS.WritableStream>;
 
-function logFilePath(): string { return path.join(paths.dataDir, 'log.txt'); }
+export function logFilePath(): string { return path.join(paths.dataDir, 'log.txt'); }
 
 async function _openLogFile() {
   if (!_LOGGER) {

--- a/test/extension-tests/successful-build/project-folder/.vscode/cmake-kits.json
+++ b/test/extension-tests/successful-build/project-folder/.vscode/cmake-kits.json
@@ -1,49 +1,63 @@
 [
-    {
-        "name": "Test Toolchain",
-        "toolchainFile": "${workspaceRoot}\\test-toolchain.cmake"
-    },
-    {
-    "name": "Generator switch test GCC Mingw - Win",
-    "compilers": {
-      "CXX": "C:\\MinGW\\bin\\g++.exe",
-      "C": "C:\\MinGW\\bin\\gcc.exe"
-    },
-    "preferredGenerator": {
-      "name": "MinGW Makefiles"
-    },
-    "environmentVariables": {
-      "PATH": "${env:PATH};C:\\MinGW\\bin"
-    }
+  {
+      "name": "Test Toolchain",
+      "toolchainFile": "${workspaceRoot}\\test-toolchain.cmake"
   },
   {
-    "name": "Generator switch test GCC Ninja - Win",
-    "compilers": {
-      "CXX": "C:\\MinGW\\bin\\g++.exe",
-      "C": "C:\\MinGW\\bin\\gcc.exe"
-    },
-    "preferredGenerator": {
-      "name": "Ninja"
-    }
-  } ,
-    {
-    "name": "Generator switch test GCC Make",
-    "compilers": {
-      "CXX": "g++",
-      "C": "gcc"
-    },
-    "preferredGenerator": {
-      "name": "Unix Makefiles"
-    }
+  "name": "Generator switch test GCC Mingw - Win",
+  "compilers": {
+    "CXX": "C:\\MinGW\\bin\\g++.exe",
+    "C": "C:\\MinGW\\bin\\gcc.exe"
   },
-  {
-    "name": "Generator switch test GCC Ninja",
-    "compilers": {
-      "CXX": "g++",
-      "C": "gcc"
-    },
-    "preferredGenerator": {
-      "name": "Ninja"
-    }
+  "preferredGenerator": {
+    "name": "MinGW Makefiles"
+  },
+  "environmentVariables": {
+    "PATH": "${env:PATH};C:\\MinGW\\bin"
   }
+},
+{
+  "name": "Generator switch test GCC Ninja - Win",
+  "compilers": {
+    "CXX": "C:\\MinGW\\bin\\g++.exe",
+    "C": "C:\\MinGW\\bin\\gcc.exe"
+  },
+  "preferredGenerator": {
+    "name": "Ninja"
+  }
+} ,
+{
+  "name": "Generator switch test GCC no generator - Win",
+  "compilers": {
+    "CXX": "C:\\MinGW\\bin\\g++.exe",
+    "C": "C:\\MinGW\\bin\\gcc.exe"
+  }
+} ,
+  {
+  "name": "Generator switch test GCC Make",
+  "compilers": {
+    "CXX": "g++",
+    "C": "gcc"
+  },
+  "preferredGenerator": {
+    "name": "Unix Makefiles"
+  }
+},
+{
+  "name": "Generator switch test GCC Ninja",
+  "compilers": {
+    "CXX": "g++",
+    "C": "gcc"
+  },
+  "preferredGenerator": {
+    "name": "Ninja"
+  }
+},
+{
+  "name": "Generator switch test GCC no generator",
+  "compilers": {
+    "CXX": "g++",
+    "C": "gcc"
+  }
+}
 ]

--- a/test/extension-tests/successful-build/test/configure-and-build.test.ts
+++ b/test/extension-tests/successful-build/test/configure-and-build.test.ts
@@ -1,6 +1,7 @@
 import {CMakeTools} from '@cmt/cmake-tools';
 import {fs} from '@cmt/pr';
 import {TestProgramResult} from '@test/helpers/testprogram/test-program-result';
+import {logFilePath} from '@cmt/logging';
 import {
   clearExistingKitConfigurationFile,
   DefaultEnvironment,
@@ -50,14 +51,26 @@ suite('Build', async () => {
     this.timeout(100000);
 
     cmt = await CMakeTools.create(testEnv.vsContext, testEnv.wsContext);
-    await cmt.setKit(await getFirstSystemKit());
+    const kit = await getFirstSystemKit();
+    console.log("Using following kit in next test: ", kit);
+    await cmt.setKit(kit);
     testEnv.projectFolder.buildDirectory.clear();
   });
 
   teardown(async function(this: Mocha.IBeforeAndAfterContext) {
     this.timeout(100000);
     await cmt.asyncDispose();
+    const logPath = logFilePath();
     testEnv.clean();
+    if (await fs.exists(logPath)) {
+      if (this.currentTest.state == "failed") {
+        const logContent = await fs.readFile(logPath);
+        logContent.toString().split('\n').forEach(line => {
+          console.log(line);
+        });
+      }
+      await fs.writeFile(logPath, "");
+    }
   });
 
   suiteTeardown(async () => {
@@ -141,9 +154,6 @@ suite('Build', async () => {
   }).timeout(100000);
 
   test('Test kit switch after missing preferred generator #512', async function(this: ITestCallbackContext) {
-    // Remove all preferred generator (Remove config dependenies, auto detection)
-    testEnv.config.updatePartial({preferredGenerators: []});
-
     // Select compiler build node dependent
     const os_compilers: {[osName: string]: {kitLabel: RegExp, generator: string}[]} = {
       linux: [
@@ -157,6 +167,8 @@ suite('Build', async () => {
     };
     if (!(workername in os_compilers))
       this.skip();
+    // Remove all preferred generator (Remove config dependenies, auto detection)
+    testEnv.config.updatePartial({preferredGenerators: []});
     const compiler = os_compilers[workername];
 
     // Run configure kit
@@ -271,7 +283,9 @@ suite('Build', async () => {
   }).timeout(200000);
 
   test('Test build twice', async function(this: ITestCallbackContext) {
+    console.log('1. Build');
     expect(await cmt.build()).eq(0);
+    console.log('2. Build');
     expect(await cmt.build()).eq(0);
     await testEnv.result.getResultAsJson();
   }).timeout(100000);


### PR DESCRIPTION
## This change addresses item #512 

### This changes behavior and stability of the extension

The following changes are proposed:

- Replaces the CMake generator check from callback by previously CMake generator check and provide it as variable to the driver

## The purpose of this change

Issue #512 reports that the extension crashes completely if there was a generator selection problem. 
The cmake generator is checked at [start of the cmake client](https://github.com/microsoft/vscode-cmake-tools/blob/10cee0f78041fb74cd73c1543d2eb180cabeeba9/src/cms-client.ts#L623) when the cmake server protocol requires the information. If there is no useable build system (generator), then there cmake-server client throws an error. But there is no way to return this error into the cmake-server-driver instance. The driver instance is broken, and cmake-tools does not know it and will not create a new instance. 

The simplest solution was to move the generator selection to the cmake-tools context so that the driver does not have to select the generator. It only uses it like other build information.

This kind of error is only possible in cmake-server-api driver, legacy driver and file-api driver need the generator before executing the cmake configure step.

## Additional information

- This PR extracts some commits from my big PR #707 and #720  to improve stability of generator selection.
