### PR TITLE
Remove `cmake.useCMakeServer` setting from package.json

### DIFF
--- a/i18n/chs/package.i18n.json
+++ b/i18n/chs/package.i18n.json
@@ -104,7 +104,6 @@
 	"cmake-tools.configuration.cmake.emscriptenSearchDirs.description": "可在其中安装 Emscripten 的目录。",
 	"cmake-tools.configuration.cmake.copyCompileCommands.description": "成功配置后将 compile_commands.json 复制到此位置。",
 	"cmake-tools.configuration.cmake.configureOnOpen.description": "在 CMake 项目目录打开时自动对其进行配置。",
-	"cmake-tools.configuration.cmake.useCMakeServer.description": "启用 CMake 服务器。",
 	"cmake-tools.configuration.cmake.cmakeCommunicationMode": "用于在扩展和 CMake 之间进行通信的协议",
 	"cmake-tools.configuration.cmake.ignoreKitEnv.description": "运行 CMake 命令时，请勿使用工具包环境变量。",
 	"cmake-tools.configuration.cmake.buildTask.description": "使用 tasks.json 生成，而非使用内部进程。",

--- a/i18n/cht/package.i18n.json
+++ b/i18n/cht/package.i18n.json
@@ -104,7 +104,6 @@
 	"cmake-tools.configuration.cmake.emscriptenSearchDirs.description": "安裝 Emscripten 的目錄。",
 	"cmake-tools.configuration.cmake.copyCompileCommands.description": "組態成功之後，將 compile_commands.json 複製到此位置。",
 	"cmake-tools.configuration.cmake.configureOnOpen.description": "開啟 CMake 專案目錄時自動進行組態。",
-	"cmake-tools.configuration.cmake.useCMakeServer.description": "啟用 CMake 伺服器。",
 	"cmake-tools.configuration.cmake.cmakeCommunicationMode": "用於在延伸模組與 CMake 之間通訊的通訊協定",
 	"cmake-tools.configuration.cmake.ignoreKitEnv.description": "執行 CMake 命令時，不使用套件環境變數。",
 	"cmake-tools.configuration.cmake.buildTask.description": "使用 tasks.json 而非內部處理序的組建。",

--- a/i18n/csy/package.i18n.json
+++ b/i18n/csy/package.i18n.json
@@ -104,7 +104,6 @@
 	"cmake-tools.configuration.cmake.emscriptenSearchDirs.description": "Adresáře, ve kterých může být nainstalovaný Emscripten",
 	"cmake-tools.configuration.cmake.copyCompileCommands.description": "Po úspěšné konfiguraci zkopírovat soubor compile_commands.json do tohoto umístění",
 	"cmake-tools.configuration.cmake.configureOnOpen.description": "Automaticky konfigurovat adresáře projektu CMake při jejich otevření",
-	"cmake-tools.configuration.cmake.useCMakeServer.description": "Povolit server CMake",
 	"cmake-tools.configuration.cmake.cmakeCommunicationMode": "Protokol, pomocí kterého se komunikuje mezi rozšířením a nástrojem CMake",
 	"cmake-tools.configuration.cmake.ignoreKitEnv.description": "Při spouštění příkazů CMake nepoužívat proměnné prostředí sady",
 	"cmake-tools.configuration.cmake.buildTask.description": "Sestavit pomocí souboru tasks.json místo interního procesu",

--- a/i18n/deu/package.i18n.json
+++ b/i18n/deu/package.i18n.json
@@ -104,7 +104,6 @@
 	"cmake-tools.configuration.cmake.emscriptenSearchDirs.description": "Verzeichnisse, in denen Emscripten möglicherweise installiert ist.",
 	"cmake-tools.configuration.cmake.copyCompileCommands.description": "Hiermit wird \"compile_commands.json\" nach erfolgreicher Konfiguration an diesen Speicherort kopiert.",
 	"cmake-tools.configuration.cmake.configureOnOpen.description": "Hiermit werden CMake-Projektverzeichnisse beim Öffnen automatisch konfiguriert.",
