### PR TITLE
Spanish translation is wrong. Update cmake-tools.i18n.json

### DIFF
--- a/i18n/esn/src/cmake-tools.i18n.json
+++ b/i18n/esn/src/cmake-tools.i18n.json
@@ -62,7 +62,7 @@
 	"run.build": "Compilando la carpeta: {0}",
 	"unable.to.configure": "Error de compilación: no se puede configurar el proyecto",
 	"driver.died.after.successful.configure": "El controlador de CMake finalizó de forma inmediata después de que la configuración se realizara correctamente.",
-	"building.status": "Edificio",
+	"building.status": "Compilando",
 	"building.target": "Compilando: {0}",
 	"stop.on.cancellation": "Detener al cancelar",
 	"starting.build": "Iniciando la compilación",


### PR DESCRIPTION
The spanish translation for 'building.status'  is wrong. 
<!-- Thanks for your contribution! To make things easier, please fill out the template below. -->

### This changes visible behavior

The following changes are proposed:

- update the i18n/esn/src/cmake-tools.i18n.json

## The purpose of this change

The spanish translation for 'building.status' in this context is absolutely wrong. 'Edificio' is a noun, and means house, or construction.. 
The correct translation is 'Compilando' as in building.target


