### PR TITLE
Fix for Github issue 741: Add context menu for CMakeLists

### DIFF
--- a/package.json
+++ b/package.json
@@ -620,8 +620,33 @@
         },
         {
           "command": "cmake.outline.configureAll",
-          "when": "view == cmake.outline && viewItem =~ /nodeType=target/",
-          "group": "3_targetActions@1"
+          "when": "view == cmake.outline && viewItem =~ /nodeType=file/ && viewItem =~ /cmakelists=true/",
+          "group": "1_fileActions@1"
+        },
+        {
+          "command": "cmake.outline.buildAll",
+          "when": "view == cmake.outline && viewItem =~ /nodeType=file/ && viewItem =~ /cmakelists=true/",
+          "group": "1_fileActions@2"
+        },
+        {
+          "command": "cmake.outline.cleanAll",
+          "when": "view == cmake.outline && viewItem =~ /nodeType=file/ && viewItem =~ /cmakelists=true/",
+          "group": "1_fileActions@3"
+        },
+        {
+          "command": "cmake.outline.cleanConfigureAll",
+          "when": "view == cmake.outline && viewItem =~ /nodeType=file/ && viewItem =~ /cmakelists=true/",
+          "group": "1_fileActions@4"
+        },
+        {
+          "command": "cmake.outline.cleanRebuildAll",
+          "when": "view == cmake.outline && viewItem =~ /nodeType=file/ && viewItem =~ /cmakelists=true/",
+          "group": "1_fileActions@5"
+        },
+        {
+          "command": "cmake.outline.compileFile",
+          "when": "view == cmake.outline && viewItem =~ /nodeType=file/ && viewItem =~ /compilable=true/",
+          "group": "1_fileActions@6"
         },
         {
           "command": "cmake.outline.compileFile",
@@ -664,6 +689,26 @@
         {
           "command": "cmake.compileFile",
           "when": "resourceLangId == c"
+        },
+        {
+          "command": "cmake.outline.configureAll",
+          "when": "resourceFilename == CMakeLists.txt"
+        },
+        {
+          "command": "cmake.outline.buildAll",
+          "when": "resourceFilename == CMakeLists.txt"
+        },
+        {
+          "command": "cmake.outline.cleanAll",
+          "when": "resourceFilename == CMakeLists.txt"
+        },
+        {
+          "command": "cmake.outline.cleanConfigureAll",
+          "when": "resourceFilename == CMakeLists.txt"
+        },
+        {
+          "command": "cmake.outline.cleanRebuildAll",
+          "when": "resourceFilename == CMakeLists.txt"
         }
       ]
     },

--- a/package.json
+++ b/package.json
@@ -625,7 +625,12 @@
         },
         {
           "command": "cmake.outline.compileFile",
-          "when": "view == cmake.outline && viewItem =~ /nodeType=file/",
+          "when": "view == cmake.outline && viewItem =~ /nodeType=file/ && viewItem =~ /compilable=true/",
+          "group": "inline"
+        },
+        {
+          "command": "cmake.outline.configureAll",
+          "when": "view == cmake.outline && viewItem =~ /nodeType=file/ && viewItem =~ /cmakelists=true/",
           "group": "inline"
         }
       ],

--- a/package.json
+++ b/package.json
@@ -619,6 +619,11 @@
           "group": "2_targetState@2"
         },
         {
+          "command": "cmake.outline.configureAll",
+          "when": "view == cmake.outline && viewItem =~ /nodeType=target/",
+          "group": "3_targetActions@1"
+        },
+        {
           "command": "cmake.outline.compileFile",
           "when": "view == cmake.outline && viewItem =~ /nodeType=file/",
           "group": "inline"

--- a/src/tree.ts
+++ b/src/tree.ts
@@ -225,7 +225,10 @@ export class SourceFileNode extends BaseNode {
     const item = new vscode.TreeItem(path.basename(this.filePath));
     item.id = this.id;
     item.resourceUri = vscode.Uri.file(this.filePath);
-    item.contextValue = 'nodeType=file';
+    const name = this.name.toLowerCase();
+    const cml = name == "cmakelists.txt";
+    const compilable = name.search(/\.c/)!==-1;
+    item.contextValue = ['nodeType=file', `compilable=${compilable}`, `cmakelists=${cml}`].join(',');
     item.command = {
       title: localize('open.file', 'Open file'),
       command: 'vscode.open',


### PR DESCRIPTION
## Changes
- Added context menu entries for CMakeLists.txt in Explorer and CMake project outline.
- Added context menu entries for source files in CMake project outline.
- Removed context menu for all other file types (they all had "compile file", which resulted usually in compiler errors)
- Compile file only works if filename contains .c (e.g. .c, .cpp, .cxx)
- Added configure all projects to CMakeLists.txt files as icon in CMake project outline.

This should resolve #741