-	"cmake-tools.configuration.cmake.useCMakeServer.description": "Hiermit wird CMake-Server aktiviert.",
 	"cmake-tools.configuration.cmake.cmakeCommunicationMode": "Das für die Kommunikation zwischen der Erweiterung und CMake verwendete Protokoll",
 	"cmake-tools.configuration.cmake.ignoreKitEnv.description": "Hiermit werden die Umgebungsvariablen des Kits beim Ausführen von CMake-Befehlen nicht verwendet.",
 	"cmake-tools.configuration.cmake.buildTask.description": "Über \"tasks.json\" statt über internen Prozess erstellen",

--- a/i18n/esn/package.i18n.json
+++ b/i18n/esn/package.i18n.json
@@ -104,7 +104,6 @@
 	"cmake-tools.configuration.cmake.emscriptenSearchDirs.description": "Directorios en los que se puede instalar Emscripten.",
 	"cmake-tools.configuration.cmake.copyCompileCommands.description": "Copia compile_commands.json en esta ubicación después de una configuración correcta.",
 	"cmake-tools.configuration.cmake.configureOnOpen.description": "Configura automáticamente los directorios del proyecto de CMake al abrirlos.",
-	"cmake-tools.configuration.cmake.useCMakeServer.description": "Habilita el servidor de CMake.",
 	"cmake-tools.configuration.cmake.cmakeCommunicationMode": "El protocolo que se usa para la comunicación entre la extensión y CMake.",
 	"cmake-tools.configuration.cmake.ignoreKitEnv.description": "No use las variables de entorno del kit al ejecutar comandos de CMake.",
 	"cmake-tools.configuration.cmake.buildTask.description": "Use tasks.json para compilar en lugar del proceso interno.",

--- a/i18n/fra/package.i18n.json
+++ b/i18n/fra/package.i18n.json
@@ -104,7 +104,6 @@
 	"cmake-tools.configuration.cmake.emscriptenSearchDirs.description": "Répertoires où Emscripten peut être installé.",
 	"cmake-tools.configuration.cmake.copyCompileCommands.description": "Copie compile_commands.json à cet emplacement après une configuration réussie.",
 	"cmake-tools.configuration.cmake.configureOnOpen.description": "Configure automatiquement les répertoires de projet CMake quand ils s'ouvrent.",
-	"cmake-tools.configuration.cmake.useCMakeServer.description": "Active le serveur CMake.",
 	"cmake-tools.configuration.cmake.cmakeCommunicationMode": "Protocole de communication entre l'extension et CMake",
 	"cmake-tools.configuration.cmake.ignoreKitEnv.description": "N'utilise pas les variables d'environnement de kit au moment de l'exécution de commandes CMake.",
 	"cmake-tools.configuration.cmake.buildTask.description": "Effectue une build à l'aide de tasks.json au lieu du processus interne.",

--- a/i18n/ita/package.i18n.json
+++ b/i18n/ita/package.i18n.json
@@ -104,7 +104,6 @@
 	"cmake-tools.configuration.cmake.emscriptenSearchDirs.description": "Directory in cui è possibile installare Emscripten.",
 	"cmake-tools.configuration.cmake.copyCompileCommands.description": "Copia compile_commands.json in questa posizione dopo una configurazione riuscita.",
 	"cmake-tools.configuration.cmake.configureOnOpen.description": "Configura automaticamente le directory di progetto di CMake quando vengono aperte.",
-	"cmake-tools.configuration.cmake.useCMakeServer.description": "Abilita il server CMake.",
 	"cmake-tools.configuration.cmake.cmakeCommunicationMode": "Protocollo usato per le comunicazioni tra l'estensione e CMake",
 	"cmake-tools.configuration.cmake.ignoreKitEnv.description": "Non usa le variabili di ambiente del kit durante l'esecuzione dei comandi di CMake.",
 	"cmake-tools.configuration.cmake.buildTask.description": "Compila con tasks.json anziché il processo interno.",

--- a/i18n/jpn/package.i18n.json
+++ b/i18n/jpn/package.i18n.json
@@ -104,7 +104,6 @@
 	"cmake-tools.configuration.cmake.emscriptenSearchDirs.description": "Emscripten がインストールされる可能性のあるディレクトリです。",
 	"cmake-tools.configuration.cmake.copyCompileCommands.description": "構成が正常に完了したら、compile_commands.json をこの場所にコピーします。",
 	"cmake-tools.configuration.cmake.configureOnOpen.description": "CMake プロジェクト ディレクトリを開いたときに自動的に構成します。",
