### PR TITLE
Fix generator selection for MSYS (issue #885)

### DIFF
--- a/src/drivers/driver.ts
+++ b/src/drivers/driver.ts
@@ -528,6 +528,9 @@ export abstract class CMakeDriver implements vscode.Disposable {
         if (gen_name == 'Unix Makefiles') {
           return this.testHaveCommand('make');
         }
+        if (gen_name == 'MSYS Makefiles') {
+            return platform === 'win32' && this.testHaveCommand('make');
+        }
         return false;
       })();
       if (!generator_present) {


### PR DESCRIPTION
Fir for GitHub issue https://github.com/microsoft/vscode-cmake-tools/issues/885

driver.ts - findBestGenerator needs to know also about MSYS, otherwise this generator can never be set properly.

