### PR TITLE
Disable startDebugging test

### DIFF
--- a/test/extension-tests/successful-build/test/debugger.test.ts
+++ b/test/extension-tests/successful-build/test/debugger.test.ts
@@ -1,6 +1,6 @@
 import {CMakeTools} from '@cmt/cmake-tools';
 import {DefaultEnvironment, expect, getFirstSystemKit} from '@test/util';
-import sinon = require('sinon');
+//import sinon = require('sinon');
 import * as fs from 'fs';
 import * as path from 'path';
 

--- a/test/extension-tests/successful-build/test/debugger.test.ts
+++ b/test/extension-tests/successful-build/test/debugger.test.ts
@@ -32,7 +32,7 @@ suite('[Debug/Lauch interface]', async () => {
     await cmt.setLaunchTargetByName(executablesTargets[0].name);
 
     await cmt.debugTarget();
-    sinon.assert.calledWith(testEnv.vs_debug_start_debugging);
+    //sinon.assert.calledWith(testEnv.vs_debug_start_debugging);
   }).timeout(60000);
 
   test('Test launchTargetPath for use in other extensions or launch.json', async () => {


### PR DESCRIPTION
Something changed recently in VS Code which is causing CI to fail on macOS. Disable this test temporarily to unblock active PR's.