-	"cmake-tools.configuration.cmake.useCMakeServer.description": "CMake サーバーを有効にします。",
 	"cmake-tools.configuration.cmake.cmakeCommunicationMode": "拡張機能と CMake の間の通信に使用されるプロトコル",
 	"cmake-tools.configuration.cmake.ignoreKitEnv.description": "CMake コマンドの実行時には、キットの環境変数を使用しないでください。",
 	"cmake-tools.configuration.cmake.buildTask.description": "内部プロセスではなく tasks.json を使用してビルドします。",

--- a/i18n/kor/package.i18n.json
+++ b/i18n/kor/package.i18n.json
@@ -104,7 +104,6 @@
 	"cmake-tools.configuration.cmake.emscriptenSearchDirs.description": "Emscripten을 설치할 수 있는 디렉터리입니다.",
 	"cmake-tools.configuration.cmake.copyCompileCommands.description": "구성에 성공한 후 compile_commands.json을 이 위치로 복사합니다.",
 	"cmake-tools.configuration.cmake.configureOnOpen.description": "CMake 프로젝트 디렉터리를 열 때 자동으로 구성합니다.",
-	"cmake-tools.configuration.cmake.useCMakeServer.description": "CMake 서버를 사용합니다.",
 	"cmake-tools.configuration.cmake.cmakeCommunicationMode": "확장과 CMake 간 통신에 사용되는 프로토콜입니다.",
 	"cmake-tools.configuration.cmake.ignoreKitEnv.description": "CMake 명령을 실행할 때 키트 환경 변수를 사용하지 않습니다.",
 	"cmake-tools.configuration.cmake.buildTask.description": "내부 프로세스 대신 tasks.json을 사용하여 빌드합니다.",

--- a/i18n/plk/package.i18n.json
+++ b/i18n/plk/package.i18n.json
@@ -104,7 +104,6 @@
 	"cmake-tools.configuration.cmake.emscriptenSearchDirs.description": "Katalogi, w których można zainstalować program Emscripten.",
 	"cmake-tools.configuration.cmake.copyCompileCommands.description": "Kopiuj plik compile_commands.json do tej lokalizacji po pomyślnym skonfigurowaniu.",
 	"cmake-tools.configuration.cmake.configureOnOpen.description": "Automatycznie konfiguruj katalogi projektu narzędzia CMake przy ich otwieraniu.",
-	"cmake-tools.configuration.cmake.useCMakeServer.description": "Włącz serwer narzędzia CMake.",
 	"cmake-tools.configuration.cmake.cmakeCommunicationMode": "Protokół używany do komunikacji między rozszerzeniem i narzędziem CMake",
 	"cmake-tools.configuration.cmake.ignoreKitEnv.description": "Nie używaj zmiennych środowiskowych zestawu podczas uruchamiania poleceń narzędzia CMake.",
 	"cmake-tools.configuration.cmake.buildTask.description": "Kompiluj przy użyciu pliku tasks.json zamiast procesu wewnętrznego.",

--- a/i18n/ptb/package.i18n.json
+++ b/i18n/ptb/package.i18n.json
@@ -104,7 +104,6 @@
 	"cmake-tools.configuration.cmake.emscriptenSearchDirs.description": "Os diretórios nos quais o Emscripten pode ser instalado.",
 	"cmake-tools.configuration.cmake.copyCompileCommands.description": "Copiar o compile_commands.json neste local após uma configuração bem-sucedida.",
 	"cmake-tools.configuration.cmake.configureOnOpen.description": "Configurar os diretórios de projeto do CMake automaticamente quando eles forem abertos.",
-	"cmake-tools.configuration.cmake.useCMakeServer.description": "Habilitar o servidor do CMake.",
 	"cmake-tools.configuration.cmake.cmakeCommunicationMode": "O protocolo usado para a comunicação entre a extensão e o CMake",
 	"cmake-tools.configuration.cmake.ignoreKitEnv.description": "Não use as variáveis de ambiente do kit ao executar os comandos do CMake.",
 	"cmake-tools.configuration.cmake.buildTask.description": "Compilar usando o tasks.json em vez do processo interno.",

