### PR TITLE
Added error messages on some configure failures

### DIFF
--- a/src/drivers/driver.ts
+++ b/src/drivers/driver.ts
@@ -676,6 +676,7 @@ export abstract class CMakeDriver implements vscode.Disposable {
 
       return retc;
     } catch {
+      log.info(localize('configure.failed', 'Failed to configure project'));
       return -1;
     } finally { this.configRunning = false; }
   }


### PR DESCRIPTION
Added error message for invalid path case.

Before this change, there was no error message at all.

Now it looks like:
```
[rollbar] Unhandled exception: Failed writing to file somepath\query.json Error: ENOENT: no such file or directory, mkdir 'somepath' {}
[driver] Failed to configure project
```
