### PR TITLE
Toolset and Platform are swapped when reading from cmake cache

### DIFF
--- a/src/drivers/cmfileapi-driver.ts
+++ b/src/drivers/cmfileapi-driver.ts
@@ -65,13 +65,13 @@ export class CMakeFileApiDriver extends codemodel.CodeModelDriver {
 
     this._generator = {
       name: cache.get('CMAKE_GENERATOR')!.value,
-      toolset: cache.get('CMAKE_GENERATOR_PLATFORM') ? cache.get('CMAKE_GENERATOR_PLATFORM')!.value : undefined,
-      platform: cache.get('CMAKE_GENERATOR_TOOLSET') ? cache.get('CMAKE_GENERATOR_TOOLSET')!.value : undefined
+      platform: cache.get('CMAKE_GENERATOR_PLATFORM') ? cache.get('CMAKE_GENERATOR_PLATFORM')!.value : undefined,
+      toolset: cache.get('CMAKE_GENERATOR_TOOLSET') ? cache.get('CMAKE_GENERATOR_TOOLSET')!.value : undefined
     } as CMakeGenerator;
 
     this._generatorInformation = {
       name: cache.get('CMAKE_GENERATOR')!.value,
-      platform: cache.get('CMAKE_GENERATOR_TOOLSET') ? cache.get('CMAKE_GENERATOR_TOOLSET')!.value : undefined
+      platform: cache.get('CMAKE_GENERATOR_PLATFORM') ? cache.get('CMAKE_GENERATOR_PLATFORM')!.value : undefined
     };
   }
 


### PR DESCRIPTION
<!-- Thanks for your contribution! To make things easier, please fill out the template below. -->

<!-- Please delete any unused sections. -->

<!-- Delete the following heading if there is no corresponding issue -->
## This change addresses item #1065

This addresses a regression in functionality when reading information from the CMake cache.