### PR TITLE
Show "Collapse all" command on project outline view

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "native"
   ],
   "engines": {
-    "vscode": "^1.29.1"
+    "vscode": "^1.30.0"
   },
   "categories": [
     "Other"
@@ -1277,7 +1277,7 @@
     "tslint": "^5.9.1",
     "typedoc": "^0.15.3",
     "typescript": "^3.7.2",
-    "vscode": "^1.1.35",
+    "vscode": "^1.1.36",
     "vscode-nls-dev": "^3.2.6",
     "webpack": "^4.39.2",
     "webpack-cli": "^3.3.7"

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -201,8 +201,10 @@ class ExtensionManager implements vscode.Disposable {
    * The project outline tree data provider
    */
   private readonly _projectOutlineProvider = new ProjectOutlineProvider();
-  private readonly _projectOutlineDisposer
-      = vscode.window.registerTreeDataProvider('cmake.outline', this._projectOutlineProvider);
+  private readonly _projectOutlineTreeView = vscode.window.createTreeView('cmake.outline', {
+    treeDataProvider: this._projectOutlineProvider,
+    showCollapseAll: true
+  });
 
   /**
    * CppTools project configuration provider. Tells cpptools how to search for
@@ -293,7 +295,7 @@ class ExtensionManager implements vscode.Disposable {
     );
     this._onDidChangeActiveTextEditorSub.dispose();
     this._kitsWatcher.close();
-    this._projectOutlineDisposer.dispose();
+    this._projectOutlineTreeView.dispose();
     if (this._cppToolsAPI) {
       this._cppToolsAPI.dispose();
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5195,7 +5195,7 @@ vscode-test@^0.4.1:
     http-proxy-agent "^2.1.0"
     https-proxy-agent "^2.2.1"
 
-vscode@^1.1.35:
+vscode@^1.1.36:
   version "1.1.36"
   resolved "https://registry.yarnpkg.com/vscode/-/vscode-1.1.36.tgz#5e1a0d1bf4977d0c7bc5159a9a13d5b104d4b1b6"
   integrity sha512-cGFh9jmGLcTapCpPCKvn8aG/j9zVQ+0x5hzYJq5h5YyUXVGa1iamOaB2M2PZXoumQPES4qeAP1FwkI0b6tL4bQ==


### PR DESCRIPTION
## This change addresses item #839

### This change adds a feature

The following changes are proposed:

- Increase version of dependency `vscode` and `engines.vscode` to ^1.30.0 (needs to using new createTreeView API)
- Use `window.createTrewView` instead `window.registerTreeDataProvider` for additional option `showCollapseAll` (its API used in vscode for adding Collapse all action on tree views)

![image](https://user-images.githubusercontent.com/8371890/74334644-5dff9a00-4dab-11ea-8621-b82431f6d549.png)
