### PR TITLE
Disable launchTarget keybinding while debugging

### DIFF
--- a/package.json
+++ b/package.json
@@ -1181,7 +1181,7 @@
       {
         "key": "shift+f5",
         "command": "cmake.launchTarget",
-        "when": "!cmake:hideDebugCommand"
+        "when": "!inDebugMode && !cmake:hideDebugCommand"
       }
     ],
     "viewsContainers": {


### PR DESCRIPTION
## This change addresses item #1170

### This changes a keybinding

The following changes are proposed:
Disable SHIFT+F5 as a keybinding for "Launch Target Without Debugging" while the debugger is active.  VS Code uses that keybinding to stop debugging and it conflicts with ours.
