### PR TITLE
Add support for Objective-C and Objective-C++ languages

### DIFF
--- a/src/cpptools.ts
+++ b/src/cpptools.ts
@@ -94,14 +94,14 @@ export function parseCompileFlags(args: string[], lang?: string): CompileFlagInf
       extraDefinitions.push(def);
     } else if (value.startsWith('-std=') || lower.startsWith('-std:') || lower.startsWith('/std:')) {
       const std = value.substring(5);
-      if (lang === 'CXX') {
+      if (lang === 'CXX' || lang === 'OBJCXX' ) {
         const s = parseCppStandard(std);
         if (s === null) {
           log.warning(localize('unknown.control.gflag.cpp', 'Unknown C++ standard control flag: {0}', value));
         } else {
           standard = s;
         }
-      } else if (lang === 'C') {
+      } else if (lang === 'C' || lang === 'OBJC' ) {
         const s = parseCStandard(std);
         if (s === null) {
           log.warning(localize('unknown.control.gflag.c', 'Unknown C standard control flag: {0}', value));


### PR DESCRIPTION
## This change addresses item #1108

### This changes visible behavior of logging

The following changes are proposed:

- Add OBJC and OBJCXX as recognized languages in vscode-cmake-tools cpptools parser
