### PR TITLE
Don't fail if CMakeLists.txt was appended to sourceDirectory

### DIFF
--- a/src/drivers/driver.ts
+++ b/src/drivers/driver.ts
@@ -394,6 +394,10 @@ export abstract class CMakeDriver implements vscode.Disposable {
       log.debug('Run _refreshExpansions cb');
       const opts = this.expansionOptions;
       this._sourceDirectory = util.lightNormalizePath(await expand.expandString(this.config.sourceDirectory, opts));
+      if (path.basename(this._sourceDirectory).toLocaleLowerCase() === "cmakelists.txt") {
+        // Don't fail if CMakeLists.txt was accidentally appended to the sourceDirectory.
+        this._sourceDirectory = path.dirname(this._sourceDirectory);
+      }
       this._binaryDir = util.lightNormalizePath(await expand.expandString(this.config.buildDirectory, opts));
 
       const installPrefix = this.config.installPrefix;


### PR DESCRIPTION
<!-- Thanks for your contribution! To make things easier, please fill out the template below. -->

<!-- Please delete any unused sections. -->

<!-- Delete the following heading if there is no corresponding issue -->
## This change addresses item #1014

If CMakeLists.txt is added to the sourceDirectory setting, we will remove it.