### PR TITLE
Restore user prompt to scan for kits

### DIFF
--- a/src/kit.ts
+++ b/src/kit.ts
@@ -30,6 +30,7 @@ export enum SpecialKits {
   ScanForKits = '__scanforkits__',
   Unspecified = '__unspec__'
 }
+export const SpecialKitsCount: number = 2;
 export type UnspecifiedKit = SpecialKits.Unspecified;
 
 type ProgressReporter = vscode.Progress<{message?: string}>;

--- a/src/kitsController.ts
+++ b/src/kitsController.ts
@@ -15,7 +15,8 @@ import {
   kitsPathForWorkspaceFolder,
   OLD_USER_KITS_FILEPATH,
   SpecialKits,
-  UnspecifiedKit
+  UnspecifiedKit,
+  SpecialKitsCount
 } from '@cmt/kit';
 import * as logging from '@cmt/logging';
 import paths from '@cmt/paths';
@@ -164,11 +165,11 @@ export class KitsController {
 
   private async _checkHaveKits(): Promise<UnspecifiedKit|'ok'|'cancel'> {
     const avail = this.availableKits;
-    if (avail.length > 1) {
+    if (avail.length > SpecialKitsCount) {
       // We have kits. Okay.
       return 'ok';
     }
-    if (avail[0].name !== SpecialKits.Unspecified) {
+    if (!avail.find(kit => kit.name == SpecialKits.Unspecified)) {
       // We should _always_ have the 'UnspecifiedKit'.
       rollbar.error(localize('invalid.only.kit', 'Invalid only kit. Expected to find `{0}`', SpecialKits.Unspecified));
       return 'ok';


### PR DESCRIPTION
When a new "special" kit was added, it broke the popup logic for the first run experience.  While new users are not necessarily blocked on this because the drop down appears with an option to scan for kits, the modal dialog ensures that the choice to scan for kits doesn't disappear in the event that the user clicks elsewhere.