### PR TITLE
Refactor and extend CMS-server driver test

### DIFF
--- a/scripts/ci.ps1
+++ b/scripts/ci.ps1
@@ -109,12 +109,31 @@ Invoke-ChronicCommand "Running TSLint" $yarn run lint:nofix
 
 # Get the CMake binary that we will use to run our tests
 $cmake_binary = Install-TestCMake -Version "3.10.0"
+$Env:CMAKE_EXECUTABLE = $cmake_binary
+
+# Add cmake to search path environment variable
+if ($PSVersionTable.Platform -eq "Unix") {
+    function set_cmake_in_path( $file, $cmake_path ) {
+        $start = "export CMAKE_BIN_DIR="
+        $content = Get-Content $file
+        if ( $content -match "^$start" ) {
+            $content -replace "^$start.*", "$start$cmake_path" |
+            Set-Content $file
+        } else {
+            Add-Content $file "$start$cmake_path"
+            Add-Content $file 'export PATH=$CMAKE_BIN_DIR:$PATH'
+        }
+    }
+    set_cmake_in_path "~/.bashrc" (get-item $cmake_binary).Directory.FullName
+} else {
+    $Env:PATH = (get-item $cmake_binary).Directory.FullName + [System.IO.Path]::PathSeparator + $Env:PATH
+}
 
 # Get the Ninja binary that we will use to run our tests
 $ninja_binary = Install-TestNinjaMakeSystem -Version "1.8.2"
 
 # Add ninja to search path environment variable
-$Env:PATH = $Env:PATH + [System.IO.Path]::PathSeparator + (get-item $ninja_binary).Directory.FullName
+$Env:PATH = (get-item $ninja_binary).Directory.FullName + [System.IO.Path]::PathSeparator + $Env:PATH
 
 if (! $NoTest) {
     # Prepare to run our tests

--- a/src/drivers/cms-driver.ts
+++ b/src/drivers/cms-driver.ts
@@ -228,6 +228,10 @@ export class CMakeServerClientDriver extends CMakeDriver {
       await this._cleanPriorConfiguration();
     }
     await cb();
+    if (!this.generator) {
+      throw new NoGeneratorError();
+    }
+
     await this._restartClient();
   }
 

--- a/test/extension-tests/successful-build/test/preferred-generators.test.ts
+++ b/test/extension-tests/successful-build/test/preferred-generators.test.ts
@@ -2,6 +2,7 @@ import {CMakeTools} from '@cmt/cmake-tools';
 import {Kit, scanForKits} from '@cmt/kit';
 import {clearExistingKitConfigurationFile, DefaultEnvironment, expect} from '@test/util';
 import {ITestCallbackContext} from 'mocha';
+import * as path from 'path';
 
 interface KitEnvironment {
   defaultKit: RegExp;
@@ -133,7 +134,8 @@ const KITS_BY_PLATFORM: {[osName: string]: KitEnvironment[]} = {
     path: [
       '/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin',
       '/Applications/Xcode.app/Contents/Developer/usr/bin',
-      '/Users/travis/.local/share/CMakeTools/test-cmake-root/3.10.0/bin'
+      process.env.CMAKE_EXECUTABLE ? path.dirname(process.env.CMAKE_EXECUTABLE)
+                                   : '/Users/travis/.local/share/CMakeTools/test-cmake-root/3.10.0/bin'
     ]
   }]
 };

--- a/test/helpers/test/default-environment.ts
+++ b/test/helpers/test/default-environment.ts
@@ -24,6 +24,9 @@ export class DefaultEnvironment {
       return Promise.resolve(undefined);
     });
     this.sandbox.stub(vscode.window, 'showInformationMessage').callsFake(() => ({doOpen: false}));
+    if (process.env.CMAKE_EXECUTABLE) {
+      this.config.updatePartial( {cmakePath: process.env.CMAKE_EXECUTABLE});
+    }
   }
 
   readonly sandbox = sinon.createSandbox();

