### PR TITLE
Don't guess the debugger if it is already provided

### DIFF
--- a/src/cmake-tools.ts
+++ b/src/cmake-tools.ts
@@ -1195,7 +1195,7 @@ export class CMakeTools implements vscode.Disposable, api.CMakeToolsAPI {
     let debug_config;
     try {
       const cache = await CMakeCache.fromPath(drv.cachePath);
-      debug_config = await debugger_mod.getDebugConfigurationFromCache(cache, targetExecutable, process.platform);
+      debug_config = await debugger_mod.getDebugConfigurationFromCache(cache, targetExecutable, process.platform, this.workspaceContext.config.debugConfig?.miDebuggerPath);
       log.debug(localize('debug.configuration.from.cache', 'Debug configuration from cache: {0}', JSON.stringify(debug_config)));
     } catch (error) {
       vscode.window


### PR DESCRIPTION
### This potentially addresses #1060 

### This changes visible behavior

The extension currently tries to guess your debugger path by swapping known compiler names with known debugger names.  If this fails, you may be unable to debug.

There is, however, a way to set your own debugger path.  If you explicitly set `cmake.debugConfig` and have the `miDebuggerPath` property set, the extension will use that instead of the guessed path.  However, the extension doesn't currently allow you to override the path unless the guessed debugger path is valid.  This change removes the inadvertent dependency on the guesswork if you are manually specifying a debugger.