### PR TITLE
Update problem matcher for msvc

### DIFF
--- a/src/diagnostics/msvc.ts
+++ b/src/diagnostics/msvc.ts
@@ -8,7 +8,7 @@ import * as vscode from 'vscode';
 import {oneLess, RawDiagnosticParser, FeedLineResult} from './util';
 
 export const REGEX
-    = /^\s*(?!\d+>)?\s*([^\s>].*)\((\d+|\d+,\d+|\d+,\d+,\d+,\d+)\):\s+((?:fatal )?error|warning|info)\s+(\w{1,2}\d+)\s*:\s*(.*)$/;
+    = /^\s*(\d+>)?\s*([^\s>].*)\((\d+|\d+,\d+|\d+,\d+,\d+,\d+)\):\s+((?:fatal )?error|warning|info)\s+(\w{1,2}\d+)\s*:\s*(.*)$/;
 
 export class Parser extends RawDiagnosticParser {
   doHandleLine(line: string) {
@@ -16,7 +16,7 @@ export class Parser extends RawDiagnosticParser {
     if (!res) {
       return FeedLineResult.NotMine;
     }
-    const [full, file, location, severity, code, message] = res;
+    const [full, /*proc*/, file, location, severity, code, message] = res;
     const range = (() => {
       const parts = location.split(',');
       const n0 = oneLess(parts[0]);

--- a/test/unit-tests/diagnostics.test.ts
+++ b/test/unit-tests/diagnostics.test.ts
@@ -333,4 +333,22 @@ suite('Diagnostics', async () => {
     expect(build_consumer.compilers.gcc.diagnostics[0].location.start.line).to.eq(65);
     expect(build_consumer.compilers.gcc.diagnostics[0].location.start.character).to.eq(0);
   });
+
+  test('Parse MSVC single proc error', () => {
+    const lines = [`C:\\foo\\bar\\include\\bar.hpp(67): error C2429: language feature 'init-statements in if/switch' requires compiler flag '/std:c++latest'`];
+    feedLines(build_consumer, [], lines);
+    expect(build_consumer.compilers.msvc.diagnostics).to.have.length(1);
+    expect(build_consumer.compilers.msvc.diagnostics[0].file).to.eq('C:\\foo\\bar\\include\\bar.hpp');
+    expect(build_consumer.compilers.msvc.diagnostics[0].location.start.line).to.eq(66);
+    expect(build_consumer.compilers.msvc.diagnostics[0].location.start.character).to.eq(0);
+  });
+
+  test('Parse MSVC multi proc error', () => {
+    const lines = [`12>C:\\foo\\bar\\include\\bar.hpp(67): error C2429: language feature 'init-statements in if/switch' requires compiler flag '/std:c++latest'`];
+    feedLines(build_consumer, [], lines);
+    expect(build_consumer.compilers.msvc.diagnostics).to.have.length(1);
+    expect(build_consumer.compilers.msvc.diagnostics[0].file).to.eq('C:\\foo\\bar\\include\\bar.hpp');
+    expect(build_consumer.compilers.msvc.diagnostics[0].location.start.line).to.eq(66);
+    expect(build_consumer.compilers.msvc.diagnostics[0].location.start.character).to.eq(0);
+  });
 });


### PR DESCRIPTION
Fix the problem matcher regular expression to account also for the '>NO' prefix of a log line created by a multi proc build.
Add two new unit tests.