### PR TITLE
Update release notes. Fix in scan for kits.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,11 @@
 Thank you to the following CMake Tools contributors: koemai, bjosa, emanspeaks, som1lse,
 dcourtois, tsing80, andy-held, notskm, thezogoth, yokuyuki, dbird137, fabianogk, randshot.
 
-**vector-of-bool** has moved on to other things and Microsoft is now maintaining this extension. Thank you **vector-of-bool** for all of your hard work getting
-this extension to where it is today!
+**vector-of-bool** has moved on to other things and Microsoft is now maintaining this extension. Thank you **vector-of-bool**
+for all of your hard work getting this extension to where it is today!
 
 Breaking changes:
-- The publisher id changes to ms-vscode.cmake-tools
+- The publisher id changes to ms-vscode.cmake-tools.
 - Scanning for kits is able to detect more accurately multiple VS installations.
   To achieve this, a Visual Studio kit is defined differently now in cmake-tools-kits.json:
   the "visualStudio" field represents an ID unique to the installation
@@ -18,35 +18,28 @@ Breaking changes:
   each time a "Scan for kits" is performed.
 
 Features:
-- Support for localized messages
-- Cross compile support for CppTools integration
-- Adapt CppTools integration to API version 3 [https://github.com/Microsoft/vscode-cmake-tools/issues/637](#637)
-- Expand kit environment variables [https://github.com/Microsoft/vscode-cmake-tools/issues/460](#460)
-- Add new commands: launchTargetDirectory, buildType, buildDirectory
-    - [https://github.com/Microsoft/vscode-cmake-tools/issues/334](#334)
-    - [https://github.com/Microsoft/vscode-cmake-tools/issues/654](#654)
-    - [https://github.com/Microsoft/vscode-cmake-tools/issues/564](#564)
-    - [https://github.com/Microsoft/vscode-cmake-tools/issues/559](#559)
-    - [https://github.com/Microsoft/vscode-cmake-tools/issues/695](#695)
-- Add support for VS2010
+- Support for localized messages.
+- Cross compile support for CppTools integration.
+- Adapt CppTools integration to API version 3. [#637](https://github.com/Microsoft/vscode-cmake-tools/issues/637)
+- Expand kit environment variables. [#460](https://github.com/Microsoft/vscode-cmake-tools/issues/460)
+- Add new commands: launchTargetDirectory, buildType, buildDirectory. [#334](https://github.com/Microsoft/vscode-cmake-tools/issues/334), [#654](https://github.com/Microsoft/vscode-cmake-tools/issues/654), [#564](https://github.com/Microsoft/vscode-cmake-tools/issues/564), [#559](https://github.com/Microsoft/vscode-cmake-tools/issues/559), [#695](https://github.com/Microsoft/vscode-cmake-tools/issues/695)
+- Add support for VS2010.
 
 Improvements:
-- Restructuring of the CMake Driver
-- Improve stability of CMake Generator Selection [https://github.com/Microsoft/vscode-cmake-tools/issues/512](#512)
-- Refactor and extend CMS-server driver test
-- Rework the CMake Build from a terminal to a task
-- Add Launch target test
-- Increase wait time in test to open terminal
+- Restructuring of the CMake Driver.
+- Improve stability of CMake Generator Selection. [#512](https://github.com/Microsoft/vscode-cmake-tools/issues/512)
+- Refactor and extend CMS-server driver test.
+- Rework the CMake Build from a terminal to a task.
+- Add Launch target test.
+- Increase wait time in test to open terminal.
 
 Bug fixes:
-- Cannot execute current target without a debugger [https://github.com/Microsoft/vscode-cmake-tools/issues/601](#601)
-- Path clobbering by bad kit file env
-    - [https://github.com/Microsoft/vscode-cmake-tools/issues/701](#701)
-    - [https://github.com/Microsoft/vscode-cmake-tools/issues/713](#713)
-- Target install missing [https://github.com/Microsoft/vscode-cmake-tools/issues/504](#504)
-- CTest controller updated on reconfig [https://github.com/Microsoft/vscode-cmake-tools/issues/212](#212)
-- Recalculate total for every run of CTest
-- Debug target does not find GDB [https://github.com/Microsoft/vscode-cmake-tools/issues/375](#375)
+- Cannot execute current target without a debugger. [#601](https://github.com/Microsoft/vscode-cmake-tools/issues/601)
+- Path clobbering by bad kit file env. [#701](https://github.com/Microsoft/vscode-cmake-tools/issues/701), [#713](https://github.com/Microsoft/vscode-cmake-tools/issues/713)
+- Target install missing. [#504](https://github.com/Microsoft/vscode-cmake-tools/issues/504)
+- CTest controller updated on reconfig. [#212](https://github.com/Microsoft/vscode-cmake-tools/issues/212)
+- Recalculate total for every run of CTest.
+- Debug target does not find GDB. [#375](https://github.com/Microsoft/vscode-cmake-tools/issues/375)
 
 ## 1.1.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,52 @@
 # What's New?
 
-[See the full changelog in the end-user documentation](https://vector-of-bool.github.io/docs/vscode-cmake-tools/changelog.html).
+## 1.2.0
+Thank you to the following CMake Tools contributors: koemai, bjosa, emanspeaks, som1lse,
+dcourtois, tsing80, andy-held, notskm, thezogoth, yokuyuki, dbird137, fabianogk, randshot.
+
+**vector-of-bool** has moved on to other things and Microsoft is now maintaining this extension. Thank you **vector-of-bool** for all of your hard work getting
+this extension to where it is today!
+
+Breaking changes:
+- The publisher id changes to ms-vscode.cmake-tools
+- Scanning for kits is able to detect more accurately multiple VS installations.
+  To achieve this, a Visual Studio kit is defined differently now in cmake-tools-kits.json:
+  the "visualStudio" field represents an ID unique to the installation
+  as opposed to "VisualStudio.${VS Version}" (which may be the same for multiple same year VS installations).
+  The CMake Tools Extension is still able to work with the old definition VS kits,
+  but for simplicity and to avoid duplicates in the json file it will prompt for permission to delete them
+  each time a "Scan for kits" is performed.
+
+Features:
+- Support for localized messages
+- Cross compile support for CppTools integration
+- Adapt CppTools integration to API version 3 [https://github.com/Microsoft/vscode-cmake-tools/issues/637](#637)
+- Expand kit environment variables [https://github.com/Microsoft/vscode-cmake-tools/issues/460](#460)
+- Add new commands: launchTargetDirectory, buildType, buildDirectory
+    - [https://github.com/Microsoft/vscode-cmake-tools/issues/334](#334)
+    - [https://github.com/Microsoft/vscode-cmake-tools/issues/654](#654)
+    - [https://github.com/Microsoft/vscode-cmake-tools/issues/564](#564)
+    - [https://github.com/Microsoft/vscode-cmake-tools/issues/559](#559)
+    - [https://github.com/Microsoft/vscode-cmake-tools/issues/695](#695)
+- Add support for VS2010
+
+Improvements:
+- Restructuring of the CMake Driver
+- Improve stability of CMake Generator Selection [https://github.com/Microsoft/vscode-cmake-tools/issues/512](#512)
+- Refactor and extend CMS-server driver test
+- Rework the CMake Build from a terminal to a task
+- Add Launch target test
+- Increase wait time in test to open terminal
+
+Bug fixes:
+- Cannot execute current target without a debugger [https://github.com/Microsoft/vscode-cmake-tools/issues/601](#601)
+- Path clobbering by bad kit file env
+    - [https://github.com/Microsoft/vscode-cmake-tools/issues/701](#701)
+    - [https://github.com/Microsoft/vscode-cmake-tools/issues/713](#713)
+- Target install missing [https://github.com/Microsoft/vscode-cmake-tools/issues/504](#504)
+- CTest controller updated on reconfig [https://github.com/Microsoft/vscode-cmake-tools/issues/212](#212)
+- Recalculate total for every run of CTest
+- Debug target does not find GDB [https://github.com/Microsoft/vscode-cmake-tools/issues/375](#375)
 
 ## 1.1.3
 

--- a/src/cmake-tools.ts
+++ b/src/cmake-tools.ts
@@ -362,7 +362,7 @@ export class CMakeTools implements vscode.Disposable, api.CMakeToolsAPI {
     this._activeKit = kit;
     if (kit) {
       log.debug(localize('injecting.new.kit', 'Injecting new Kit into CMake driver'));
-      const drv = await this.getCMakeDriverInstance();
+      const drv = await this._cmakeDriver;  // Use only an existing driver, do not create one
       if (drv) {
         try {
           this._statusMessage.set(localize('reloading.status', 'Reloading...'));

--- a/src/cmake-tools.ts
+++ b/src/cmake-tools.ts
@@ -362,7 +362,7 @@ export class CMakeTools implements vscode.Disposable, api.CMakeToolsAPI {
     this._activeKit = kit;
     if (kit) {
       log.debug(localize('injecting.new.kit', 'Injecting new Kit into CMake driver'));
-      const drv = await this._cmakeDriver;  // Use only an existing driver, do not create one
+      const drv = await this.getCMakeDriverInstance();
       if (drv) {
         try {
           this._statusMessage.set(localize('reloading.status', 'Reloading...'));

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1021,10 +1021,10 @@ class ExtensionManager implements vscode.Disposable {
       break;
     }
 
-    if (process.env['CMT_TESTING'] === '1') {
-      log.trace(localize('running.in.test.mode', 'Running CMakeTools in test mode. selectKit is disabled.'));
-      return false;
-    }
+    // if (process.env['CMT_TESTING'] === '1') {
+    //   log.trace(localize('running.in.test.mode', 'Running CMakeTools in test mode. selectKit is disabled.'));
+    //   return false;
+    // }
 
     interface KitItem extends vscode.QuickPickItem {
       kit: Kit;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1021,10 +1021,10 @@ class ExtensionManager implements vscode.Disposable {
       break;
     }
 
-    // if (process.env['CMT_TESTING'] === '1') {
-    //   log.trace(localize('running.in.test.mode', 'Running CMakeTools in test mode. selectKit is disabled.'));
-    //   return false;
-    // }
+    if (process.env['CMT_TESTING'] === '1') {
+      log.trace(localize('running.in.test.mode', 'Running CMakeTools in test mode. selectKit is disabled.'));
+      return false;
+    }
 
     interface KitItem extends vscode.QuickPickItem {
       kit: Kit;


### PR DESCRIPTION
Update release notes for CMake Tools #1.2.

Fix in scan for kits: 
    If cmake-tools-kits.json still has kits saved with the old format kit definition
(visualStudio field as "VisualStudio.$(installation version)", as opposed to "$(unique installation id)"),  then ask if the user allows them to be deleted from the user-local kits file.
    If the user answers 'NO' or doesn't answer, nothing needs to be done, even if there is an active kit set, because the extension is able to work with both definitions of a VS kit. In this case, the new cmake-tools-kits.json may have some duplicate kits pointing to the same toolset.
    If the answer is 'YES' and if there is an active kit selected that is among the ones to be deleted,  then the user must also pick a new kit.
 