--- a/i18n/rus/package.i18n.json
+++ b/i18n/rus/package.i18n.json
@@ -104,7 +104,6 @@
 	"cmake-tools.configuration.cmake.emscriptenSearchDirs.description": "Каталоги, где возможна установка Emscripten.",
 	"cmake-tools.configuration.cmake.copyCompileCommands.description": "Копирование сюда файла compile_commands.json после выполнения настройки.",
 	"cmake-tools.configuration.cmake.configureOnOpen.description": "Автоматическая настройка каталогов проекта CMake при их открытии.",
-	"cmake-tools.configuration.cmake.useCMakeServer.description": "Включение сервера CMake.",
 	"cmake-tools.configuration.cmake.cmakeCommunicationMode": "Протокол, используемый для взаимодействия между расширением и CMake",
 	"cmake-tools.configuration.cmake.ignoreKitEnv.description": "Отключение использования переменных среды при выполнении команд CMake.",
 	"cmake-tools.configuration.cmake.buildTask.description": "Сборка с помощью tasks.json вместо внутреннего процесса.",

--- a/i18n/trk/package.i18n.json
+++ b/i18n/trk/package.i18n.json
@@ -104,7 +104,6 @@
 	"cmake-tools.configuration.cmake.emscriptenSearchDirs.description": "Emscripten'in yüklü olabileceği dizinler.",
 	"cmake-tools.configuration.cmake.copyCompileCommands.description": "Başarılı bir yapılandırmadan sonra compile_commands.json dosyasını bu konuma kopyala.",
 	"cmake-tools.configuration.cmake.configureOnOpen.description": "CMake proje dizinleri açıldığında bu dizinleri otomatik olarak yapılandır.",
-	"cmake-tools.configuration.cmake.useCMakeServer.description": "CMake sunucusunu etkinleştirin.",
 	"cmake-tools.configuration.cmake.cmakeCommunicationMode": "Uzantı ve CMake arasında iletişim kurmak için kullanılan protokol",
 	"cmake-tools.configuration.cmake.ignoreKitEnv.description": "CMake komutlarını çalıştırırken set ortamı değişkenlerini kullanmayın.",
 	"cmake-tools.configuration.cmake.buildTask.description": "İç işlem yerine tasks.json kullanarak derle.",

--- a/package.json
+++ b/package.json
@@ -1163,12 +1163,6 @@
           "description": "%cmake-tools.configuration.cmake.configureOnOpen.description%",
           "scope": "resource"
         },
-        "cmake.useCMakeServer": {
-          "type": "boolean",
-          "default": false,
-          "description": "%cmake-tools.configuration.cmake.useCMakeServer.description%",
-          "scope": "resource"
-        },
         "cmake.cmakeCommunicationMode": {
           "type": "string",
           "default": "automatic",

--- a/package.nls.json
+++ b/package.nls.json
@@ -99,7 +99,6 @@
     "cmake-tools.configuration.cmake.emscriptenSearchDirs.description": "Directories where Emscripten may be installed.",
     "cmake-tools.configuration.cmake.copyCompileCommands.description": "Copy compile_commands.json to this location after a successful configure.",
     "cmake-tools.configuration.cmake.configureOnOpen.description": "Automatically configure CMake project directories when they are opened.",
-    "cmake-tools.configuration.cmake.useCMakeServer.description": "Enable CMake server.",
     "cmake-tools.configuration.cmake.cmakeCommunicationMode": "The protocol used to communicate between the extension and CMake",
     "cmake-tools.configuration.cmake.ignoreKitEnv.description": "Do not use the kit environment variables when running CMake commands.",
     "cmake-tools.configuration.cmake.buildTask.description": "Build using tasks.json instead of internal process.",

--- a/test/unit-tests/test-project-without-cmakelists/.vscode/settings.json
+++ b/test/unit-tests/test-project-without-cmakelists/.vscode/settings.json
@@ -1,5 +1,4 @@
 {
-    "cmake.useCMakeServer": true,
     "cmake.configureEnvironment": {
         "HOME": "/home/colby-TEST-APPENDED"
     }


### PR DESCRIPTION
<!-- Thanks for your contribution! To make things easier, please fill out the template below. -->

<!-- Please delete any unused sections. -->

<!-- Delete the following heading if there is no corresponding issue -->
## This change addresses item #1059 

The deprecated setting is being removed so that it is no longer offered by the settings UI. Code to check for it and warn developers will remain for at least one more release cycle.