### PR TITLE
Support source files outside the base path

### DIFF
--- a/src/drivers/cmakefileapi/api_helpers.ts
+++ b/src/drivers/cmakefileapi/api_helpers.ts
@@ -170,7 +170,9 @@ export async function loadConfigurationTargetMap(reply_path: string, codeModel_f
 }
 
 function convertToAbsolutePath(input_path: string, base_path: string) {
-  return path.normalize(path.join(base_path, input_path));
+  // Prepend the base path to the input path if the input path is relative.
+  const absolute_path = path.isAbsolute(input_path) ? input_path : path.join(base_path, input_path);
+  return path.normalize(absolute_path);
 }
 
 function convertToExtCodeModelFileGroup(targetObject: index_api.CodeModelKind.TargetObject): CodeModelFileGroup[] {


### PR DESCRIPTION
<!-- Thanks for your contribution! To make things easier, please fill out the template below. -->

<!-- Please delete any unused sections. -->

<!-- Delete the following heading if there is no corresponding issue -->
## This change addresses item #1140 

Incorrect paths were being constructed for source files located outside of the base path.  This fix detects when absolute paths are created by the file api and doesn't attempt to concatenate them with the base path.