### PR TITLE
Add references back to the 'getting started' page

### DIFF
--- a/docs/configuring.rst
+++ b/docs/configuring.rst
@@ -6,6 +6,9 @@ CMake Configuring
 CMake Tools wraps the CMake *configure* process separately from the *build*
 process.
 
+.. seealso::
+    - :ref:`getting-started`
+
 A Crash-Course on CMake's Configuration Process
 ***********************************************
 

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -7,6 +7,9 @@ CMake Tools supports a variety of settings that can be set at the user or
 workspace level via VSCode's ``settings.json`` file. This page talks about
 the available options and how they are used.
 
+.. seealso::
+    - :ref:`getting-started`
+
 Options marked with *Supports substitution* allow variable references to appear
 in their strings. See the :ref:`var-subs` section
 


### PR DESCRIPTION
<!-- Thanks for your contribution! To make things easier, please fill out the template below. -->

<!-- Please delete any unused sections. -->

<!-- Delete the following heading if there is no corresponding issue -->
## This change addresses item #769 

### This changes documentation (in the future)

The following changes are proposed:

Add links back to the "Getting Started" page.