--- a/test/unit-tests/cms-driver/cms-driver.test.ts
+++ b/test/unit-tests/cms-driver/cms-driver.test.ts
@@ -22,6 +22,7 @@ let driver: CMakeDriver|null = null;
 // tslint:disable:no-unused-expression
 
 suite('CMake-Server-Driver tests', () => {
+  const cmakePath: string = process.env.CMAKE_EXECUTABLE? process.env.CMAKE_EXECUTABLE: 'cmake';
   let kitDefault: Kit;
   if (process.platform === 'win32') {
     kitDefault = {
@@ -66,7 +67,7 @@ suite('CMake-Server-Driver tests', () => {
     const root = getTestRootFilePath('test/unit-tests/cms-driver/workspace');
     const projectRoot = getTestRootFilePath('test/unit-tests/cms-driver/workspace/test_project');
     const config = ConfigurationReader.createForDirectory(root);
-    const executable = await getCMakeExecutableInformation('cmake');
+    const executable = await getCMakeExecutableInformation(cmakePath);
 
     driver = await cms_driver.CMakeServerClientDriver
                  .create(executable, config, kitDefault, projectRoot, async () => {}, []);
@@ -82,7 +83,7 @@ suite('CMake-Server-Driver tests', () => {
     const root = getTestRootFilePath('test/unit-tests/cms-driver/workspace');
     const projectRoot = getTestRootFilePath('test/unit-tests/cms-driver/workspace/test_project');
     const config = ConfigurationReader.createForDirectory(root);
-    const executable = await getCMakeExecutableInformation('cmake');
+    const executable = await getCMakeExecutableInformation(cmakePath);
 
     driver = await cms_driver.CMakeServerClientDriver
                  .create(executable, config, kitDefault, projectRoot, async () => {}, []);
@@ -93,7 +94,7 @@ suite('CMake-Server-Driver tests', () => {
     const root = getTestRootFilePath('test/unit-tests/cms-driver/workspace');
     const projectRoot = getTestRootFilePath('test/unit-tests/cms-driver/workspace/test_project');
     const config = ConfigurationReader.createForDirectory(root);
-    const executable = await getCMakeExecutableInformation('cmake');
+    const executable = await getCMakeExecutableInformation(cmakePath);
 
     driver = await cms_driver.CMakeServerClientDriver
                  .create(executable, config, kitDefault, projectRoot, async () => {}, []);
@@ -109,7 +110,7 @@ suite('CMake-Server-Driver tests', () => {
     const root = getTestRootFilePath('test/unit-tests/cms-driver/workspace');
     const projectRoot = getTestRootFilePath('test/unit-tests/cms-driver/workspace/test_project');
     const config = ConfigurationReader.createForDirectory(root);
-    const executable = await getCMakeExecutableInformation('cmake');
+    const executable = await getCMakeExecutableInformation(cmakePath);
 
     const kit = {name: 'GCC', preferredGenerator: {name: 'BlaBla'}} as Kit;
 
@@ -122,7 +123,7 @@ suite('CMake-Server-Driver tests', () => {
     const root = getTestRootFilePath('test/unit-tests/cms-driver/workspace');
     const projectRoot = getTestRootFilePath('test/unit-tests/cms-driver/workspace/empty_project');
     const config = ConfigurationReader.createForDirectory(root);
-    const executable = await getCMakeExecutableInformation('cmake');
+    const executable = await getCMakeExecutableInformation(cmakePath);
 
     let called = false;
     const checkPreconditionHelper = async (e: CMakePreconditionProblems) => {
@@ -139,7 +140,7 @@ suite('CMake-Server-Driver tests', () => {
     const root = getTestRootFilePath('test/unit-tests/cms-driver/workspace');
     const projectRoot = getTestRootFilePath('test/unit-tests/cms-driver/workspace/test_project');
     const config = ConfigurationReader.createForDirectory(root);
-    const executable = await getCMakeExecutableInformation('cmake');
+    const executable = await getCMakeExecutableInformation(cmakePath);
 
     let called = false;
     const checkPreconditionHelper = async (e: CMakePreconditionProblems) => {
@@ -160,7 +161,7 @@ suite('CMake-Server-Driver tests', () => {
     const root = getTestRootFilePath('test/unit-tests/cms-driver/workspace');
     const projectRoot = getTestRootFilePath('test/unit-tests/cms-driver/workspace/test_project');
     const config = ConfigurationReader.createForDirectory(root);
-    const executable = await getCMakeExecutableInformation('cmake');
+    const executable = await getCMakeExecutableInformation(cmakePath);
 
     let called = false;
     const checkPreconditionHelper = async (e: CMakePreconditionProblems) => {
@@ -181,7 +182,7 @@ suite('CMake-Server-Driver tests', () => {
     const root = getTestRootFilePath('test/unit-tests/cms-driver/workspace');
     const projectRoot = getTestRootFilePath('test/unit-tests/cms-driver/workspace/test_project');
     const config = ConfigurationReader.createForDirectory(root);
-    const executable = await getCMakeExecutableInformation('cmake');
+    const executable = await getCMakeExecutableInformation(cmakePath);
 
     let called = false;
     const checkPreconditionHelper = async (e: CMakePreconditionProblems) => {
@@ -204,7 +205,7 @@ suite('CMake-Server-Driver tests', () => {
     const root = getTestRootFilePath('test/unit-tests/cms-driver/workspace');
     const projectRoot = getTestRootFilePath('test/unit-tests/cms-driver/workspace/test_project');
     const config = ConfigurationReader.createForDirectory(root);
-    const executable = await getCMakeExecutableInformation('cmake');
+    const executable = await getCMakeExecutableInformation(cmakePath);
 
     let called = false;
     const checkPreconditionHelper = async (e: CMakePreconditionProblems) => {
@@ -227,7 +228,7 @@ suite('CMake-Server-Driver tests', () => {
     const root = getTestRootFilePath('test/unit-tests/cms-driver/workspace');
     const projectRoot = getTestRootFilePath('test/unit-tests/cms-driver/workspace/test_project');
     const config = ConfigurationReader.createForDirectory(root);
-    const executable = await getCMakeExecutableInformation('cmake');
+    const executable = await getCMakeExecutableInformation(cmakePath);
 
     let called = false;
     const checkPreconditionHelper = async (e: CMakePreconditionProblems) => {
@@ -250,7 +251,7 @@ suite('CMake-Server-Driver tests', () => {
     const root = getTestRootFilePath('test/unit-tests/cms-driver/workspace');
     const projectRoot = getTestRootFilePath('test/unit-tests/cms-driver/workspace/test_project');
     const config = ConfigurationReader.createForDirectory(root);
-    const executable = await getCMakeExecutableInformation('cmake');
+    const executable = await getCMakeExecutableInformation(cmakePath);
 
     let called = false;
     const checkPreconditionHelper = async (e: CMakePreconditionProblems) => {
@@ -273,7 +274,7 @@ suite('CMake-Server-Driver tests', () => {
     const root = getTestRootFilePath('test/unit-tests/cms-driver/workspace');
     const projectRoot = getTestRootFilePath('test/unit-tests/cms-driver/workspace/test_project');
     const config = ConfigurationReader.createForDirectory(root);
-    const executable = await getCMakeExecutableInformation('cmake');
+    const executable = await getCMakeExecutableInformation(cmakePath);
 
     let called = false;
     const checkPreconditionHelper = async (e: CMakePreconditionProblems) => {
@@ -297,7 +298,7 @@ suite('CMake-Server-Driver tests', () => {
     const root = getTestRootFilePath('test/unit-tests/cms-driver/workspace');
     const projectRoot = getTestRootFilePath('test/unit-tests/cms-driver/workspace/test_project');
     const config = ConfigurationReader.createForDirectory(root);
-    const executable = await getCMakeExecutableInformation('cmake');
+    const executable = await getCMakeExecutableInformation(cmakePath);
 
     driver = await cms_driver.CMakeServerClientDriver
                  .create(executable, config, kitNinja, projectRoot, async () => {}, []);
@@ -315,7 +316,7 @@ suite('CMake-Server-Driver tests', () => {
     const root = getTestRootFilePath('test/unit-tests/cms-driver/workspace');
     const projectRoot = getTestRootFilePath('test/unit-tests/cms-driver/workspace/test_project');
     const config = ConfigurationReader.createForDirectory(root);
-    const executable = await getCMakeExecutableInformation('cmake');
+    const executable = await getCMakeExecutableInformation(cmakePath);
 
     driver = await cms_driver.CMakeServerClientDriver
                  .create(executable, config, kitDefault, projectRoot, async () => {}, []);
@@ -334,7 +335,7 @@ suite('CMake-Server-Driver tests', () => {
     const root = getTestRootFilePath('test/unit-tests/cms-driver/workspace');
     const projectRoot = getTestRootFilePath('test/unit-tests/cms-driver/workspace/test_project');
     const config = ConfigurationReader.createForDirectory(root);
-    const executable = await getCMakeExecutableInformation('cmake');
+    const executable = await getCMakeExecutableInformation(cmakePath);
 
     driver = await cms_driver.CMakeServerClientDriver
                  .create(executable, config, kitDefault, projectRoot, async () => {}, []);
@@ -346,7 +347,7 @@ suite('CMake-Server-Driver tests', () => {
     const root = getTestRootFilePath('test/unit-tests/cms-driver/workspace');
     const projectRoot = getTestRootFilePath('test/unit-tests/cms-driver/workspace/test_project');
     const config = ConfigurationReader.createForDirectory(root);
-    const executable = await getCMakeExecutableInformation('cmake');
+    const executable = await getCMakeExecutableInformation(cmakePath);
 
     driver = await cms_driver.CMakeServerClientDriver
                        .create(executable, config, kitDefault, projectRoot, async () => {}, []);

--- a/test/unit-tests/cms-driver/workspace/bad_command/CMakeLists.txt
+++ b/test/unit-tests/cms-driver/workspace/bad_command/CMakeLists.txt
@@ -1,0 +1,4 @@
+cmake_minimum_required(VERSION 3.2)
+project(TestProject VERSION 0.1)
+
+bad_command()


### PR DESCRIPTION
I have extended the CMS-Server tests at development of cmake-file-api(7) implementation.

This PR contains 
- Bug fix in the test infrastructure.
  The CI script downloads a CMake version but not all tests used the downloaded CMake version. In some parts the cmake version provided by OS via`PATH` environment variable is used.
- Extend tests for cmake configure (check error behavior)
- Add test for invalid preferred cmake generator (define a expected error behavior)
- Prepares test suite for reuse at legacy or file api driver tests.