### PR TITLE
User defined generator has priority over any other selection criteria

### DIFF
--- a/src/drivers/driver.ts
+++ b/src/drivers/driver.ts
@@ -320,7 +320,17 @@ export abstract class CMakeDriver implements vscode.Disposable {
     if (kit.preferredGenerator)
       preferredGenerators.push(kit.preferredGenerator);
 
-    this._generator = await this.findBestGenerator(preferredGenerators);
+    // Use the "best generator" selection logic only if the user did not define already
+    // in settings (via "cmake.generator") a particular generator to be used.
+    if (this.config.generator) {
+      this._generator = {
+        name: this.config.generator,
+        platform: this.config.platform || undefined,
+        toolset: this.config.toolset || undefined,
+      };
+    } else {
+      this._generator = await this.findBestGenerator(preferredGenerators);
+    }
   }
 
   protected abstract doSetKit(needsClean: boolean, cb: () => Promise<void>): Promise<void>;


### PR DESCRIPTION
Issues like https://github.com/microsoft/vscode-cmake-tools/issues/880 and https://github.com/microsoft/vscode-cmake-tools/issues/885 started to occur after the 1.2 update because the following logic changed, starting with https://github.com/microsoft/vscode-cmake-tools/commit/6d04ebd7d1e86c11d17f28296a0d9d22e2fabee0:
- before the above commit, the extension would trigger the 'best generator' search only if the user did not define in settings (via "cmake.generator") any specific generator
- after the above commit, the 'best generator' search is triggered regardless of the cmake.generator setting. Even if it includes its value, it can happen that some other generator be picked instead, in case any criterias are not met (like tools not being on the path).

Some other aspect of issue 885 is still fixed by PR https://github.com/microsoft/vscode-cmake-tools/pull/903. That change is needed for the scenario when the user would not define any "cmake.generator" in settings, but would define a preferred generator in the kits json. Even if make.exe would be on the path, making MSYS Makefiles generation possible, the extension would still pick something else instead (without that fix), depending what will be found in the path (Ninja, Unix or MingW...).

Issue 880 can be worked around if mingw32-make.exe is on the path, or pointed to via settings. But with this fix, configuring would still work properly, as it used to up to 1.1.3 release. 

