### PR TITLE
SetKit fix (kit selection is not persisted properly when triggered at…

### DIFF
--- a/src/cmake-tools.ts
+++ b/src/cmake-tools.ts
@@ -362,7 +362,8 @@ export class CMakeTools implements vscode.Disposable, api.CMakeToolsAPI {
     this._activeKit = kit;
     if (kit) {
       log.debug(localize('injecting.new.kit', 'Injecting new Kit into CMake driver'));
-      const drv = await this._cmakeDriver;  // Use only an existing driver, do not create one
+      //const drv = await this._cmakeDriver;  // Use only an existing driver, do not create one
+      const drv = await this.getCMakeDriverInstance();
       if (drv) {
         try {
           this._statusMessage.set(localize('reloading.status', 'Reloading...'));


### PR DESCRIPTION
setKit may be called also very early, before a CMake driver instance is created. That can happen, for example, when a project folder is just opening and it doesn't have an active kit saved, triggering the kits quick pick to show up.
Not having a CMake driver instance at the time of selecting the kit causes the selection to not be persisted properly. 
The fix is to create a new instance of the CMake driver in setKit, if none exists yet.