### PR TITLE
Fix a crash related to the cmake.buildDirectory command

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -233,10 +233,11 @@ class ExtensionManager implements vscode.Disposable {
       // Expected schema is file...
       return vscode.workspace.getWorkspaceFolder(vscode.Uri.file(folder as string));
     }
-    if ((folder as vscode.WorkspaceFolder).uri) {
-      return folder;
+    const workspaceFolder = folder as vscode.WorkspaceFolder;
+    if (util.isNullOrUndefined(folder) || util.isNullOrUndefined(workspaceFolder.uri)) {
+      return this._folders.activeFolder?.folder;
     }
-    return this._folders.activeFolder?.folder;
+    return workspaceFolder;
   }
 
   private async _pickFolder() {

--- a/src/util.ts
+++ b/src/util.ts
@@ -563,3 +563,9 @@ export function chokidarOnAnyChange(watcher: chokidar.FSWatcher, listener: (path
 export function isString(x: any): x is string {
   return Object.prototype.toString.call(x) === "[object String]";
 }
+
+export function isNullOrUndefined(x?: any): boolean {
+  // Double equals provides the correct answer for 'null' and 'undefined'
+  // http://www.ecma-international.org/ecma-262/6.0/index.html#sec-abstract-equality-comparison
+  return x == null;
+}


### PR DESCRIPTION
<!-- Thanks for your contribution! To make things easier, please fill out the template below. -->

<!-- Please delete any unused sections. -->

<!-- Delete the following heading if there is no corresponding issue -->
## This change addresses item #1150

The `cmake.buildDirectory` command is supposed to support being called without a parameter (defaulting to the active folder).  There was a bug preventing this.