### PR TITLE
Fix for issue 886: ignore vs kits processing when not on windows

### DIFF
--- a/src/kit.ts
+++ b/src/kit.ts
@@ -725,20 +725,23 @@ export async function scanForClangCLKits(searchPaths: string[]): Promise<Promise
 }
 
 async function getVSInstallForKit(kit: Kit): Promise<VSInstallation|undefined> {
-    if (process.platform === "win32") {
-        console.assert(kit.visualStudio);
-        console.assert(kit.visualStudioArchitecture);
-        const installs = await vsInstallations();
-        const match = (inst: VSInstallation) =>
-            // old Kit format
-            (legacyKitVSName(inst) == kit.visualStudio) ||
-            // new Kit format
-            (kitVSName(inst) === kit.visualStudio) ||
-            // Clang for VS kit format
-            (!!kit.compilers && kit.name.indexOf("Clang") >= 0 && kit.name.indexOf(vsDisplayName(inst)) >= 0);
-
-        return installs.find(inst => match(inst));
+    if (process.platform !== "win32") {
+        return undefined;
     }
+
+    console.assert(kit.visualStudio);
+    console.assert(kit.visualStudioArchitecture);
+
+    const installs = await vsInstallations();
+    const match = (inst: VSInstallation) =>
+        // old Kit format
+        (legacyKitVSName(inst) == kit.visualStudio) ||
+        // new Kit format
+        (kitVSName(inst) === kit.visualStudio) ||
+        // Clang for VS kit format
+        (!!kit.compilers && kit.name.indexOf("Clang") >= 0 && kit.name.indexOf(vsDisplayName(inst)) >= 0);
+
+    return installs.find(inst => match(inst));
 }
 
 export async function getVSKitEnvironment(kit: Kit): Promise<Map<string, string>|null> {

--- a/src/kit.ts
+++ b/src/kit.ts
@@ -724,11 +724,10 @@ export async function scanForClangCLKits(searchPaths: string[]): Promise<Promise
   return results;
 }
 
-async function getVSInstallForKit(kit: Kit): Promise<VSInstallation | undefined> {
+async function getVSInstallForKit(kit: Kit): Promise<VSInstallation|undefined> {
     if (process.platform === "win32") {
         console.assert(kit.visualStudio);
         console.assert(kit.visualStudioArchitecture);
-
         const installs = await vsInstallations();
         const match = (inst: VSInstallation) =>
             // old Kit format
@@ -742,7 +741,7 @@ async function getVSInstallForKit(kit: Kit): Promise<VSInstallation | undefined>
     }
 }
 
-export async function getVSKitEnvironment(kit: Kit): Promise<Map<string, string> | null> {
+export async function getVSKitEnvironment(kit: Kit): Promise<Map<string, string>|null> {
   const requested = await getVSInstallForKit(kit);
   if (!requested) {
     return null;

--- a/src/kit.ts
+++ b/src/kit.ts
@@ -724,22 +724,25 @@ export async function scanForClangCLKits(searchPaths: string[]): Promise<Promise
   return results;
 }
 
-async function getVSInstallForKit(kit: Kit): Promise<VSInstallation|undefined> {
-  console.assert(kit.visualStudio);
-  console.assert(kit.visualStudioArchitecture);
-  const installs = await vsInstallations();
-  const match = (inst: VSInstallation) =>
-      // old Kit format
-      (legacyKitVSName(inst) == kit.visualStudio) ||
-      // new Kit format
-      (kitVSName(inst) === kit.visualStudio) ||
-      // Clang for VS kit format
-      (!!kit.compilers && kit.name.indexOf("Clang") >= 0 && kit.name.indexOf(vsDisplayName(inst)) >= 0);
+async function getVSInstallForKit(kit: Kit): Promise<VSInstallation | undefined> {
+    if (process.platform === "win32") {
+        console.assert(kit.visualStudio);
+        console.assert(kit.visualStudioArchitecture);
 
-  return installs.find(inst => match(inst));
+        const installs = await vsInstallations();
+        const match = (inst: VSInstallation) =>
+            // old Kit format
+            (legacyKitVSName(inst) == kit.visualStudio) ||
+            // new Kit format
+            (kitVSName(inst) === kit.visualStudio) ||
+            // Clang for VS kit format
+            (!!kit.compilers && kit.name.indexOf("Clang") >= 0 && kit.name.indexOf(vsDisplayName(inst)) >= 0);
+
+        return installs.find(inst => match(inst));
+    }
 }
 
-export async function getVSKitEnvironment(kit: Kit): Promise<Map<string, string>|null> {
+export async function getVSKitEnvironment(kit: Kit): Promise<Map<string, string> | null> {
   const requested = await getVSInstallForKit(kit);
   if (!requested) {
     return null;


### PR DESCRIPTION
Fix for GitHub issue #886 . Visual Studio installations may be defined (together with other non VS tools) in the user kits json file that is parsed on linux and/or mac, in which case getVSInstallForKit should be a no-op to avoid other invalid issues down the road. 