### PR TITLE
Support ARM IntelliSenseModes and GNU language standards for cpptools

### DIFF
--- a/package.json
+++ b/package.json
@@ -1359,7 +1359,7 @@
     "open": "^6.4.0",
     "rimraf": "^2.5.4",
     "tmp": "^0.0.33",
-    "vscode-cpptools": "^3.0.1",
+    "vscode-cpptools": "^4.0.1",
     "vscode-extension-telemetry": "^0.1.2",
     "vscode-nls": "^4.1.1",
     "which": "~1.3.0",

--- a/src/cpptools.ts
+++ b/src/cpptools.ts
@@ -42,7 +42,7 @@ interface TargetDefaults {
 }
 
 function parseCppStandard(std: string): StandardVersion|null {
-  let is_gnu = std.startsWith('gnu');
+  const is_gnu = std.startsWith('gnu');
   if (std.endsWith('++2a') || std.endsWith('++20') || std.endsWith('++latest')) {
     return is_gnu ? 'gnu++20' : 'c++20';
   } else if (std.endsWith('++17') || std.endsWith('++1z')) {
@@ -62,7 +62,7 @@ function parseCppStandard(std: string): StandardVersion|null {
 
 function parseCStandard(std: string): StandardVersion|null {
   // GNU options from: https://gcc.gnu.org/onlinedocs/gcc/C-Dialect-Options.html#C-Dialect-Options
-  let is_gnu = std.startsWith('gnu');
+  const is_gnu = std.startsWith('gnu');
   if (/(c|gnu)(90|89|iso9899:(1990|199409))/.test(std)) {
     return is_gnu ? 'gnu89' : 'c89';
   } else if (/(c|gnu)(99|9x|iso9899:(1999|199x))/.test(std)) {
@@ -78,7 +78,7 @@ function parseCStandard(std: string): StandardVersion|null {
 
 function parseTargetArch(target: string): Architecture {
 // ARM options from https://en.wikipedia.org/wiki/ARM_architecture#Cores
-  let is_arm_32: (value: string) => boolean = (value) => {
+  const is_arm_32: (value: string) => boolean = (value) => {
     if (value.indexOf('armv8-r') >=0 || value.indexOf('armv8-m') >=0) {
       return true;
     } else {

--- a/src/cpptools.ts
+++ b/src/cpptools.ts
@@ -112,10 +112,10 @@ function parseTargetArch(target: string): Architecture {
 }
 
 export function parseCompileFlags(cptVersion: cpt.Version, args: string[], lang?: string): CompileFlagInformation {
+  const can_use_gnu_std = (cptVersion >= cpt.Version.v4);
   const iter = args[Symbol.iterator]();
   const extraDefinitions: string[] = [];
   let standard: StandardVersion = (lang === 'C') ? 'c11' : 'c++17';
-  const can_use_gnu_std = (cptVersion >= cpt.Version.v4);
   let targetArch: Architecture = undefined;
   while (1) {
     const {done, value} = iter.next();
@@ -200,14 +200,15 @@ export function parseCompileFlags(cptVersion: cpt.Version, args: string[], lang?
  * and target architecture parsed from compiler flags.
  */
 export function getIntelliSenseMode(cptVersion: cpt.Version, compiler_path: string, target_arch: Architecture) {
+  const can_use_arm = (cptVersion >= cpt.Version.v4);
   const compiler_name = path.basename(compiler_path || "").toLocaleLowerCase();
   if (compiler_name === 'cl.exe') {
     const clArch = path.basename(path.dirname(compiler_path));
     switch (clArch) {
       case 'arm64':
-        return (cptVersion >= cpt.Version.v4) ? 'msvc-arm64' : 'msvc-x64';
+        return can_use_arm ? 'msvc-arm64' : 'msvc-x64';
       case 'arm':
-        return (cptVersion >= cpt.Version.v4) ? 'msvc-arm' : 'msvc-x86';
+        return can_use_arm ? 'msvc-arm' : 'msvc-x86';
       case 'x86':
         return 'msvc-x86';
       case 'x64':
@@ -217,17 +218,17 @@ export function getIntelliSenseMode(cptVersion: cpt.Version, compiler_path: stri
   } else if (compiler_name.indexOf('armclang') >= 0) {
     switch (target_arch) {
       case 'arm64':
-        return (cptVersion >= cpt.Version.v4) ? 'clang-arm64' : 'clang-x64';
+        return can_use_arm ? 'clang-arm64' : 'clang-x64';
       case 'arm':
       default:
-        return (cptVersion >= cpt.Version.v4) ? 'clang-arm' : 'clang-x86';
+        return can_use_arm ? 'clang-arm' : 'clang-x86';
     }
   } else if (compiler_name.indexOf('clang') >= 0) {
     switch (target_arch) {
       case 'arm64':
-        return (cptVersion >= cpt.Version.v4) ? 'clang-arm64' : 'clang-x64';
+        return can_use_arm ? 'clang-arm64' : 'clang-x64';
       case 'arm':
-        return (cptVersion >= cpt.Version.v4) ? 'clang-arm' : 'clang-x86';
+        return can_use_arm ? 'clang-arm' : 'clang-x86';
       case 'x86':
         return 'clang-x86';
       case 'x64':
@@ -237,9 +238,9 @@ export function getIntelliSenseMode(cptVersion: cpt.Version, compiler_path: stri
   }  else if (compiler_name.indexOf('aarch64') >= 0) {
     // Compiler with 'aarch64' in its name may also have 'arm', so check for
     // aarch64 compilers before checking for ARM specific compilers.
-    return (cptVersion >= cpt.Version.v4) ? 'gcc-arm64' : 'gcc-x64';
+    return can_use_arm ? 'gcc-arm64' : 'gcc-x64';
   } else if (compiler_name.indexOf('arm') >= 0) {
-    return (cptVersion >= cpt.Version.v4) ? 'gcc-arm' : 'gcc-x86';
+    return can_use_arm ? 'gcc-arm' : 'gcc-x86';
   } else if (compiler_name.indexOf('gcc') >= 0 || compiler_name.indexOf('g++') >= 0) {
     switch (target_arch) {
       case 'x86':

--- a/src/cpptools.ts
+++ b/src/cpptools.ts
@@ -82,6 +82,7 @@ function parseCStandard(std: string, can_use_gnu: boolean): StandardVersion|null
 }
 
 function parseTargetArch(target: string): Architecture {
+  // Value of target param is lowercased.
   const is_arm_32: (value: string) => boolean = value => {
     // ARM verions from https://en.wikipedia.org/wiki/ARM_architecture#Cores
     if (value.indexOf('armv8-r') >=0 || value.indexOf('armv8-m') >=0) {
@@ -102,6 +103,7 @@ function parseTargetArch(target: string): Architecture {
     case 'x86_64':
       return 'x64';
   }
+  // Check triple target value
   if (target.indexOf('aarch64') >= 0 || target.indexOf('armv8-a') >= 0 || target.indexOf('armv8.') >= 0) {
     return 'arm64';
   } else if (target.indexOf('arm') >= 0 || is_arm_32(target)) {
@@ -400,7 +402,7 @@ export class CppConfigurationProvider implements cpt.CustomConfigurationProvider
     }
     const normalizedCompilerPath = util.platformNormalizePath(comp_path);
     const flags = fileGroup.compileFlags ? [...shlex.split(fileGroup.compileFlags)] : target.compileFlags;
-    const {standard, extraDefinitions, targetArch} = parseCompileFlags(this._cpptoolsVersion, flags, lang);
+    const {standard, extraDefinitions, targetArch} = parseCompileFlags(this.cpptoolsVersion, flags, lang);
     const defines = (fileGroup.defines || target.defines).concat(extraDefinitions);
     const includePath = fileGroup.includePath ? fileGroup.includePath.map(p => p.path) : target.includePath;
 
@@ -434,7 +436,7 @@ export class CppConfigurationProvider implements cpt.CustomConfigurationProvider
       defines,
       standard,
       includePath: normalizedIncludePath,
-      intelliSenseMode: getIntelliSenseMode(this._cpptoolsVersion, comp_path, targetArch),
+      intelliSenseMode: getIntelliSenseMode(this.cpptoolsVersion, comp_path, targetArch),
       compilerPath: normalizedCompilerPath || undefined,
       compilerArgs: flags || undefined
     };
@@ -479,12 +481,18 @@ export class CppConfigurationProvider implements cpt.CustomConfigurationProvider
     }
   }
 
-  /**
-   * Saves the version of Cpptools API.
-   * @param version
+    /**
+   * Gets the version of Cpptools API.
    */
-  saveCppToolsVersion(version: cpt.Version) {
-    this._cpptoolsVersion = version;
+  get cpptoolsVersion(): cpt.Version {
+    return this._cpptoolsVersion;
+  }
+  /**
+   * Set the version of Cpptools API.
+   * @param value of CppTools API version
+   */
+  set cpptoolsVersion(value: cpt.Version) {
+    this._cpptoolsVersion = value;
   }
 
   /**

--- a/src/cpptools.ts
+++ b/src/cpptools.ts
@@ -82,8 +82,8 @@ function parseCStandard(std: string, can_use_gnu: boolean): StandardVersion|null
 }
 
 function parseTargetArch(target: string): Architecture {
-// ARM options from https://en.wikipedia.org/wiki/ARM_architecture#Cores
   const is_arm_32: (value: string) => boolean = value => {
+    // ARM verions from https://en.wikipedia.org/wiki/ARM_architecture#Cores
     if (value.indexOf('armv8-r') >=0 || value.indexOf('armv8-m') >=0) {
       return true;
     } else {

--- a/src/cpptools.ts
+++ b/src/cpptools.ts
@@ -70,7 +70,12 @@ function parseCStandard(std: string, can_use_gnu: boolean): StandardVersion|null
   } else if (/(c|gnu)(11|1x|iso9899:2011)/.test(std)) {
     return is_gnu ? 'gnu11' : 'c11';
   } else if (/(c|gnu)(17|18|iso9899:(2017|2018))/.test(std)) {
-    return is_gnu ? 'gnu18' : 'c18';
+    if (can_use_gnu) {
+      // cpptools supports 'c18' in same version it supports GNU std.
+      return is_gnu ? 'gnu18' : 'c18';
+    } else {
+      return 'c11';
+    }
   } else {
     return null;
   }

--- a/src/cpptools.ts
+++ b/src/cpptools.ts
@@ -78,7 +78,7 @@ function parseCStandard(std: string): StandardVersion|null {
 
 function parseTargetArch(target: string): Architecture {
 // ARM options from https://en.wikipedia.org/wiki/ARM_architecture#Cores
-  const is_arm_32: (value: string) => boolean = (value) => {
+  const is_arm_32: (value: string) => boolean = value => {
     if (value.indexOf('armv8-r') >=0 || value.indexOf('armv8-m') >=0) {
       return true;
     } else {
@@ -87,7 +87,7 @@ function parseTargetArch(target: string): Architecture {
       const verNum = +verStr;
       return verNum <= 7;
     }
-  }
+  };
   switch(target) {
     case '-m32':
     case 'i686':

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -470,7 +470,7 @@ class ExtensionManager implements vscode.Disposable {
     );
     rollbar.invokeAsync(localize('update.code.model.for.cpptools', 'Update code model for cpptools'), {}, async () => {
       if (!this._cppToolsAPI) {
-        this._cppToolsAPI = await cpt.getCppToolsApi(cpt.Version.v3);
+        this._cppToolsAPI = await cpt.getCppToolsApi(cpt.Version.v4);
       }
       if (this._cppToolsAPI && cmt.codeModel && cmt.activeKit) {
         const codeModel = cmt.codeModel;
@@ -487,6 +487,7 @@ class ExtensionManager implements vscode.Disposable {
         const opts = drv ? drv.expansionOptions : undefined;
         const env = await effectiveKitEnvironment(kit, opts);
         const clCompilerPath = await findCLCompilerPath(env);
+        this._configProvider.saveCppToolsVersion(cpptools.getVersion());
         this._configProvider.updateConfigurationData({cache, codeModel, clCompilerPath, activeTarget: cmt.defaultBuildTarget, folder: cmt.folder.uri.fsPath});
         await this.ensureCppToolsProviderRegistered();
         if (cpptools.notifyReady && this.cpptoolsNumFoldersReady < this._folders.size) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -487,7 +487,7 @@ class ExtensionManager implements vscode.Disposable {
         const opts = drv ? drv.expansionOptions : undefined;
         const env = await effectiveKitEnvironment(kit, opts);
         const clCompilerPath = await findCLCompilerPath(env);
-        this._configProvider.saveCppToolsVersion(cpptools.getVersion());
+        this._configProvider.cpptoolsVersion = cpptools.getVersion();
         this._configProvider.updateConfigurationData({cache, codeModel, clCompilerPath, activeTarget: cmt.defaultBuildTarget, folder: cmt.folder.uri.fsPath});
         await this.ensureCppToolsProviderRegistered();
         if (cpptools.notifyReady && this.cpptoolsNumFoldersReady < this._folders.size) {

--- a/test/unit-tests/cpptools.test.ts
+++ b/test/unit-tests/cpptools.test.ts
@@ -4,6 +4,7 @@ import { CMakeCache } from '@cmt/cache';
 import * as path from 'path';
 import * as codemodel_api from '@cmt/drivers/codemodel-driver-interface';
 import * as vscode from 'vscode';
+import { Version } from 'vscode-cpptools';
 import * as util from '@cmt/util';
 
 // tslint:disable:no-unused-expression
@@ -16,67 +17,69 @@ function getTestResourceFilePath(filename: string): string {
 suite('CppTools tests', () => {
   test('Parse some compiler flags', () => {
     // Parse definition
-    let info = parseCompileFlags(['-DFOO=BAR']);
+    const cpptoolsVersion = Version.v4;
+    let info = parseCompileFlags(cpptoolsVersion, ['-DFOO=BAR']);
     expect(info.extraDefinitions).to.eql(['FOO=BAR']);
-    info = parseCompileFlags(['-D', 'FOO=BAR']);
+    info = parseCompileFlags(cpptoolsVersion, ['-D', 'FOO=BAR']);
     expect(info.extraDefinitions).to.eql(['FOO=BAR']);
-    info = parseCompileFlags(['-DFOO=BAR', '/D', 'BAZ=QUX']);
+    info = parseCompileFlags(cpptoolsVersion, ['-DFOO=BAR', '/D', 'BAZ=QUX']);
     expect(info.extraDefinitions).to.eql(['FOO=BAR', 'BAZ=QUX']);
     expect(info.standard).to.eql('c++17');
     // Parse language standard
-    info = parseCompileFlags(['-std=c++03']);
+    info = parseCompileFlags(cpptoolsVersion, ['-std=c++03']);
     expect(info.standard).to.eql('c++03');
-    info = parseCompileFlags(['-std=gnu++14']);
+    info = parseCompileFlags(cpptoolsVersion, ['-std=gnu++14']);
     expect(info.standard).to.eql('gnu++14');
     // Parse target architecture
-    info = parseCompileFlags(['--target=aarch64-arm-none-eabi']);
+    info = parseCompileFlags(cpptoolsVersion, ['--target=aarch64-arm-none-eabi']);
     expect(info.targetArch).to.eql('arm64');
-    info = parseCompileFlags(['-target', 'arm-arm-none-eabi']);
+    info = parseCompileFlags(cpptoolsVersion, ['-target', 'arm-arm-none-eabi']);
     expect(info.targetArch).to.eql('arm');
-    info = parseCompileFlags(['-arch=x86_64']);
+    info = parseCompileFlags(cpptoolsVersion, ['-arch=x86_64']);
     expect(info.targetArch).to.eql('x64');
-    info = parseCompileFlags(['-arch', 'aarch64']);
+    info = parseCompileFlags(cpptoolsVersion, ['-arch', 'aarch64']);
     expect(info.targetArch).to.eql('arm64');
-    info = parseCompileFlags(['-arch', 'i686']);
+    info = parseCompileFlags(cpptoolsVersion, ['-arch', 'i686']);
     expect(info.targetArch).to.eql('x86');
-    info = parseCompileFlags(['/arch:x86_64']);
+    info = parseCompileFlags(cpptoolsVersion, ['/arch:x86_64']);
     expect(info.targetArch).to.eql('x64');
-    info = parseCompileFlags(['-march=amd64']);
+    info = parseCompileFlags(cpptoolsVersion, ['-march=amd64']);
     expect(info.targetArch).to.eql('x64');
-    info = parseCompileFlags(['-m32']);
+    info = parseCompileFlags(cpptoolsVersion, ['-m32']);
     expect(info.targetArch).to.eql('x86');
-    info = parseCompileFlags(['-m00']);
+    info = parseCompileFlags(cpptoolsVersion, ['-m00']);
     expect(info.targetArch).to.eql(undefined);
   });
 
   test('Get IntelliSenseMode', () => {
-    let mode = getIntelliSenseMode('armclang', 'arm');
+    const cpptoolsVersion = Version.v4;
+    let mode = getIntelliSenseMode(cpptoolsVersion, 'armclang', 'arm');
     expect(mode).to.eql('clang-arm');
-    mode = getIntelliSenseMode('armclang', 'arm64');
+    mode = getIntelliSenseMode(cpptoolsVersion, 'armclang', 'arm64');
     expect(mode).to.eql('clang-arm64');
-    mode = getIntelliSenseMode('armclang', undefined);
+    mode = getIntelliSenseMode(cpptoolsVersion, 'armclang', undefined);
     expect(mode).to.eql('clang-arm');
-    mode = getIntelliSenseMode('clang', 'x64');
+    mode = getIntelliSenseMode(cpptoolsVersion, 'clang', 'x64');
     expect(mode).to.eql('clang-x64');
-    mode = getIntelliSenseMode('clang', 'arm');
+    mode = getIntelliSenseMode(cpptoolsVersion, 'clang', 'arm');
     expect(mode).to.eql('clang-arm');
-    mode = getIntelliSenseMode('gcc', undefined);
+    mode = getIntelliSenseMode(cpptoolsVersion, 'gcc', undefined);
     expect(mode).to.eql('gcc-x64');
-    mode = getIntelliSenseMode('g++', 'x86');
+    mode = getIntelliSenseMode(cpptoolsVersion, 'g++', 'x86');
     expect(mode).to.eql('gcc-x86');
-    mode = getIntelliSenseMode('arm-none-eabi-g++', undefined);
+    mode = getIntelliSenseMode(cpptoolsVersion, 'arm-none-eabi-g++', undefined);
     expect(mode).to.eql('gcc-arm');
-    mode = getIntelliSenseMode('aarch64-linux-gnu-gcc', undefined);
+    mode = getIntelliSenseMode(cpptoolsVersion, 'aarch64-linux-gnu-gcc', undefined);
     expect(mode).to.eql('gcc-arm64');
-    mode = getIntelliSenseMode('bin//Hostx64//x64//cl.exe', undefined);
+    mode = getIntelliSenseMode(cpptoolsVersion, 'bin//Hostx64//x64//cl.exe', undefined);
     expect(mode).to.eql('msvc-x64');
-    mode = getIntelliSenseMode('bin//Hostx64//x86//cl.exe', undefined);
+    mode = getIntelliSenseMode(cpptoolsVersion, 'bin//Hostx64//x86//cl.exe', undefined);
     expect(mode).to.eql('msvc-x86');
-    mode = getIntelliSenseMode('bin//Hostx64//arm//cl.exe', undefined);
+    mode = getIntelliSenseMode(cpptoolsVersion, 'bin//Hostx64//arm//cl.exe', undefined);
     expect(mode).to.eql('msvc-arm');
-    mode = getIntelliSenseMode('bin//Hostx64//arm64//cl.exe', undefined);
+    mode = getIntelliSenseMode(cpptoolsVersion, 'bin//Hostx64//arm64//cl.exe', undefined);
     expect(mode).to.eql('msvc-arm64');
-    mode = getIntelliSenseMode('cl.exe', undefined);
+    mode = getIntelliSenseMode(cpptoolsVersion, 'cl.exe', undefined);
     expect(mode).to.eql('msvc-x64');
   });
 

--- a/test/unit-tests/cpptools.test.ts
+++ b/test/unit-tests/cpptools.test.ts
@@ -22,10 +22,12 @@ suite('CppTools tests', () => {
     expect(info.extraDefinitions).to.eql(['FOO=BAR']);
     info = parseCompileFlags(['-DFOO=BAR', '/D', 'BAZ=QUX']);
     expect(info.extraDefinitions).to.eql(['FOO=BAR', 'BAZ=QUX']);
-    // Parse language standard
     expect(info.standard).to.eql('c++17');
+    // Parse language standard
     info = parseCompileFlags(['-std=c++03']);
     expect(info.standard).to.eql('c++03');
+    info = parseCompileFlags(['-std=gnu++14']);
+    expect(info.standard).to.eql('gnu++14');
     // Parse target architecture
     info = parseCompileFlags(['--target=aarch64-arm-none-eabi']);
     expect(info.targetArch).to.eql('arm64');

--- a/test/unit-tests/cpptools.test.ts
+++ b/test/unit-tests/cpptools.test.ts
@@ -59,7 +59,7 @@ suite('CppTools tests', () => {
     mode = getIntelliSenseMode('clang', 'arm');
     expect(mode).to.eql('clang-arm');
     mode = getIntelliSenseMode('gcc', undefined);
-    expect(mode).to.eql('gcc-x64')
+    expect(mode).to.eql('gcc-x64');
     mode = getIntelliSenseMode('g++', 'x86');
     expect(mode).to.eql('gcc-x86');
     mode = getIntelliSenseMode('arm-none-eabi-g++', undefined);

--- a/test/unit-tests/cpptools.test.ts
+++ b/test/unit-tests/cpptools.test.ts
@@ -17,70 +17,100 @@ function getTestResourceFilePath(filename: string): string {
 suite('CppTools tests', () => {
   test('Parse some compiler flags', () => {
     // Parse definition
-    const cpptoolsVersion = Version.v4;
-    let info = parseCompileFlags(cpptoolsVersion, ['-DFOO=BAR']);
+    const cpptoolsVersion3 = Version.v3;
+    const cpptoolsVersion4 = Version.v4;
+
+    // Verify CppTools API version 4
+    let info = parseCompileFlags(cpptoolsVersion4, ['-DFOO=BAR']);
     expect(info.extraDefinitions).to.eql(['FOO=BAR']);
-    info = parseCompileFlags(cpptoolsVersion, ['-D', 'FOO=BAR']);
+    info = parseCompileFlags(cpptoolsVersion4, ['-D', 'FOO=BAR']);
     expect(info.extraDefinitions).to.eql(['FOO=BAR']);
-    info = parseCompileFlags(cpptoolsVersion, ['-DFOO=BAR', '/D', 'BAZ=QUX']);
+    info = parseCompileFlags(cpptoolsVersion4, ['-DFOO=BAR', '/D', 'BAZ=QUX']);
     expect(info.extraDefinitions).to.eql(['FOO=BAR', 'BAZ=QUX']);
     expect(info.standard).to.eql('c++17');
     // Parse language standard
-    info = parseCompileFlags(cpptoolsVersion, ['-std=c++03']);
+    info = parseCompileFlags(cpptoolsVersion4, ['-std=c++03']);
     expect(info.standard).to.eql('c++03');
-    info = parseCompileFlags(cpptoolsVersion, ['-std=gnu++14']);
+    info = parseCompileFlags(cpptoolsVersion4, ['-std=gnu++14']);
     expect(info.standard).to.eql('gnu++14');
+    info = parseCompileFlags(cpptoolsVersion4, ['-std=c18']);
+    expect(info.standard).to.eql('c18');
     // Parse target architecture
-    info = parseCompileFlags(cpptoolsVersion, ['--target=aarch64-arm-none-eabi']);
+    info = parseCompileFlags(cpptoolsVersion4, ['--target=aarch64-arm-none-eabi']);
     expect(info.targetArch).to.eql('arm64');
-    info = parseCompileFlags(cpptoolsVersion, ['-target', 'arm-arm-none-eabi']);
+    info = parseCompileFlags(cpptoolsVersion4, ['-target', 'arm-arm-none-eabi']);
     expect(info.targetArch).to.eql('arm');
-    info = parseCompileFlags(cpptoolsVersion, ['-arch=x86_64']);
+    info = parseCompileFlags(cpptoolsVersion4, ['-arch=x86_64']);
     expect(info.targetArch).to.eql('x64');
-    info = parseCompileFlags(cpptoolsVersion, ['-arch', 'aarch64']);
+    info = parseCompileFlags(cpptoolsVersion4, ['-arch', 'aarch64']);
     expect(info.targetArch).to.eql('arm64');
-    info = parseCompileFlags(cpptoolsVersion, ['-arch', 'i686']);
+    info = parseCompileFlags(cpptoolsVersion4, ['-arch', 'i686']);
     expect(info.targetArch).to.eql('x86');
-    info = parseCompileFlags(cpptoolsVersion, ['/arch:x86_64']);
+    info = parseCompileFlags(cpptoolsVersion4, ['/arch:x86_64']);
     expect(info.targetArch).to.eql('x64');
-    info = parseCompileFlags(cpptoolsVersion, ['-march=amd64']);
+    info = parseCompileFlags(cpptoolsVersion4, ['-march=amd64']);
     expect(info.targetArch).to.eql('x64');
-    info = parseCompileFlags(cpptoolsVersion, ['-m32']);
+    info = parseCompileFlags(cpptoolsVersion4, ['-m32']);
     expect(info.targetArch).to.eql('x86');
-    info = parseCompileFlags(cpptoolsVersion, ['-m00']);
+    info = parseCompileFlags(cpptoolsVersion4, ['-m00']);
     expect(info.targetArch).to.eql(undefined);
+
+    // Verify CppTools API version 3
+    info = parseCompileFlags(cpptoolsVersion3, ['-std=c++03']);
+    expect(info.standard).to.eql('c++03');
+    info = parseCompileFlags(cpptoolsVersion3, ['-std=gnu++14']);
+    expect(info.standard).to.eql('c++14');
+    info = parseCompileFlags(cpptoolsVersion3, ['-std=c18']);
+    expect(info.standard).to.eql('c11');
   });
 
   test('Get IntelliSenseMode', () => {
-    const cpptoolsVersion = Version.v4;
-    let mode = getIntelliSenseMode(cpptoolsVersion, 'armclang', 'arm');
+    const cpptoolsVersion3 = Version.v3;
+    const cpptoolsVersion4 = Version.v4;
+
+    // Verify CppTools API version 4
+    let mode = getIntelliSenseMode(cpptoolsVersion4, 'armclang', 'arm');
     expect(mode).to.eql('clang-arm');
-    mode = getIntelliSenseMode(cpptoolsVersion, 'armclang', 'arm64');
+    mode = getIntelliSenseMode(cpptoolsVersion4, 'armclang', 'arm64');
     expect(mode).to.eql('clang-arm64');
-    mode = getIntelliSenseMode(cpptoolsVersion, 'armclang', undefined);
+    mode = getIntelliSenseMode(cpptoolsVersion4, 'armclang', undefined);
     expect(mode).to.eql('clang-arm');
-    mode = getIntelliSenseMode(cpptoolsVersion, 'clang', 'x64');
+    mode = getIntelliSenseMode(cpptoolsVersion4, 'clang', 'x64');
     expect(mode).to.eql('clang-x64');
-    mode = getIntelliSenseMode(cpptoolsVersion, 'clang', 'arm');
+    mode = getIntelliSenseMode(cpptoolsVersion4, 'clang', 'arm');
     expect(mode).to.eql('clang-arm');
-    mode = getIntelliSenseMode(cpptoolsVersion, 'gcc', undefined);
+    mode = getIntelliSenseMode(cpptoolsVersion4, 'gcc', undefined);
     expect(mode).to.eql('gcc-x64');
-    mode = getIntelliSenseMode(cpptoolsVersion, 'g++', 'x86');
+    mode = getIntelliSenseMode(cpptoolsVersion4, 'g++', 'x86');
     expect(mode).to.eql('gcc-x86');
-    mode = getIntelliSenseMode(cpptoolsVersion, 'arm-none-eabi-g++', undefined);
+    mode = getIntelliSenseMode(cpptoolsVersion4, 'arm-none-eabi-g++', undefined);
     expect(mode).to.eql('gcc-arm');
-    mode = getIntelliSenseMode(cpptoolsVersion, 'aarch64-linux-gnu-gcc', undefined);
+    mode = getIntelliSenseMode(cpptoolsVersion4, 'aarch64-linux-gnu-gcc', undefined);
     expect(mode).to.eql('gcc-arm64');
-    mode = getIntelliSenseMode(cpptoolsVersion, 'bin//Hostx64//x64//cl.exe', undefined);
+    mode = getIntelliSenseMode(cpptoolsVersion4, 'bin//Hostx64//x64//cl.exe', undefined);
     expect(mode).to.eql('msvc-x64');
-    mode = getIntelliSenseMode(cpptoolsVersion, 'bin//Hostx64//x86//cl.exe', undefined);
+    mode = getIntelliSenseMode(cpptoolsVersion4, 'bin//Hostx64//x86//cl.exe', undefined);
     expect(mode).to.eql('msvc-x86');
-    mode = getIntelliSenseMode(cpptoolsVersion, 'bin//Hostx64//arm//cl.exe', undefined);
+    mode = getIntelliSenseMode(cpptoolsVersion4, 'bin//Hostx64//arm//cl.exe', undefined);
     expect(mode).to.eql('msvc-arm');
-    mode = getIntelliSenseMode(cpptoolsVersion, 'bin//Hostx64//arm64//cl.exe', undefined);
+    mode = getIntelliSenseMode(cpptoolsVersion4, 'bin//Hostx64//arm64//cl.exe', undefined);
     expect(mode).to.eql('msvc-arm64');
-    mode = getIntelliSenseMode(cpptoolsVersion, 'cl.exe', undefined);
+    mode = getIntelliSenseMode(cpptoolsVersion4, 'cl.exe', undefined);
     expect(mode).to.eql('msvc-x64');
+
+    // Verify CppTools API version 3
+    mode = getIntelliSenseMode(cpptoolsVersion3, 'bin//Hostx64//arm//cl.exe', undefined);
+    expect(mode).to.eql('msvc-x86');
+    mode = getIntelliSenseMode(cpptoolsVersion3, 'bin//Hostx64//arm64//cl.exe', undefined);
+    expect(mode).to.eql('msvc-x64');
+    mode = getIntelliSenseMode(cpptoolsVersion3, 'arm-none-eabi-g++', undefined);
+    expect(mode).to.eql('gcc-x86');
+    mode = getIntelliSenseMode(cpptoolsVersion3, 'aarch64-linux-gnu-gcc', undefined);
+    expect(mode).to.eql('gcc-x64');
+    mode = getIntelliSenseMode(cpptoolsVersion3, 'clang', 'arm64');
+    expect(mode).to.eql('clang-x64');
+    mode = getIntelliSenseMode(cpptoolsVersion3, 'clang', 'arm');
+    expect(mode).to.eql('clang-x86');
   });
 
   test('Validate code model', async () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5152,10 +5152,10 @@ vm-browserify@^1.0.1:
   resolved "https://registry.yarnpkg.com/vm-browserify/-/vm-browserify-1.1.2.tgz#78641c488b8e6ca91a75f511e7a3b32a86e5dda0"
   integrity sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==
 
-vscode-cpptools@^3.0.1:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/vscode-cpptools/-/vscode-cpptools-3.1.0.tgz#fbc0e493e81a05baf01702ea8b9467c39fba257d"
-  integrity sha512-z4W/A1TQMEtqTEWNY3Hb4HJcJ2J3HeaLHp3TyqCotoRkLU8ovH4jmDb5tNTyh3DgIiaAAnDalO03A4wm5IvNBg==
+vscode-cpptools@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/vscode-cpptools/-/vscode-cpptools-4.0.1.tgz#7e591572b437a6aca47b767487b52bc253e6d911"
+  integrity sha512-2IjtWe7rjIp20J+5m0Yjpa8TjGhdQWChwE49iYJBUUTHFqJDFq0aXNAyiDNw6BDWI1Q2Z/gmeQGsJBoxTb0J0Q==
 
 vscode-extension-telemetry@^0.1.2:
   version "0.1.2"


### PR DESCRIPTION
<!-- Thanks for your contribution! To make things easier, please fill out the template below. -->

<!-- Please delete any unused sections. -->

<!-- Delete the following heading if there is no corresponding issue -->
## This change addresses items https://github.com/microsoft/vscode-cmake-tools/issues/1155, https://github.com/microsoft/vscode-cmake-tools/issues/1208

### This changes
- Setting IntelliSenseMode in vscode-cpptools based on compiler name and target architecture parsed from compiler flags.

- Parsing C and C++ language standard compiler flag options to support GNU language standard options in vscode-cpptools.

- Added unit tests for both new features.

## The purpose of this change

Support ARM IntelliSenseModes in vscode-cpptools extension https://github.com/microsoft/vscode-cmake-tools/issues/1155 

Support GNU language standard options in vscode-cpptools extension https://github.com/microsoft/vscode-cmake-tools/issues/1208
