### PR TITLE
update flow for missing CMakeLists.txt

### DIFF
--- a/src/cmake-tools.ts
+++ b/src/cmake-tools.ts
@@ -229,7 +229,7 @@ export class CMakeTools implements vscode.Disposable, api.CMakeToolsAPI {
       break;
     case CMakePreconditionProblems.MissingCMakeListsFile:
       const quickStart = localize('quickstart.cmake.project', 'Quickstart a new CMake project');
-      const changeSetting = localize('edit setting', 'Update cmake.sourceDirectory setting');
+      const changeSetting = localize('edit.setting', 'Edit the \'cmake.sourceDirectory\' setting');
       const result = await vscode.window.showErrorMessage(
             localize('missing.cmakelists', 'CMakeLists.txt was not found in the root of the workspace folder'), quickStart, changeSetting);
       if (result === quickStart) {

--- a/src/cmake-tools.ts
+++ b/src/cmake-tools.ts
@@ -228,10 +228,14 @@ export class CMakeTools implements vscode.Disposable, api.CMakeToolsAPI {
       vscode.window.showErrorMessage(localize('no.source.directory.found', 'You do not have a source directory open'));
       break;
     case CMakePreconditionProblems.MissingCMakeListsFile:
-      const do_quickstart
-          = await vscode.window.showErrorMessage(localize('missing.cmakelists', 'You do not have a CMakeLists.txt', 'Quickstart a new CMake project'));
-      if (do_quickstart) {
+      const quickStart = localize('quickstart.cmake.project', 'Quickstart a new CMake project');
+      const changeSetting = localize('edit setting', 'Update cmake.sourcePath setting');
+      const result = await vscode.window.showErrorMessage(
+            localize('missing.cmakelists', 'CMakeLists.txt not found in workspace root folder'), quickStart, changeSetting);
+      if (result === quickStart) {
         vscode.commands.executeCommand('cmake.quickStart');
+      } else if (result === changeSetting) {
+        vscode.commands.executeCommand('workbench.action.openSettings');
       }
       break;
     }
@@ -585,6 +589,7 @@ export class CMakeTools implements vscode.Disposable, api.CMakeToolsAPI {
                 prog_sub.dispose();
               }
             } else {
+              progress.report({message: localize('configure.failed', 'Failed to configure project')});
               return -1;
             }
           });

--- a/src/cmake-tools.ts
+++ b/src/cmake-tools.ts
@@ -229,7 +229,7 @@ export class CMakeTools implements vscode.Disposable, api.CMakeToolsAPI {
       break;
     case CMakePreconditionProblems.MissingCMakeListsFile:
       const quickStart = localize('quickstart.cmake.project', 'Quickstart a new CMake project');
-      const changeSetting = localize('edit setting', 'Update cmake.sourcePath setting');
+      const changeSetting = localize('edit setting', 'Update cmake.sourceDirectory setting');
       const result = await vscode.window.showErrorMessage(
             localize('missing.cmakelists', 'CMakeLists.txt not found in workspace root folder'), quickStart, changeSetting);
       if (result === quickStart) {

--- a/src/cmake-tools.ts
+++ b/src/cmake-tools.ts
@@ -231,7 +231,7 @@ export class CMakeTools implements vscode.Disposable, api.CMakeToolsAPI {
       const quickStart = localize('quickstart.cmake.project', 'Quickstart a new CMake project');
       const changeSetting = localize('edit setting', 'Update cmake.sourceDirectory setting');
       const result = await vscode.window.showErrorMessage(
-            localize('missing.cmakelists', 'CMakeLists.txt not found in workspace root folder'), quickStart, changeSetting);
+            localize('missing.cmakelists', 'CMakeLists.txt was not found in the root of the workspace folder'), quickStart, changeSetting);
       if (result === quickStart) {
         vscode.commands.executeCommand('cmake.quickStart');
       } else if (result === changeSetting) {

--- a/src/drivers/driver.ts
+++ b/src/drivers/driver.ts
@@ -642,6 +642,8 @@ export abstract class CMakeDriver implements vscode.Disposable {
       telemetry.logEvent('configure', telemetryProperties, telemetryMeasures);
 
       return retc;
+    } catch {
+      return -1;
     } finally { this.configRunning = false; }
   }
 


### PR DESCRIPTION
## This change addresses item #533

### This changes visible behavior

The following changes are proposed:

When CMakeLists.txt is not discovered in the root of the folder, give the user the open to open settings and update the cmake.sourceDirectory setting

