### PR TITLE
Update HandleBars version. Bump up CMake Tools Release version to #1.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,25 +2,22 @@
 
 ## 1.2.3
 Bug fixes:
-- CTest status bar button text appears malformed. [#911] (https://github.com/microsoft/vscode-cmake-tools/issues/911)
-- Cleanup fix for message "Platform undefined / toolset {}". [#913] (https://github.com/microsoft/vscode-cmake-tools/issues/913)
-- Fix incorrect file associations when language is unset. [#926] (https://github.com/microsoft/vscode-cmake-tools/issues/911)
-
-Improvements:
-- Add telemetry for crashes.
+- CTest status bar button text appears malformed. [#911](https://github.com/microsoft/vscode-cmake-tools/issues/911)
+- Cleanup fix for message "Platform undefined / toolset {}". [#913](https://github.com/microsoft/vscode-cmake-tools/issues/913)
+- Fix incorrect file associations when language is unset. [#926](https://github.com/microsoft/vscode-cmake-tools/issues/926)
 
 ## 1.2.2
 Bug fixes:
-- Fix broken SchemaProvider. [#874] (https://github.com/microsoft/vscode-cmake-tools/issues/874)
-- Fix the RegExp for finding a debugger. [#884] (https://github.com/microsoft/vscode-cmake-tools/issues/884)
-- Update flow for missing CMakeLists.txt. [#533] (https://github.com/microsoft/vscode-cmake-tools/issues/533)
-- getVSInstallForKit should be a no-op on systems other than windows. [#886] (https://github.com/microsoft/vscode-cmake-tools/issues/886)
-- Include missing source directories in the custom browse path [#882]. (https://github.com/microsoft/vscode-cmake-tools/issues/882)
-- Handle exceptions thrown by spawn. [#895] (https://github.com/microsoft/vscode-cmake-tools/issues/895)
+- Fix broken SchemaProvider. [#874](https://github.com/microsoft/vscode-cmake-tools/issues/874)
+- Fix the RegExp for finding a debugger. [#884](https://github.com/microsoft/vscode-cmake-tools/issues/884)
+- Update flow for missing CMakeLists.txt. [#533](https://github.com/microsoft/vscode-cmake-tools/issues/533)
+- getVSInstallForKit should be a no-op on systems other than windows. [#886](https://github.com/microsoft/vscode-cmake-tools/issues/886)
+- Include missing source directories in the custom browse path. [#882](https://github.com/microsoft/vscode-cmake-tools/issues/882)
+- Handle exceptions thrown by spawn. [#895](https://github.com/microsoft/vscode-cmake-tools/issues/895)
 - Various generators fixes:
-    - [#900] (https://github.com/microsoft/vscode-cmake-tools/issues/900)
-    - [#880] (https://github.com/microsoft/vscode-cmake-tools/issues/880)
-    - [#885] (https://github.com/microsoft/vscode-cmake-tools/issues/885)
+    - [#900](https://github.com/microsoft/vscode-cmake-tools/issues/900)
+    - [#880](https://github.com/microsoft/vscode-cmake-tools/issues/880)
+    - [#885](https://github.com/microsoft/vscode-cmake-tools/issues/885)
 
 ## 1.2.1
 Thank you to the following CMake Tools contributors: koemai, bjosa, emanspeaks, som1lse,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Bug fixes:
 - Fix incorrect file associations when language is unset. [#926] (https://github.com/microsoft/vscode-cmake-tools/issues/911)
 
 Improvements:
-- Add telemetry for crashes
+- Add telemetry for crashes.
 
 ## 1.2.2
 Bug fixes:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # What's New?
 
+## 1.2.3
+Bug fixes:
+- CTest status bar button text appears malformed. [#911] (https://github.com/microsoft/vscode-cmake-tools/issues/911)
+- Cleanup fix for message "Platform undefined / toolset {}". [#913] (https://github.com/microsoft/vscode-cmake-tools/issues/913)
+- Fix incorrect file associations when language is unset. [#926] (https://github.com/microsoft/vscode-cmake-tools/issues/911)
+
+Improvements:
+- Add telemetry for crashes
+
 ## 1.2.2
 Bug fixes:
 - Fix broken SchemaProvider. [#874] (https://github.com/microsoft/vscode-cmake-tools/issues/874)

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "cmake-tools",
   "displayName": "CMake Tools",
   "description": "Extended CMake support in Visual Studio Code",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "publisher": "ms-vscode",
   "repository": {
     "type": "git",
@@ -1115,7 +1115,7 @@
   "resolutions": {
     "marked": "^0.7.0",
     "diff": "^3.5.0",
-    "handlebars": "^4.5.2",
+    "handlebars": "^4.5.3",
     "https-proxy-agent": "^2.2.4"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2376,10 +2376,10 @@ gulplog@^1.0.0:
   dependencies:
     glogg "^1.0.0"
 
-handlebars@*, handlebars@^4.0.6, handlebars@^4.5.2:
-  version "4.5.2"
-  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.5.2.tgz#5a4eb92ab5962ca3415ac188c86dc7f784f76a0f"
-  integrity sha512-29Zxv/cynYB7mkT1rVWQnV7mGX6v7H/miQ6dbEpYTKq5eJBN7PsRB+ViYJlcT6JINTSu4dVB9kOqEun78h6Exg==
+handlebars@*, handlebars@^4.0.6, handlebars@^4.5.3:
+  version "4.5.3"
+  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.5.3.tgz#5cf75bd8714f7605713511a56be7c349becb0482"
+  integrity sha512-3yPecJoJHK/4c6aZhSvxOyG4vJKDshV36VHp0iVCDVh7o9w2vwi3NSnL2MMPj3YdduqaBcu7cGbggJQM0br9xA==
   dependencies:
     neo-async "^2.6.0"
     optimist "^0.6.1"


### PR DESCRIPTION
Update HandleBars to #4.5.3, because of security reasons.

Update CMake Tools version and changelog for #1.2.3 bug fixes release.