### PR TITLE
Include missing source directories in the custom browse path

### DIFF
--- a/src/cpptools.ts
+++ b/src/cpptools.ts
@@ -265,6 +265,10 @@ export class CppConfigurationProvider implements cpt.CustomConfigurationProvider
         uri: vscode.Uri.file(abs).toString(),
         configuration,
       });
+      const dir = path.dirname(abs_norm);
+      if (this._workspaceBrowseConfiguration.browsePath.indexOf(dir) < 0) {
+        this._workspaceBrowseConfiguration.browsePath.push(dir);
+      }
     }
   }
 


### PR DESCRIPTION
<!-- Thanks for your contribution! To make things easier, please fill out the template below. -->

<!-- Please delete any unused sections. -->

<!-- Delete the following heading if there is no corresponding issue -->
## This change addresses item #882

The source directories were not being included in the browse path.  Only include directories were added.