### PR TITLE
Add component governance.

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,5 @@
+name: $(Date:yyyyMMdd).$(Rev:r)
+pr:
+- 'develop'
+jobs:
+- template: jobs/build.windows.yml

--- a/jobs/build.windows.yml
+++ b/jobs/build.windows.yml
@@ -1,0 +1,22 @@
+parameters:
+  name: ''
+  pool: ''
+
+jobs:
+- job: Windows
+  pool:
+    vmImage: 'vs2017-win2016'
+
+  steps:
+  - task: NodeTool@0
+    displayName: 'Use Node 10.16.x'
+    inputs:
+      versionSpec: 10.16.x
+
+  - script: yarn install
+    displayName: "Install Dependencies"
+    workingDirectory: '$(Build.SourcesDirectory)'
+
+  - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
+    displayName: 'Component Detection'
+    continueOnError: true


### PR DESCRIPTION
This enables component governance to run (which enables flagging of security issues and auto-generation of a third party notices).

I didn't bother actually setting up the Azure Pipeline CI build stuff (looks like travis-ci is still being used).

I might add a new THIRD.md if it's available in time...waiting for the legal policy to be added.