### PR TITLE
Added command to hide launch and debug commands and debug button

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,5 +8,6 @@
     },
     "typescript.tsdk": "./node_modules/typescript/lib", // we want to use the TS server from our node_modules folder to control its version
     "files.trimTrailingWhitespace": true,
-    "clang-format.executable": "${workspaceFolder}/node_modules/.bin/clang-format"
+    "clang-format.executable": "${workspaceFolder}/node_modules/.bin/clang-format",
+    "editor.tabSize": 2
 }

--- a/package.json
+++ b/package.json
@@ -366,6 +366,14 @@
       {
         "command": "cmake.outline.revealInCMakeLists",
         "title": "%cmake-tools.command.cmake.outline.revealInCMakeLists.title%"
+      },
+      {
+        "command": "cmake.hideLaunchCommand",
+        "title": "%cmake-tools.command.cmake.hideLaunchCommand.title%"
+      },
+      {
+        "command": "cmake.hideDebugCommand",
+        "title": "%cmake-tools.command.cmake.hideDebugCommand.title%"
       }
     ],
     "menus": {
@@ -439,18 +447,20 @@
           "command": "cmake.editCache"
         },
         {
-          "command": "cmake.debugTarget"
+          "command": "cmake.debugTarget",
+          "when": "!cmake:hideDebugCommand"
         },
         {
           "command": "cmake.debugTargetAll",
-          "when": "cmake:multiRoot"
+          "when": "cmake:multiRoot && !cmake:hideDebugCommand"
         },
         {
-          "command": "cmake.launchTarget"
+          "command": "cmake.launchTarget",
+          "when": "!cmake:hideLaunchCommand"
         },
         {
           "command": "cmake.launchTargetAll",
-          "when": "cmake:multiRoot"
+          "when": "cmake:multiRoot && !cmake:hideLaunchCommand"
         },
         {
           "command": "cmake.selectLaunchTarget"
@@ -461,6 +471,14 @@
         {
           "command": "cmake.stopAll",
           "when": "cmake:multiRoot"
+        },
+        {
+          "command": "cmake.hideLaunchCommand",
+          "when": "never"
+        },
+        {
+          "command": "cmake.hideDebugCommand",
+          "when": "never"
         },
         {
           "command": "cmake.outline.configure",
@@ -1174,11 +1192,12 @@
       {
         "key": "ctrl+f5",
         "command": "cmake.debugTarget",
-        "when": "!inDebugMode && inCMakeProject"
+        "when": "!inDebugMode && inCMakeProject && !cmake:hideDebugCommand"
       },
       {
         "key": "shift+f5",
-        "command": "cmake.launchTarget"
+        "command": "cmake.launchTarget",
+        "when": "!cmake:hideDebugCommand"
       }
     ],
     "viewsContainers": {

--- a/package.json
+++ b/package.json
@@ -366,14 +366,6 @@
       {
         "command": "cmake.outline.revealInCMakeLists",
         "title": "%cmake-tools.command.cmake.outline.revealInCMakeLists.title%"
-      },
-      {
-        "command": "cmake.hideLaunchCommand",
-        "title": "%cmake-tools.command.cmake.hideLaunchCommand.title%"
-      },
-      {
-        "command": "cmake.hideDebugCommand",
-        "title": "%cmake-tools.command.cmake.hideDebugCommand.title%"
       }
     ],
     "menus": {
@@ -471,14 +463,6 @@
         {
           "command": "cmake.stopAll",
           "when": "cmake:multiRoot"
-        },
-        {
-          "command": "cmake.hideLaunchCommand",
-          "when": "never"
-        },
-        {
-          "command": "cmake.hideDebugCommand",
-          "when": "never"
         },
         {
           "command": "cmake.outline.configure",

--- a/package.nls.json
+++ b/package.nls.json
@@ -43,6 +43,8 @@
     "cmake-tools.command.cmake.outline.setDefaultTarget.title": "Set as Build Target",
     "cmake-tools.command.cmake.outline.setLaunchTarget.title": "Set as Launch/Debug Target",
     "cmake-tools.command.cmake.outline.revealInCMakeLists.title": "Open CMakeLists.txt",
+    "cmake-tools.command.cmake.hideLaunchCommand.title": "Hide launch command",
+    "cmake-tools.command.cmake.hideDebugCommand.title": "Hide debug command",
     "cmake-tools.command.cmake.folders.setActiveFolder.title": "Set Active Folder",
     "cmake-tools.configuration.title": "CMake Tools configuration",
     "cmake-tools.configuration.cmake.cmakePath.description": "Name/path of the CMake executable to use.",

--- a/package.nls.json
+++ b/package.nls.json
@@ -43,8 +43,6 @@
     "cmake-tools.command.cmake.outline.setDefaultTarget.title": "Set as Build Target",
     "cmake-tools.command.cmake.outline.setLaunchTarget.title": "Set as Launch/Debug Target",
     "cmake-tools.command.cmake.outline.revealInCMakeLists.title": "Open CMakeLists.txt",
-    "cmake-tools.command.cmake.hideLaunchCommand.title": "Hide launch command",
-    "cmake-tools.command.cmake.hideDebugCommand.title": "Hide debug command",
     "cmake-tools.command.cmake.folders.setActiveFolder.title": "Set Active Folder",
     "cmake-tools.configuration.title": "CMake Tools configuration",
     "cmake-tools.configuration.cmake.cmakePath.description": "Name/path of the CMake executable to use.",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -858,13 +858,13 @@ class ExtensionManager implements vscode.Disposable {
   async viewLog() { await logging.showLogFile(); }
 
   async hideLaunchCommand(shouldHide: boolean = true) {
-    // Don't hide command to launch/debug target here since the target can still be useful, one example is in launch.json
+    // Don't hide command to get/set launch/debug target here since the target can still be useful, one example is in launch.json
     this._statusBar.hideDebugButton(shouldHide);
     await util.setContextValue(HIDE_LAUNCH_COMMAND_KEY, shouldHide);
   }
 
   async hideDebugCommand(shouldHide: boolean = true) {
-    // Don't hide command to launch/debug target here since the target can still be useful, one example is in launch.json
+    // Don't hide command to get/set launch/debug target here since the target can still be useful, one example is in launch.json
     await util.setContextValue(HIDE_DEBUG_COMMAND_KEY, shouldHide);
   }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -39,6 +39,8 @@ const localize: nls.LocalizeFunc = nls.loadMessageBundle();
 const log = logging.createLogger('extension');
 
 const MULTI_ROOT_MODE_KEY = 'cmake:multiRoot';
+const HIDE_LAUNCH_COMMAND_KEY = 'cmake:hideLaunchCommand';
+const HIDE_DEBUG_COMMAND_KEY = 'cmake:hideDebugCommand';
 
 type CMakeToolsMapFn = (cmt: CMakeTools) => Thenable<any>;
 type CMakeToolsQueryMapFn = (cmt: CMakeTools) => Thenable<string | string[] | null>;
@@ -854,6 +856,17 @@ class ExtensionManager implements vscode.Disposable {
   resetState(folder?: vscode.WorkspaceFolder) { return this.mapCMakeToolsFolder(cmt => cmt.resetState(), folder); }
 
   async viewLog() { await logging.showLogFile(); }
+
+  async hideLaunchCommand(shouldHide: boolean = true) {
+    // Don't hide command to launch/debug target here since the target can still be useful, one example is in launch.json
+    this._statusBar.hideDebugButton(shouldHide);
+    await util.setContextValue(HIDE_LAUNCH_COMMAND_KEY, shouldHide);
+  }
+
+  async hideDebugCommand(shouldHide: boolean = true) {
+    // Don't hide command to launch/debug target here since the target can still be useful, one example is in launch.json
+    await util.setContextValue(HIDE_DEBUG_COMMAND_KEY, shouldHide);
+  }
 }
 
 /**
@@ -941,7 +954,9 @@ async function setup(context: vscode.ExtensionContext, progress: ProgressHandle)
     'resetState',
     'viewLog',
     'compileFile',
-    'tasksBuildCommand'
+    'tasksBuildCommand',
+    'hideLaunchCommand',
+    'hideDebugCommand'
     // 'toggleCoverageDecorations', // XXX: Should coverage decorations be revived?
   ];
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -858,13 +858,13 @@ class ExtensionManager implements vscode.Disposable {
   async viewLog() { await logging.showLogFile(); }
 
   async hideLaunchCommand(shouldHide: boolean = true) {
-    // Don't hide command to get/set launch/debug target here since the target can still be useful, one example is in launch.json
-    this._statusBar.hideDebugButton(shouldHide);
+    // Don't hide command selectLaunchTarget here since the target can still be useful, one example is ${command:cmake.luanchTargetPath} in launch.json
     await util.setContextValue(HIDE_LAUNCH_COMMAND_KEY, shouldHide);
   }
 
   async hideDebugCommand(shouldHide: boolean = true) {
-    // Don't hide command to get/set launch/debug target here since the target can still be useful, one example is in launch.json
+    // Don't hide command selectLaunchTarget here since the target can still be useful, one example is ${command:cmake.luanchTargetPath} in launch.json
+    this._statusBar.hideDebugButton(shouldHide);
     await util.setContextValue(HIDE_DEBUG_COMMAND_KEY, shouldHide);
   }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -858,12 +858,12 @@ class ExtensionManager implements vscode.Disposable {
   async viewLog() { await logging.showLogFile(); }
 
   async hideLaunchCommand(shouldHide: boolean = true) {
-    // Don't hide command selectLaunchTarget here since the target can still be useful, one example is ${command:cmake.luanchTargetPath} in launch.json
+    // Don't hide command selectLaunchTarget here since the target can still be useful, one example is ${command:cmake.launchTargetPath} in launch.json
     await util.setContextValue(HIDE_LAUNCH_COMMAND_KEY, shouldHide);
   }
 
   async hideDebugCommand(shouldHide: boolean = true) {
-    // Don't hide command selectLaunchTarget here since the target can still be useful, one example is ${command:cmake.luanchTargetPath} in launch.json
+    // Don't hide command selectLaunchTarget here since the target can still be useful, one example is ${command:cmake.launchTargetPath} in launch.json
     this._statusBar.hideDebugButton(shouldHide);
     await util.setContextValue(HIDE_DEBUG_COMMAND_KEY, shouldHide);
   }

--- a/src/status.ts
+++ b/src/status.ts
@@ -84,7 +84,7 @@ export class StatusBar implements vscode.Disposable {
       setVisible(item, this._visible && !!item.text);
     }
     setVisible(this._debugButton,
-               this._visible && vscode.extensions.getExtension('ms-vscode.cpptools') !== undefined
+               this._visible && !this._hideDebugButton && vscode.extensions.getExtension('ms-vscode.cpptools') !== undefined
                    && !!this._debugButton.text);
   }
 
@@ -249,5 +249,11 @@ export class StatusBar implements vscode.Disposable {
     this._warningMessage.text = `$(alert) ${msg}`;
     this._warningMessage.show();
     setTimeout(() => this._warningMessage.hide(), 5000);
+  }
+
+  private _hideDebugButton = false;
+  hideDebugButton(shouldHide: boolean = true) {
+    this._hideDebugButton = shouldHide;
+    this.reloadVisibility();
   }
 }


### PR DESCRIPTION
I don't really like this way, but didn't find a better one...

The reason to hide those commands is that the program may not be a desktop program. So commands to set/get launch/debug targets are not hidden since they could still be useful even if the program is not targeting desktop.
