### PR TITLE
Change rollbar to a logger, and add telemetries for configuring and building

### DIFF
--- a/package.json
+++ b/package.json
@@ -1031,9 +1031,9 @@
     "module-alias": "^2.0.6",
     "open": "^6.4.0",
     "rimraf": "^2.5.4",
-    "rollbar": "~2.2.8",
     "tmp": "^0.0.33",
     "vscode-cpptools": "^2.1.2",
+    "vscode-extension-telemetry": "^0.1.2",
     "which": "~1.3.0",
     "xml2js": "^0.4.17"
   },

--- a/src/cmake-tools.ts
+++ b/src/cmake-tools.ts
@@ -177,6 +177,7 @@ export class CMakeTools implements vscode.Disposable, api.CMakeToolsAPI {
    */
   dispose() {
     log.debug('Disposing CMakeTools extension');
+    telemetry.deactivate();
     this._nagUpgradeSubscription.dispose();
     this._nagManager.dispose();
     this._termCloseSub.dispose();
@@ -491,7 +492,7 @@ export class CMakeTools implements vscode.Disposable, api.CMakeToolsAPI {
     log.debug('Safe constructing new CMakeTools instance');
     const inst = new CMakeTools(ctx, wsc);
     await inst._init();
-    telemetry.activate(ctx);
+    telemetry.activate();
     log.debug('CMakeTools instance initialization complete.');
     return inst;
   }

--- a/src/cmake-tools.ts
+++ b/src/cmake-tools.ts
@@ -34,6 +34,7 @@ import {fs} from './pr';
 import {buildCmdStr} from './proc';
 import {Property} from './prop';
 import rollbar from './rollbar';
+import * as telemetry from './telemetry';
 import {setContextValue} from './util';
 import {VariantManager} from './variant';
 
@@ -288,8 +289,6 @@ export class CMakeTools implements vscode.Disposable, api.CMakeToolsAPI {
    */
   private async _init() {
     log.debug('Starting CMakeTools second-phase init');
-    // First, start up Rollbar
-    await rollbar.requestPermissions(this.extensionContext);
     // Start up the variant manager
     await this._variantManager.initialize();
     // Set the status bar message
@@ -360,6 +359,7 @@ export class CMakeTools implements vscode.Disposable, api.CMakeToolsAPI {
       if (!cmake.isPresent) {
         vscode.window.showErrorMessage(`Bad CMake executable "${
             cmake.path}". Is it installed or settings contain the correct path (cmake.cmakePath)?`);
+        telemetry.logEvent('CMakeExecutableNotFound');
         return null;
       }
 
@@ -428,6 +428,7 @@ export class CMakeTools implements vscode.Disposable, api.CMakeToolsAPI {
     log.debug('Safe constructing new CMakeTools instance');
     const inst = new CMakeTools(ctx, wsc);
     await inst._init();
+    telemetry.activate(ctx);
     log.debug('CMakeTools instance initialization complete.');
     return inst;
   }

--- a/src/drivers/driver.ts
+++ b/src/drivers/driver.ts
@@ -612,16 +612,12 @@ export abstract class CMakeDriver implements vscode.Disposable {
       const timeEnd: number = new Date().getTime();
 
       const cmakeVersion = this.cmake.version;
-      const telemetryProperties: {[key: string]: string} = {
+      const telemetryProperties: telemetry.Properties = {
         CMakeExecutableVersion: cmakeVersion ? `${cmakeVersion.major}.${cmakeVersion.minor}.${cmakeVersion.patch}` : '',
         CMakeGenerator: this.generatorName || '',
         ConfigType: this.isMultiConf ? 'MultiConf' : this.currentBuildType || '',
       };
-      const azureSphereTargetApiSet = this.cmakeCacheEntries.get('AZURE_SPHERE_TARGET_API_SET');
-      if (azureSphereTargetApiSet) {
-        telemetryProperties['AzureSphereTargetApiSet'] = azureSphereTargetApiSet.value;
-      }
-      const telemetryMeasures: {[key: string]: number} = {
+      const telemetryMeasures: telemetry.Measures = {
         Duration: timeEnd - timeStart,
       };
       if (consumer instanceof CMakeOutputConsumer) {
@@ -641,7 +637,7 @@ export abstract class CMakeDriver implements vscode.Disposable {
         rollbar.error('Wrong build result type.');
         telemetryMeasures['ErrorCount'] = retc ? 1 : 0;
       }
-      telemetry.logEvent('parse', telemetryProperties, telemetryMeasures);
+      telemetry.logEvent('configure', telemetryProperties, telemetryMeasures);
 
       return retc;
     } finally { this.configRunning = false; }
@@ -743,10 +739,10 @@ export abstract class CMakeDriver implements vscode.Disposable {
     const timeStart: number = new Date().getTime();
     const child = await this._doCMakeBuild(target, consumer);
     const timeEnd: number = new Date().getTime();
-    const telemetryProperties: {[key: string]: string} = {
+    const telemetryProperties: telemetry.Properties = {
       ConfigType: this.isMultiConf ? 'MultiConf' : this.currentBuildType || '',
     };
-    const telemetryMeasures: {[key: string]: number} = {
+    const telemetryMeasures: telemetry.Measures = {
       Duration: timeEnd - timeStart,
     };
     if (child) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -602,7 +602,6 @@ class ExtensionManager implements vscode.Disposable {
         message = `Loading kit ${raw_name}`;
         break;
       }
-      rollbar.updatePayload({kit: k});
       // Load the kit into the backend
       await vscode.window.withProgress(
           {
@@ -1214,15 +1213,6 @@ async function setup(context: vscode.ExtensionContext, progress: ProgressHandle)
  * @returns A promise that will resolve when the extension is ready for use
  */
 export async function activate(context: vscode.ExtensionContext) {
-  const packageJSON = util.thisExtensionPackage();
-  rollbar.updatePayload({
-    environment: 'production',
-    packageJSON,
-    client: {
-      code_version: packageJSON.version,
-    },
-    platform: process.platform,
-  });
   await vscode.window.withProgress(
       {
         location: vscode.ProgressLocation.Notification,

--- a/src/rollbar.ts
+++ b/src/rollbar.ts
@@ -1,98 +1,15 @@
 /**
  * Wrapper around Rollbar, for error reporting.
- */ /** */
-
-import * as path from 'path';
-import * as vscode from 'vscode';
-
-import Rollbar = require('rollbar');
+ */
 
 import * as logging from './logging';
 
 const log = logging.createLogger('rollbar');
 
-const SRC_ROOT = path.dirname(__dirname);
-
 /**
  * The wrapper around Rollbar. Presents a nice functional API.
  */
 class RollbarController {
-  /**
-   * The payload to send with any messages. Can be updated via `updatePayload`.
-   */
-  private readonly _payload: object = {
-    platform: 'client',
-    server: {
-      // Because extensions are installed in a user-local directory, the
-      // absolute path to the source files will be different on each machine.
-      // If we set the root directory of the source tree then Rollbar will be
-      // able to better merge identical issues.
-      root: SRC_ROOT,
-    },
-  };
-
-  /**
-   * The Rollbar client instance we use to communicate.
-   */
-  private readonly _rollbar = new Rollbar({
-    accessToken: '14d411d713be4a5a9f9d57660534cac7',
-    reportLevel: 'error',
-    payload: this._payload,
-  });
-
-  /**
-   * If `true`, we will send messages. We must get the user's permission first!
-   */
-  private _enabled = false;
-
-  /**
-   * Request permission to use Rollbar from the user. This will show a message
-   * box at the top of the window on first permission request.
-   * @param extensionContext Extension context, where we use a memento to
-   * remember our permission
-   */
-  async requestPermissions(extensionContext: vscode.ExtensionContext): Promise<void> {
-    log.debug('Checking Rollbar permissions');
-    if (process.env['CMT_TESTING'] === '1') {
-      log.trace('Running CMakeTools in test mode. Rollbar is disabled.');
-      return;
-    }
-    if (process.env['CMT_DEVRUN'] === '1') {
-      log.trace('Running CMakeTools in developer mode. Rollbar reporting is disabled.');
-      return;
-    }
-    // The memento key where we store permission. Update this to ask again.
-    const key = 'rollbar-optin3';
-    const optin = extensionContext.globalState.get(key);
-    if (optin === true) {
-      this._enabled = true;
-    } else if (optin == false) {
-      this._enabled = false;
-    } else if (optin === undefined) {
-      log.debug('Asking user for permission to user Rollbar...');
-      // We haven't asked yet. Ask them now:
-      const item = await vscode.window.showInformationMessage(
-          'Would you like to opt-in to send anonymous error and exception data to help improve CMake Tools?',
-          {
-            title: 'Yes!',
-            isCloseAffordance: false,
-          } as vscode.MessageItem,
-          {
-            title: 'No Thanks',
-            isCloseAffordance: true,
-          } as vscode.MessageItem);
-
-      if (item === undefined) {
-        // We didn't get an answer
-        log.trace('User did not answer. Rollbar is not enabled.');
-        return;
-      }
-      extensionContext.globalState.update(key, !item.isCloseAffordance);
-      this._enabled = !item.isCloseAffordance;
-    }
-    log.debug('Rollbar enabled? ', this._enabled);
-  }
-
   /**
    * Log an exception with Rollbar.
    * @param what A message about what we were doing when the exception happened
@@ -100,15 +17,11 @@ class RollbarController {
    * @param additional Additional items in the payload
    * @returns The LogResult if we are enabled. `null` otherwise.
    */
-  exception(what: string, exception: Error, additional: object = {}): Rollbar.LogResult|null {
+  exception(what: string, exception: Error, additional: object = {}): void {
     log.fatal('Unhandled exception:', what, exception, JSON.stringify(additional));
     // tslint:disable-next-line
     console.error(exception);
     debugger;
-    if (this._enabled) {
-      return this._rollbar.error(what, exception, additional);
-    }
-    return null;
   }
 
   /**
@@ -117,34 +30,13 @@ class RollbarController {
    * @param additional Additional items in the payload
    * @returns The LogResult if we are enabled. `null` otherwise.
    */
-  error(what: string, additional: object = {}): Rollbar.LogResult|null {
+  error(what: string, additional: object = {}): void {
     log.error(what, JSON.stringify(additional));
     debugger;
-    if (this._enabled) {
-      const stack = new Error().stack;
-      return this._rollbar.error(what, additional, {stack});
-    }
-    return null;
   }
 
-  info(what: string, additional: object = {}): Rollbar.LogResult | null {
+  info(what: string, additional: object = {}): void {
     log.info(what, JSON.stringify(additional));
-    if (this._enabled) {
-      const stack = new Error().stack;
-      return this._rollbar.info(what, additional, { stack });
-    }
-    return null;
-  }
-
-  /**
-   * Update the content of the Rollbar payload with additional context
-   * information.
-   * @param data Daya to merge into the payload
-   */
-  updatePayload(data: object) {
-    Object.assign(this._payload, data);
-    this._rollbar.configure({payload: this._payload});
-    log.debug('Updated Rollbar payload', JSON.stringify(data));
   }
 
   /**

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -4,9 +4,11 @@
  * ------------------------------------------------------------------------------------------ */
 'use strict';
 
-import * as vscode from 'vscode';
 import * as util from './util';
 import TelemetryReporter from 'vscode-extension-telemetry';
+
+export type Properties = { [key: string]: string };
+export type Measures = { [key: string]: number };
 
 interface IPackageInfo {
     name: string;
@@ -16,12 +18,9 @@ interface IPackageInfo {
 
 let telemetryReporter: TelemetryReporter | null;
 
-export function activate(context: vscode.ExtensionContext): void {
+export function activate(): void {
     try {
         telemetryReporter = createReporter();
-        if (telemetryReporter) {
-            context.subscriptions.push(telemetryReporter);
-        }
     } catch (e) {
         // can't really do much about this
     }
@@ -33,7 +32,7 @@ export function deactivate(): void {
     }
 }
 
-export function logEvent(eventName: string, properties?: { [key: string]: string }, measures?: { [key: string]: number }): void {
+export function logEvent(eventName: string, properties?: Properties, measures?: Measures): void {
     if (telemetryReporter) {
         telemetryReporter.sendTelemetryEvent(eventName, properties, measures);
     }

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -1,0 +1,57 @@
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) Microsoft Corporation. All Rights Reserved.
+ * See 'LICENSE' in the project root for license information.
+ * ------------------------------------------------------------------------------------------ */
+'use strict';
+
+import * as vscode from 'vscode';
+import * as util from './util';
+import TelemetryReporter from 'vscode-extension-telemetry';
+
+interface IPackageInfo {
+    name: string;
+    version: string;
+    aiKey: string;
+}
+
+let telemetryReporter: TelemetryReporter | null;
+
+export function activate(context: vscode.ExtensionContext): void {
+    try {
+        telemetryReporter = createReporter();
+        if (telemetryReporter) {
+            context.subscriptions.push(telemetryReporter);
+        }
+    } catch (e) {
+        // can't really do much about this
+    }
+}
+
+export function deactivate(): void {
+    if (telemetryReporter) {
+        telemetryReporter.dispose();
+    }
+}
+
+export function logEvent(eventName: string, properties?: { [key: string]: string }, measures?: { [key: string]: number }): void {
+    if (telemetryReporter) {
+        telemetryReporter.sendTelemetryEvent(eventName, properties, measures);
+    }
+}
+
+function createReporter(): TelemetryReporter | null {
+    const packageInfo: IPackageInfo = getPackageInfo();
+    if (packageInfo && packageInfo.aiKey) {
+        return new TelemetryReporter(packageInfo.name, packageInfo.version, packageInfo.aiKey);
+    }
+    return null;
+}
+
+function getPackageInfo(): IPackageInfo {
+    const packageJSON: util.PackageJSON = util.thisExtensionPackage();
+    return {
+        name: `${packageJSON.publisher}.${packageJSON.name}`,
+        version: packageJSON.version,
+        aiKey: "AIF-d9b70cd4-b9f9-4d70-929b-a071c400b217"
+    };
+}

--- a/src/util.ts
+++ b/src/util.ts
@@ -379,6 +379,7 @@ export function thisExtension() {
 
 export interface PackageJSON {
   name: string;
+  publisher: string;
   version: string;
 }
 
@@ -386,6 +387,7 @@ export function thisExtensionPackage(): PackageJSON {
   const pkg = thisExtension().packageJSON as PackageJSON;
   return {
     name: pkg.name,
+    publisher: pkg.publisher,
     version: pkg.version,
   };
 }

--- a/test/unit-tests/diagnostics.test.ts
+++ b/test/unit-tests/diagnostics.test.ts
@@ -149,8 +149,8 @@ suite('Diagnostics', async () => {
       '/Users/ruslan.sorokin/Projects/Other/dpi/core/dpi_histogram.h:85:15: warning: comparison of unsigned expression >= 0 is always true [-Wtautological-compare]'
     ];
     feedLines(build_consumer, [], lines);
-    expect(build_consumer.gcc.diagnostics).to.have.length(1);
-    const diag = build_consumer.gcc.diagnostics[0];
+    expect(build_consumer.compilers.gcc.diagnostics).to.have.length(1);
+    const diag = build_consumer.compilers.gcc.diagnostics[0];
     expect(diag.location.start.line).to.eq(84);
     expect(diag.message).to.eq('comparison of unsigned expression >= 0 is always true [-Wtautological-compare]');
     expect(diag.location.start.character).to.eq(14);
@@ -164,8 +164,8 @@ suite('Diagnostics', async () => {
   test('Parse more GCC diagnostics', () => {
     const lines = [`/Users/Tobias/Code/QUIT/Source/qidespot1.cpp:303:49: error: expected ';' after expression`];
     feedLines(build_consumer, [], lines);
-    expect(build_consumer.gcc.diagnostics).to.have.length(1);
-    const diag = build_consumer.gcc.diagnostics[0];
+    expect(build_consumer.compilers.gcc.diagnostics).to.have.length(1);
+    const diag = build_consumer.compilers.gcc.diagnostics[0];
     const expected = '/Users/Tobias/Code/QUIT/Source/qidespot1.cpp';
     expect(platformPathEquivalent(diag.file, expected), `${diag.file} != ${expected}`).to.be.true;
     expect(diag.location.start.line).to.eq(302);
@@ -177,8 +177,8 @@ suite('Diagnostics', async () => {
   test('Parsing fatal error diagnostics', () => {
     const lines = ['/some/path/here:4:26: fatal error: some_header.h: No such file or directory'];
     feedLines(build_consumer, [], lines);
-    expect(build_consumer.gcc.diagnostics).to.have.length(1);
-    const diag = build_consumer.gcc.diagnostics[0];
+    expect(build_consumer.compilers.gcc.diagnostics).to.have.length(1);
+    const diag = build_consumer.compilers.gcc.diagnostics[0];
     expect(diag.location.start.line).to.eq(3);
     expect(diag.message).to.eq('some_header.h: No such file or directory');
     expect(diag.location.start.line).to.eq(3);
@@ -192,8 +192,8 @@ suite('Diagnostics', async () => {
   test('Parsing fatal error diagnostics in french', () => {
     const lines = ['/home/romain/TL/test/base.c:2:21: erreur fatale : bonjour.h : Aucun fichier ou dossier de ce type'];
     feedLines(build_consumer, [], lines);
-    expect(build_consumer.gcc.diagnostics).to.have.length(1);
-    const diag = build_consumer.gcc.diagnostics[0];
+    expect(build_consumer.compilers.gcc.diagnostics).to.have.length(1);
+    const diag = build_consumer.compilers.gcc.diagnostics[0];
 
     expect(diag.location.start.line).to.eq(1);
     expect(diag.message).to.eq('bonjour.h : Aucun fichier ou dossier de ce type');
@@ -206,8 +206,8 @@ suite('Diagnostics', async () => {
   test('Parsing warning diagnostics', () => {
     const lines = ['/some/path/here:4:26: warning: unused parameter \'data\''];
     feedLines(build_consumer, [], lines);
-    expect(build_consumer.gcc.diagnostics).to.have.length(1);
-    const diag = build_consumer.gcc.diagnostics[0];
+    expect(build_consumer.compilers.gcc.diagnostics).to.have.length(1);
+    const diag = build_consumer.compilers.gcc.diagnostics[0];
 
     expect(diag.location.start.line).to.eq(3);
     expect(diag.message).to.eq('unused parameter \'data\'');
@@ -220,8 +220,8 @@ suite('Diagnostics', async () => {
   test('Parsing warning diagnostics 2', () => {
     const lines = [`/test/main.cpp:21:14: warning: unused parameter ‘v’ [-Wunused-parameter]`];
     feedLines(build_consumer, [], lines);
-    expect(build_consumer.gcc.diagnostics).to.have.length(1);
-    const diag = build_consumer.gcc.diagnostics[0];
+    expect(build_consumer.compilers.gcc.diagnostics).to.have.length(1);
+    const diag = build_consumer.compilers.gcc.diagnostics[0];
 
     expect(diag.location.start.line).to.eq(20);
     expect(diag.location.start.character).to.eq(13);
@@ -232,8 +232,8 @@ suite('Diagnostics', async () => {
   test('Parsing warning diagnostics in french', () => {
     const lines = ['/home/romain/TL/test/base.c:155:2: attention : déclaration implicite de la fonction ‘create’'];
     feedLines(build_consumer, [], lines);
-    expect(build_consumer.gcc.diagnostics).to.have.length(1);
-    const diag = build_consumer.gcc.diagnostics[0];
+    expect(build_consumer.compilers.gcc.diagnostics).to.have.length(1);
+    const diag = build_consumer.compilers.gcc.diagnostics[0];
 
     expect(diag.location.start.line).to.eq(154);
     expect(diag.message).to.eq('déclaration implicite de la fonction ‘create’');
@@ -246,8 +246,8 @@ suite('Diagnostics', async () => {
   test('Parsing linker error', () => {
     const lines = ['/some/path/here:101: undefined reference to `some_function\''];
     feedLines(build_consumer, [], lines);
-    expect(build_consumer.gnuLD.diagnostics).to.have.length(1);
-    const diag = build_consumer.gnuLD.diagnostics[0];
+    expect(build_consumer.compilers.gnuLD.diagnostics).to.have.length(1);
+    const diag = build_consumer.compilers.gnuLD.diagnostics[0];
 
     expect(diag.location.start.line).to.eq(100);
     expect(diag.message).to.eq('undefined reference to `some_function\'');
@@ -259,8 +259,8 @@ suite('Diagnostics', async () => {
   test('Parsing linker error in french', () => {
     const lines = ['/home/romain/TL/test/test_fa_tp4.c:9 : référence indéfinie vers « create_automaton_product56 »'];
     feedLines(build_consumer, [], lines);
-    expect(build_consumer.gnuLD.diagnostics).to.have.length(1);
-    const diag = build_consumer.gnuLD.diagnostics[0];
+    expect(build_consumer.compilers.gnuLD.diagnostics).to.have.length(1);
+    const diag = build_consumer.compilers.gnuLD.diagnostics[0];
 
     expect(diag.location.start.line).to.eq(8);
     expect(diag.message).to.eq('référence indéfinie vers « create_automaton_product56 »');
@@ -274,8 +274,8 @@ suite('Diagnostics', async () => {
       '"C:\\path\\source\\debug\\debug.c", line 631 (col. 3): warning #68-D: integer conversion resulted in a change of sign'
     ];
     feedLines(build_consumer, [], lines);
-    expect(build_consumer.ghs.diagnostics).to.have.length(1);
-    const diag = build_consumer.ghs.diagnostics[0];
+    expect(build_consumer.compilers.ghs.diagnostics).to.have.length(1);
+    const diag = build_consumer.compilers.ghs.diagnostics[0];
 
     expect(diag.location.start.line).to.eq(630);
     expect(diag.message).to.eq('#68-D: integer conversion resulted in a change of sign');
@@ -290,8 +290,8 @@ suite('Diagnostics', async () => {
       '"C:\\path\\source\\debug\\debug.c", At end of source: remark #96-D: a translation unit must contain at least one declaration'
     ];
     feedLines(build_consumer, [], lines);
-    expect(build_consumer.ghs.diagnostics).to.have.length(1);
-    const diag = build_consumer.ghs.diagnostics[0];
+    expect(build_consumer.compilers.ghs.diagnostics).to.have.length(1);
+    const diag = build_consumer.compilers.ghs.diagnostics[0];
 
     expect(diag.location.start.line).to.eq(0);
     expect(diag.message).to.eq('#96-D: a translation unit must contain at least one declaration');
@@ -304,8 +304,8 @@ suite('Diagnostics', async () => {
   test('Parsing GHS Diagnostics fatal error', () => {
     const lines = ['"C:\\path\\source\\debug\\debug.c", line 631 (col. 3): fatal error #68: some fatal error'];
     feedLines(build_consumer, [], lines);
-    expect(build_consumer.ghs.diagnostics).to.have.length(1);
-    const diag = build_consumer.ghs.diagnostics[0];
+    expect(build_consumer.compilers.ghs.diagnostics).to.have.length(1);
+    const diag = build_consumer.compilers.ghs.diagnostics[0];
     expect(diag.location.start.line).to.eq(630);
     expect(diag.message).to.eq('#68: some fatal error');
     expect(diag.location.start.character).to.eq(2);
@@ -322,15 +322,15 @@ suite('Diagnostics', async () => {
       `make: *** [Makefile:84 all] Error 2`
     ];
     feedLines(build_consumer, [], lines);
-    expect(build_consumer.gnuLD.diagnostics).to.have.length(0);
+    expect(build_consumer.compilers.gnuLD.diagnostics).to.have.length(0);
   });
 
   test('Parse GCC error on line zero', () => {
     const lines = ['/foo.h:66:0: warning: ignoring #pragma comment [-Wunknown-pragmas]'];
     feedLines(build_consumer, [], lines);
-    expect(build_consumer.gcc.diagnostics).to.have.length(1);
-    expect(build_consumer.gcc.diagnostics[0].file).to.eq('/foo.h');
-    expect(build_consumer.gcc.diagnostics[0].location.start.line).to.eq(65);
-    expect(build_consumer.gcc.diagnostics[0].location.start.character).to.eq(0);
+    expect(build_consumer.compilers.gcc.diagnostics).to.have.length(1);
+    expect(build_consumer.compilers.gcc.diagnostics[0].file).to.eq('/foo.h');
+    expect(build_consumer.compilers.gcc.diagnostics[0].location.start.line).to.eq(65);
+    expect(build_consumer.compilers.gcc.diagnostics[0].location.start.character).to.eq(0);
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -201,6 +201,16 @@ ansi-styles@^3.2.1:
   dependencies:
     color-convert "^1.9.0"
 
+applicationinsights@1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/applicationinsights/-/applicationinsights-1.4.0.tgz#e17e436427b6e273291055181e29832cca978644"
+  integrity sha512-TV8MYb0Kw9uE2cdu4V/UvTKdOABkX2+Fga9iDz0zqV7FLrNXfmAugWZmmdTx4JoynYkln3d5CUHY3oVSUEbfFw==
+  dependencies:
+    cls-hooked "^4.2.2"
+    continuation-local-storage "^3.2.1"
+    diagnostic-channel "0.2.0"
+    diagnostic-channel-publishers "^0.3.2"
+
 argparse@^1.0.7:
   version "1.0.10"
   resolved "https://registry.yarnpkg.com/argparse/-/argparse-1.0.10.tgz#bcd6791ea5ae09725e17e5ad988134cd40b3d911"
@@ -234,13 +244,24 @@ assertion-error@^1.0.1:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/assertion-error/-/assertion-error-1.1.0.tgz#e60b6b0e8f301bd97e5375215bda406c85118c0b"
 
+async-hook-jl@^1.7.6:
+  version "1.7.6"
+  resolved "https://registry.yarnpkg.com/async-hook-jl/-/async-hook-jl-1.7.6.tgz#4fd25c2f864dbaf279c610d73bf97b1b28595e68"
+  integrity sha512-gFaHkFfSxTjvoxDMYqDuGHlcRyUuamF8s+ZTtJdDzqjws4mCt7v0vuV79/E2Wr2/riMQgtG4/yUtXWs1gZ7JMg==
+  dependencies:
+    stack-chain "^1.3.7"
+
+async-listener@^0.6.0:
+  version "0.6.10"
+  resolved "https://registry.yarnpkg.com/async-listener/-/async-listener-0.6.10.tgz#a7c97abe570ba602d782273c0de60a51e3e17cbc"
+  integrity sha512-gpuo6xOyF4D5DE5WvyqZdPA3NGhiT6Qf07l7DCB0wwDEsLvDIbCr6j9S5aj5Ch96dLace5tXVzWBZkxU/c5ohw==
+  dependencies:
+    semver "^5.3.0"
+    shimmer "^1.1.0"
+
 async@^1.5.2:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/async/-/async-1.5.2.tgz#ec6a61ae56480c0c3cb241c95618e20892f9672a"
-
-async@~1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/async/-/async-1.2.1.tgz#a4816a17cd5ff516dfa2c7698a453369b9790de0"
 
 asynckit@^0.4.0:
   version "0.4.0"
@@ -340,6 +361,15 @@ clang-format@^1.2.2:
     glob "^7.0.0"
     resolve "^1.1.6"
 
+cls-hooked@^4.2.2:
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/cls-hooked/-/cls-hooked-4.2.2.tgz#ad2e9a4092680cdaffeb2d3551da0e225eae1908"
+  integrity sha512-J4Xj5f5wq/4jAvcdgoGsL3G103BtWpZrMo8NEinRltN+xpTZdI+M38pyQqhuFU/P792xkMFvnKSf+Lm81U1bxw==
+  dependencies:
+    async-hook-jl "^1.7.6"
+    emitter-listener "^1.0.1"
+    semver "^5.4.1"
+
 co@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/co/-/co-4.6.0.tgz#6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184"
@@ -384,9 +414,13 @@ concat-map@0.0.1:
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
   integrity sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=
 
-console-polyfill@0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/console-polyfill/-/console-polyfill-0.3.0.tgz#84900902a18c47a5eba932be75fa44d23e8af861"
+continuation-local-storage@^3.2.1:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/continuation-local-storage/-/continuation-local-storage-3.2.1.tgz#11f613f74e914fe9b34c92ad2d28fe6ae1db7ffb"
+  integrity sha512-jx44cconVqkCEEyLSKWwkvUXwO561jXMa3LPjTPsm5QR22PA0/mhe33FT4Xb5y74JDvt/Cq+5lm8S8rskLv9ZA==
+  dependencies:
+    async-listener "^0.6.0"
+    emitter-listener "^1.1.1"
 
 core-util-is@1.0.2:
   version "1.0.2"
@@ -399,12 +433,6 @@ dashdash@^1.12.0:
   integrity sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=
   dependencies:
     assert-plus "^1.0.0"
-
-debug@2.6.9:
-  version "2.6.9"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
-  dependencies:
-    ms "2.0.0"
 
 debug@3.1.0, debug@=3.1.0:
   version "3.1.0"
@@ -419,12 +447,6 @@ debug@^3.1.0:
   dependencies:
     ms "^2.1.1"
 
-decache@^3.0.5:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/decache/-/decache-3.1.0.tgz#4f5036fbd6581fcc97237ac3954a244b9536c2da"
-  dependencies:
-    find "^0.2.4"
-
 deep-eql@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/deep-eql/-/deep-eql-3.0.1.tgz#dfc9404400ad1c8fe023e7da1df1c147c4b444df"
@@ -435,6 +457,18 @@ delayed-stream@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
   integrity sha1-3zrhmayt+31ECqrgsp4icrJOxhk=
+
+diagnostic-channel-publishers@^0.3.2:
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/diagnostic-channel-publishers/-/diagnostic-channel-publishers-0.3.3.tgz#376b7798f4fa90f37eb4f94d2caca611b0e9c330"
+  integrity sha512-qIocRYU5TrGUkBlDDxaziAK1+squ8Yf2Ls4HldL3xxb/jzmWO2Enux7CvevNKYmF2kDXZ9HiRqwjPsjk8L+i2Q==
+
+diagnostic-channel@0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/diagnostic-channel/-/diagnostic-channel-0.2.0.tgz#cc99af9612c23fb1fff13612c72f2cbfaa8d5a17"
+  integrity sha1-zJmvlhLCP7H/8TYSxy8sv6qNWhc=
+  dependencies:
+    semver "^5.3.0"
 
 diff@3.3.1:
   version "3.3.1"
@@ -454,11 +488,12 @@ ecc-jsbn@~0.1.1:
     jsbn "~0.1.0"
     safer-buffer "^2.1.0"
 
-error-stack-parser@1.3.3:
-  version "1.3.3"
-  resolved "https://registry.yarnpkg.com/error-stack-parser/-/error-stack-parser-1.3.3.tgz#fada6e3a9cd2b0e080e6d6fc751418649734f35c"
+emitter-listener@^1.0.1, emitter-listener@^1.1.1:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/emitter-listener/-/emitter-listener-1.1.2.tgz#56b140e8f6992375b3d7cb2cab1cc7432d9632e8"
+  integrity sha512-Bt1sBAGFHY9DKY+4/2cV6izcKJUf5T7/gkdmkxzX/qv9CcGH8xSwVRW5mtX03SWJtRTWSOpzCuWN9rBFYZepZQ==
   dependencies:
-    stackframe "^0.3.1"
+    shimmer "^1.2.0"
 
 es6-promise@^4.0.3:
   version "4.2.8"
@@ -486,10 +521,6 @@ esutils@^2.0.2:
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.2.tgz#0abf4f1caa5bcb1f7a9d8acc6dea4faaa04bac9b"
   integrity sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=
 
-extend@3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.0.tgz#5a474353b9f3353ddd8176dfd37b91c83a46f1d4"
-
 extend@~3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"
@@ -514,12 +545,6 @@ fast-json-stable-stringify@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz#d5142c0caee6b1189f87d3a76111064f86c8bbf2"
   integrity sha1-1RQsDK7msRifh9OnYREGT4bIu/I=
-
-find@^0.2.4:
-  version "0.2.9"
-  resolved "https://registry.yarnpkg.com/find/-/find-0.2.9.tgz#4b73f1ff9e56ad91b76e716407fe5ffe6554bb8c"
-  dependencies:
-    traverse-chain "~0.1.0"
 
 follow-redirects@^1.5.10:
   version "1.5.10"
@@ -709,10 +734,6 @@ is-wsl@^1.1.0:
   resolved "https://registry.yarnpkg.com/is-wsl/-/is-wsl-1.1.0.tgz#1f16e4aa22b04d1336b66188a66af3c600c3a66d"
   integrity sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=
 
-is_js@^0.9.0:
-  version "0.9.0"
-  resolved "https://registry.yarnpkg.com/is_js/-/is_js-0.9.0.tgz#0ab94540502ba7afa24c856aa985561669e9c52d"
-
 isarray@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-0.0.1.tgz#8a18acfca9a8f4177e09abfc6038939b05d1eedf"
@@ -761,7 +782,7 @@ json-stable-stringify@^1.0.1:
   dependencies:
     jsonify "~0.0.0"
 
-json-stringify-safe@~5.0.0, json-stringify-safe@~5.0.1:
+json-stringify-safe@~5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
 
@@ -815,10 +836,6 @@ lolex@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/lolex/-/lolex-4.1.0.tgz#ecdd7b86539391d8237947a3419aa8ac975f0fe1"
   integrity sha512-BYxIEXiVq5lGIXeVHnsFzqa1TxN5acnKnPCdlZSpzm8viNEOhiigupA4vTQ9HEFQ6nLTQ9wQOgBknJgzUYQ9Aw==
-
-lru-cache@~2.2.1:
-  version "2.2.4"
-  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-2.2.4.tgz#6c658619becf14031d0d0b594b16042ce4dc063d"
 
 make-error@^1.1.1:
   version "1.3.4"
@@ -1026,12 +1043,6 @@ rechoir@^0.6.2:
   dependencies:
     resolve "^1.1.6"
 
-request-ip@~2.0.1:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/request-ip/-/request-ip-2.0.2.tgz#deeae6d4af21768497db8cd05fa37143f8f1257e"
-  dependencies:
-    is_js "^0.9.0"
-
 request@^2.88.0:
   version "2.88.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.88.0.tgz#9c2fca4f7d35b592efe57c7f0a55e81052124fef"
@@ -1076,22 +1087,6 @@ rimraf@^2.5.4:
   dependencies:
     glob "^7.0.5"
 
-rollbar@~2.2.8:
-  version "2.2.10"
-  resolved "https://registry.yarnpkg.com/rollbar/-/rollbar-2.2.10.tgz#ef9ac02186f30e2ab1ab62b3b93599e12ea0b67c"
-  dependencies:
-    async "~1.2.1"
-    console-polyfill "0.3.0"
-    debug "2.6.9"
-    error-stack-parser "1.3.3"
-    extend "3.0.0"
-    json-stringify-safe "~5.0.0"
-    lru-cache "~2.2.1"
-    request-ip "~2.0.1"
-    uuid "3.0.x"
-  optionalDependencies:
-    decache "^3.0.5"
-
 safe-buffer@^5.0.1, safe-buffer@^5.1.2:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.0.tgz#b74daec49b1148f88c64b68d49b1e815c1f2f519"
@@ -1123,6 +1118,11 @@ shelljs@^0.8.2:
     glob "^7.0.0"
     interpret "^1.0.0"
     rechoir "^0.6.2"
+
+shimmer@^1.1.0, shimmer@^1.2.0:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/shimmer/-/shimmer-1.2.1.tgz#610859f7de327b587efebf501fb43117f9aff337"
+  integrity sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw==
 
 sinon@~5.0.7:
   version "5.0.10"
@@ -1177,9 +1177,10 @@ sshpk@^1.7.0:
     safer-buffer "^2.0.2"
     tweetnacl "~0.14.0"
 
-stackframe@^0.3.1:
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/stackframe/-/stackframe-0.3.1.tgz#33aa84f1177a5548c8935533cbfeb3420975f5a4"
+stack-chain@^1.3.7:
+  version "1.3.7"
+  resolved "https://registry.yarnpkg.com/stack-chain/-/stack-chain-1.3.7.tgz#d192c9ff4ea6a22c94c4dd459171e3f00cea1285"
+  integrity sha1-0ZLJ/06moiyUxN1FkXHj8AzqEoU=
 
 supports-color@4.4.0:
   version "4.4.0"
@@ -1215,10 +1216,6 @@ tough-cookie@~2.4.3:
   dependencies:
     psl "^1.1.24"
     punycode "^1.4.1"
-
-traverse-chain@~0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/traverse-chain/-/traverse-chain-0.1.0.tgz#61dbc2d53b69ff6091a12a168fd7d433107e40f1"
 
 ts-node@^6.0.0:
   version "6.0.3"
@@ -1346,10 +1343,6 @@ url-parse@^1.4.4:
     querystringify "^2.1.1"
     requires-port "^1.0.0"
 
-uuid@3.0.x:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.0.1.tgz#6544bba2dfda8c1cf17e629a3a305e2bb1fee6c1"
-
 uuid@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
@@ -1368,6 +1361,13 @@ vscode-cpptools@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/vscode-cpptools/-/vscode-cpptools-2.1.2.tgz#465d42c66850e877ee5a14574c9376ffca151968"
   integrity sha512-oMx/wsLQM6NggnmWn4t8lIrt1K7Zpl5G34zxNu+J6KHGnCxBzc+NHnxXS1Vu1hLxGWwANAvdxr3mEcA2LMe7hQ==
+
+vscode-extension-telemetry@^0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/vscode-extension-telemetry/-/vscode-extension-telemetry-0.1.2.tgz#049207f5453930888ff68ca925b07bab08f2c955"
+  integrity sha512-FSbaZKlIH3VKvBJsKw7v5bESWHXzltji2rtjaJeJglpQH4tfClzwHMzlMXUZGiblV++djEzb1gW8mb5E+wxFsg==
+  dependencies:
+    applicationinsights "1.4.0"
 
 vscode-test@^0.4.1:
   version "0.4.3"


### PR DESCRIPTION
1. Changed rollbar to a logger. It doesn't send any data anymore, but still has all other previous functions such as logging error and triggering debugger.
1. Added telemetries for
    - CMake exe not found.
    - Configure: CMake exe version, generator, config type, duration, warning count, and error count
    - Build: Config type, duration, warning count, and error count