### PR TITLE
Update cpptools.ts

### DIFF
--- a/src/cpptools.ts
+++ b/src/cpptools.ts
@@ -181,7 +181,7 @@ export class CppConfigurationProvider implements cpt.CustomConfigurationProvider
   /** Our name visible to cpptools */
   readonly name = 'CMake Tools';
   /** Our extension ID, visible to cpptools */
-  readonly extensionId = 'vector-of-bool.cmake-tools';
+  readonly extensionId = 'ms-vscode.cmake-tools';
   /**
    * This value determines if we need to show the user an error message about missing compilers. When an update succeeds
    * without missing any compilers, we set this to `true`, otherwise `false`.


### PR DESCRIPTION
change old extensionId to new

I had problem, that .vscode/settings.json was created with "C_Cpp.default.configurationProvider": "vector-of-bool.cmake-tools", changing this to ms-vscode.cmake-tools fixed Intellisense for me.

I took a look at the source and I *think*, this is the relevant part, but since I didn't want to dive in extension development, maybe someone can confirm, if this is the right place...