### PR TITLE
Dev/andris/cmake tools/check publisher

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1320,6 +1320,11 @@ class SchemaProvider implements vscode.TextDocumentContentProvider {
  * @returns A promise that will resolve when the extension is ready for use
  */
 export async function activate(context: vscode.ExtensionContext) {
+    const oldCMakeToolsExtension = vscode.extensions.getExtension('vector-of-bool.cmake-tools');
+    if (oldCMakeToolsExtension) {
+        await vscode.window.showInformationMessage(localize('uninstall.old.cmaketools', 'CMakeTools changed publisher from "vector-of-bool" to "ms-vscode" starting wtih version #1.2. It is recommended to uninstall any older versions of CMakeTools.'));
+    }
+
   // Register a protocol handler to serve localized schemas
   vscode.workspace.registerTextDocumentContentProvider('cmake-tools-schema', new SchemaProvider());
   vscode.commands.executeCommand("setContext", "inCMakeProject", true);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1320,9 +1320,12 @@ class SchemaProvider implements vscode.TextDocumentContentProvider {
  * @returns A promise that will resolve when the extension is ready for use
  */
 export async function activate(context: vscode.ExtensionContext) {
+    // CMakeTools versions newer or equal to #1.2 should not coexist with older versions
+    // because the publisher changed (from vector-of-bool into ms-vscode),
+    // causing many undesired behaviors (duplicate operations, registrations for UI elements, etc...)
     const oldCMakeToolsExtension = vscode.extensions.getExtension('vector-of-bool.cmake-tools');
     if (oldCMakeToolsExtension) {
-        await vscode.window.showInformationMessage(localize('uninstall.old.cmaketools', 'CMakeTools changed publisher from "vector-of-bool" to "ms-vscode" starting wtih version #1.2. It is recommended to uninstall any older versions of CMakeTools.'));
+        await vscode.window.showInformationMessage(localize('uninstall.old.cmaketools', 'CMakeTools changed publisher from "vector-of-bool" to "ms-vscode" starting with version #1.2. It is recommended to uninstall any older versions of CMakeTools.'));
     }
 
   // Register a protocol handler to serve localized schemas

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1325,7 +1325,7 @@ export async function activate(context: vscode.ExtensionContext) {
     // causing many undesired behaviors (duplicate operations, registrations for UI elements, etc...)
     const oldCMakeToolsExtension = vscode.extensions.getExtension('vector-of-bool.cmake-tools');
     if (oldCMakeToolsExtension) {
-        await vscode.window.showInformationMessage(localize('uninstall.old.cmaketools', 'CMakeTools changed publisher from "vector-of-bool" to "ms-vscode" starting with version #1.2. It is recommended to uninstall any older versions of CMakeTools.'));
+        await vscode.window.showInformationMessage(localize('uninstall.old.cmaketools', 'CMake Tools is now published by Microsoft starting with version 1.2.0. Please uninstall any older versions of CMake Tools.'));
     }
 
   // Register a protocol handler to serve localized schemas


### PR DESCRIPTION
CMakeTools versions newer or equal to #1.2 should not coexist with older versions, because the publisher changed (from vector-of-bool into ms-vscode), causing many undesired behaviors (duplicate operations, registrations for UI elements, etc...).

Notify the user that is recommended to uninstall any CMakeTools version older than #1.2. 
