### PR TITLE
clear the terminal for compile active file

### DIFF
--- a/src/drivers/driver.ts
+++ b/src/drivers/driver.ts
@@ -269,8 +269,13 @@ export abstract class CMakeDriver implements vscode.Disposable {
       const env = this.getEffectiveSubprocessEnvironment();
       const key = `${cmd.directory}${JSON.stringify(env)}`;
       let existing = this._compileTerms.get(key);
-      const shellPath = process.platform === 'win32' ? 'cmd.exe' : undefined;
+      if (existing && this.config.clearOutputBeforeBuild) {
+        this._compileTerms.delete(key);
+        existing.dispose();
+        existing = undefined;
+      }
       if (!existing) {
+        const shellPath = process.platform === 'win32' ? 'cmd.exe' : undefined;
         const term = vscode.window.createTerminal({
           name: localize('file.compilation', 'File Compilation'),
           cwd: cmd.directory,


### PR DESCRIPTION
<!-- Thanks for your contribution! To make things easier, please fill out the template below. -->

<!-- Please delete any unused sections. -->

<!-- Delete the following heading if there is no corresponding issue -->
## This change addresses item #1122

### This changes visible behavior

The following changes are proposed:
When building, dispose the terminal created by the compileFile command if the clearOutputBeforeBuild setting is set.

