### PR TITLE
Workaround for MacOS lldb #965

### DIFF
--- a/src/debugger.ts
+++ b/src/debugger.ts
@@ -161,6 +161,10 @@ export async function getDebugConfigurationFromCache(cache: CMakeCache, target: 
     } else {
       // Look for lldb
       clang_debugger_path = compiler_path.replace(clang_compiler_regex, 'lldb');
+      if(clang_debugger_path == '/usr/bin/lldb' && platform == 'darwin') {
+        // Default Apple lldb in /usr/bin will definitely not work, try lldb-mi instead
+        clang_debugger_path = '/Applications/Xcode.app/Contents/Developer/usr/bin/lldb-mi';
+      }
       if ((clang_debugger_path.search(new RegExp('lldb')) != -1) && await checkDebugger(clang_debugger_path)) {
         return createLLDBDebugConfiguration(clang_debugger_path, target);
       }


### PR DESCRIPTION
<!-- Thanks for your contribution! To make things easier, please fill out the template below. -->

<!-- Delete the following heading if there is no corresponding issue -->
## This change addresses item #965

### This changes default fallback lldb search apth

The following changes are proposed:

- On MacOS, the system lldb is not a MI enabled debugger, and will always fail.
- Xcode dev tools always includes a working MI debugger at `/Applications/Xcode.app/Contents/Developer/usr/bin/lldb-mi`. 
- This change will address the issue when /usr/bin/clang is the selected compiler, and debugging without `launch.json` always fails when hitting Ctrl+f5

Also note, `/usr/bin/lldb` cannot be normally replaced by user, so it's always going to be Apple supplied binary there. There is no reason to try launching a debug session with it.
