### PR TITLE
Change the name of unspecified kit back to __unspec__

### DIFF
--- a/src/kit.ts
+++ b/src/kit.ts
@@ -28,7 +28,7 @@ const log = logging.createLogger('kit');
  */
 export enum SpecialKits {
   ScanForKits = '__scanforkits__',
-  Unspecified = '__unspecified__'
+  Unspecified = '__unspec__'
 }
 export type UnspecifiedKit = SpecialKits.Unspecified;
 


### PR DESCRIPTION
#1032 

The issue that kit name `__unspecified__` causes the extension think there's no active kit seems to be a side effect, but it doesn't really worth more exploration on this as we can't change the name anyway since this name is indirectly depended by other extensions (at least Azure Sphere) though command setKitByName.