### PR TITLE
Support temp folders not located on system drive

### DIFF
--- a/src/kit.ts
+++ b/src/kit.ts
@@ -535,6 +535,7 @@ async function collectDevBatVars(devbat: string, args: string[], major_version: 
     `cd /d "%~dp0"`,
     `set "VS${major_version}0COMNTOOLS=${common_dir}"`,
     `call "${devbat}" ${args.join(' ')} || exit`,
+    `cd /d "%~dp0"`, /* Switch back to original drive */
   ];
   for (const envvar of MSVC_ENVIRONMENT_VARIABLES) {
     bat.push(`echo ${envvar} := %${envvar}% >> ${envfname}`);


### PR DESCRIPTION
### This changes CMake: Scan for Kits

The following changes are proposed:

- Switch back to the folder from which "devbat" was called after calling it


## The purpose of this change
If you do not change back to "%~dp0" after calling "devbat" and your temp directory is on another drive as your Visual Studio installation the corresponding ".env" file will not be created next to "devbat" but in the user's home directory. This causes the Visual Studio 2017 Kits to not be found.

Occured with:
* VS2017 15.5.3
* temp directory on drive D:
* CMake Tools 1.2.3

## Other Notes/Information
I hope the information provided by me is sufficient. This is my first pull request here :)

Edit: I did some more investigation. Seems like the proposed fix is a workaround for issues like
https://developercommunity.visualstudio.com/content/problem/26780/vsdevcmdbat-changes-the-current-working-directory.html
https://developercommunity.visualstudio.com/content/problem/134471/vcvarsallbat-changes-current-directory.html