### PR TITLE
proc.execute exceptions are not handled as expected

### DIFF
--- a/src/proc.ts
+++ b/src/proc.ts
@@ -165,7 +165,7 @@ export function execute(command: string,
 
     result = new Promise<ExecutionResult>(resolve => {
       if (child) {
-        child.on('error', err => { resolve({ retc: -1, stdout: "", stderr: err.message }) });
+        child.on('error', err => { resolve({ retc: -1, stdout: "", stderr: err.message }); });
         let stdout_acc = '';
         let line_acc = '';
         let stderr_acc = '';

--- a/src/proc.ts
+++ b/src/proc.ts
@@ -163,9 +163,9 @@ export function execute(command: string,
 
     const encoding = options.outputEncoding ? options.outputEncoding:'utf8';
 
-    result = new Promise<ExecutionResult>((resolve, reject) => {
+    result = new Promise<ExecutionResult>(resolve => {
       if (child) {
-        child.on('error', err => { reject(err); });
+        child.on('error', err => { resolve({ retc: -1, stdout: "", stderr: err.message }) });
         let stdout_acc = '';
         let line_acc = '';
         let stderr_acc = '';


### PR DESCRIPTION
<!-- Thanks for your contribution! To make things easier, please fill out the template below. -->

<!-- Please delete any unused sections. -->

<!-- Delete the following heading if there is no corresponding issue -->
## This change addresses item #977 

`proc.execute` was written with the expectation that it would return an error code for failures however, it returns a rejected promise in some cases which the codebase was not written to handle.