### PR TITLE
Fix problem #1067 - RUNTIME_OUTPUT_DIRECTORY

### DIFF
--- a/src/drivers/cmakefileapi/api_helpers.ts
+++ b/src/drivers/cmakefileapi/api_helpers.ts
@@ -127,7 +127,15 @@ async function convertTargetObjectFileToExtensionTarget(build_dir: string, file_
   if (targetObject.artifacts) {
     executable_path = targetObject.artifacts.find(artifact => artifact.path.endsWith(targetObject.nameOnDisk));
     if (executable_path) {
-      executable_path = path.normalize(path.join(build_dir, executable_path.path));
+      if (await fs.exists(executable_path.path)) {
+        executable_path = path.normalize(executable_path.path);
+      } else {
+        executable_path = path.normalize(path.join(build_dir, executable_path.path));
+        if (!fs.exists(executable_path)) {
+          // Will be empty after cmake configuration
+          executable_path = "";
+        }
+      }
     }
   }
 

--- a/test/unit-tests/driver/driver-codemodel-tests.ts
+++ b/test/unit-tests/driver/driver-codemodel-tests.ts
@@ -124,11 +124,11 @@ export function makeCodeModelDriverTestsuite(
     }).timeout(90000);
 
 
-    test('Test first executable target directory', async () => {
+    test('Test executable target information', async () => {
       const codemodel_data = await generateCodeModelForConfiguredDriver();
       expect(codemodel_data).to.be.not.null;
 
-      const target = codemodel_data!.configurations[0].projects[0].targets.find(t => t.type == 'EXECUTABLE');
+      const target = codemodel_data!.configurations[0].projects[0].targets.find(t => t.type == 'EXECUTABLE' && t.name == 'TestBuildProcess');
       expect(target).to.be.not.undefined;
 
       // Test target name used for node label

--- a/test/unit-tests/driver/driver-test.ts
+++ b/test/unit-tests/driver/driver-test.ts
@@ -127,9 +127,12 @@ export function makeDriverTestsuite(driver_generator: (cmake: CMakeExecutable,
       expect(await driver.cleanConfigure([])).to.be.eq(0);
       expect(await driver.build(driver.allTargetName)).to.be.eq(0);
 
-      expect(driver.executableTargets.length).to.be.eq(1);
+      expect(driver.executableTargets.length).to.be.eq(2);
       expect(driver.executableTargets[0].name).to.be.equal('TestBuildProcess');
       expect(fs.existsSync(driver.executableTargets[0].path)).to.be.true;
+
+      expect(driver.executableTargets[1].name).to.be.equal('TestBuildProcessOtherOutputDir');
+      expect(fs.existsSync(driver.executableTargets[1].path)).to.be.true;
     }).timeout(90000);
 
     test('Configure fails on invalid preferred generator', async () => {

--- a/test/unit-tests/driver/driver-test.ts
+++ b/test/unit-tests/driver/driver-test.ts
@@ -128,11 +128,13 @@ export function makeDriverTestsuite(driver_generator: (cmake: CMakeExecutable,
       expect(await driver.build(driver.allTargetName)).to.be.eq(0);
 
       expect(driver.executableTargets.length).to.be.eq(2);
-      expect(driver.executableTargets[0].name).to.be.equal('TestBuildProcess');
-      expect(fs.existsSync(driver.executableTargets[0].path)).to.be.true;
+      const targetInTopLevelBuildDir = driver.executableTargets.find(t => t.name == 'TestBuildProcess');
+      expect(targetInTopLevelBuildDir).to.not.undefined;
+      expect(fs.existsSync(targetInTopLevelBuildDir!.path)).to.be.true;
 
-      expect(driver.executableTargets[1].name).to.be.equal('TestBuildProcessOtherOutputDir');
-      expect(fs.existsSync(driver.executableTargets[1].path)).to.be.true;
+      const targetInRuntimeOutputDir = driver.executableTargets.find(t => t.name == 'TestBuildProcessOtherOutputDir');
+      expect(targetInRuntimeOutputDir).to.not.undefined;
+      expect(fs.existsSync(targetInRuntimeOutputDir!.path)).to.be.true;
     }).timeout(90000);
 
     test('Configure fails on invalid preferred generator', async () => {

--- a/test/unit-tests/driver/workspace/test_project/CMakeLists.txt
+++ b/test/unit-tests/driver/workspace/test_project/CMakeLists.txt
@@ -9,6 +9,21 @@ add_subdirectory(shared_lib_dummy)
 add_executable(TestBuildProcess main.cpp)
 set_property(TARGET TestBuildProcess PROPERTY CXX_STANDARD 98)
 
+add_executable(TestBuildProcessOtherOutputDir main.cpp)
+set_property(TARGET TestBuildProcessOtherOutputDir PROPERTY CXX_STANDARD 98)
+
+set_target_properties( TestBuildProcessOtherOutputDir
+    PROPERTIES
+    ARCHIVE_OUTPUT_DIRECTORY "${PROJECT_SOURCE_DIR}/lib"
+    LIBRARY_OUTPUT_DIRECTORY "${PROJECT_SOURCE_DIR}/lib"
+    RUNTIME_OUTPUT_DIRECTORY "${PROJECT_SOURCE_DIR}/bin"
+)
+target_compile_definitions(TestBuildProcessOtherOutputDir PRIVATE
+    "CMT_COOKIE=\"${CMT_COOKIE}\""
+    "C_COMPILER_ID=\"${CMAKE_C_COMPILER_ID}\""
+)
+target_link_libraries(TestBuildProcessOtherOutputDir StaticLibDummy)
+
 add_custom_command(
     TARGET TestBuildProcess
     POST_BUILD
@@ -16,6 +31,7 @@ add_custom_command(
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
     COMMENT "Running in ${CMAKE_CURRENT_BINARY_DIR}"
 )
+
 
 set(extraArgsEnvironment "${EXTRA_ARGS_TEST}" CACHE STRING "environment")
 set(configureEnvironment "$ENV{_CONFIGURE_ENV}" CACHE STRING "configureEnvironment")


### PR DESCRIPTION
## This change addresses item #1067

The artifact paths could be relative or absolute. The path type depends on the RUNTIME_OUTPUT_DIRECTORY.

