### PR TITLE
Adapt cpptools integration to API verison 3

### DIFF
--- a/src/cpptools.ts
+++ b/src/cpptools.ts
@@ -220,27 +220,24 @@ export class CppConfigurationProvider implements cpt.CustomConfigurationProvider
       }
     }
 
-    let cpptoolsCompilerPath = (flags.length === 0) ? comp_path : `${comp_path} ${flags.join(' ')}`;
-    if (sysroot && cpptoolsCompilerPath.indexOf("--sysroot") < 0) {
-      if (sysroot.match(/\s/)) {
-        cpptoolsCompilerPath += ` "--sysroot=${sysroot}"`;
-      }
-      else {
-        cpptoolsCompilerPath += ` --sysroot=${sysroot}`;
-      }
+    if (sysroot) {
+      flags.push(`--sysroot=${sysroot}`);
     }
 
     this._workspaceBrowseConfiguration = {
       browsePath: newBrowsePath,
       standard,
-      compilerPath: cpptoolsCompilerPath || undefined,
+      compilerPath: comp_path || undefined,
+      compilerArgs: flags || undefined
     };
+
     return {
       defines,
       standard,
       includePath,
       intelliSenseMode: is_msvc ? 'msvc-x64' : 'clang-x64',
-      compilerPath: cpptoolsCompilerPath || undefined,
+      compilerPath: comp_path || undefined,
+      compilerArgs: flags || undefined
     };
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -64,6 +64,13 @@
   dependencies:
     "@types/chai" "*"
 
+"@types/chai-string@^1.4.1":
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/@types/chai-string/-/chai-string-1.4.2.tgz#0f116504a666b6c6a3c42becf86634316c9a19ac"
+  integrity sha512-ld/1hV5qcPRGuwlPdvRfvM3Ka/iofOk2pH4VkasK4b1JJP1LjNmWWn0LsISf6RRzyhVOvs93rb9tM09e+UuF8Q==
+  dependencies:
+    "@types/chai" "*"
+
 "@types/chai@*", "@types/chai@^4.0.4":
   version "4.1.3"
   resolved "https://registry.yarnpkg.com/@types/chai/-/chai-4.1.3.tgz#b8a74352977a23b604c01aa784f5b793443fb7dc"
@@ -307,6 +314,11 @@ chai-as-promised@^7.1.1:
   resolved "https://registry.yarnpkg.com/chai-as-promised/-/chai-as-promised-7.1.1.tgz#08645d825deb8696ee61725dbf590c012eb00ca0"
   dependencies:
     check-error "^1.0.2"
+
+chai-string@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/chai-string/-/chai-string-1.5.0.tgz#0bdb2d8a5f1dbe90bc78ec493c1c1c180dd4d3d2"
+  integrity sha512-sydDC3S3pNAQMYwJrs6dQX0oBQ6KfIPuOZ78n7rocW0eJJlsHPh2t3kwW7xfwYA/1Bf6/arGtSUo16rxR2JFlw==
 
 chai@^4.1.2:
   version "4.1.2"


### PR DESCRIPTION
<!-- Thanks for your contribution! To make things easier, please fill out the template below. -->

<!-- Please delete any unused sections. -->

<!-- Delete the following heading if there is no corresponding issue -->
## This change addresses item #637 

Changed cpptools integration to use api version 3.

## The purpose of this change

Cpptools changed in version 3 the api for the `WorkspaceBrowseConfiguration` and `SourceFileConfiguration`. The compiler flags are now included in the `compilerArgs` property.
