### PR TITLE
Fix scope for state variable that guards the silent scan for kits

### DIFF
--- a/src/kit.ts
+++ b/src/kit.ts
@@ -975,7 +975,7 @@ export async function scanForKits(opt?: KitScanOptions) {
 
 // Rescan if the kits versions (extension context state var versus value defined for this release) don't match.
 export async function scanForKitsIfNeeded(context: vscode.ExtensionContext) : Promise<void> {
-  const kitsVersionSaved = context.workspaceState.get<number>('kitsVersionSaved');
+  const kitsVersionSaved = context.globalState.get<number>('kitsVersionSaved');
   const kitsVersionCurrent = 1;
 
   // Scan also when there is no kits version saved in the state.

--- a/src/kit.ts
+++ b/src/kit.ts
@@ -979,7 +979,8 @@ export async function scanForKitsIfNeeded(context: vscode.ExtensionContext) : Pr
   const kitsVersionCurrent = 1;
 
   // Scan also when there is no kits version saved in the state.
-  if (!kitsVersionSaved || kitsVersionSaved !== kitsVersionCurrent) {
+  if ((!kitsVersionSaved || kitsVersionSaved !== kitsVersionCurrent) &&
+       process.env['CMT_TESTING'] !== '1') {
     await scanForKits();
     context.globalState.update('kitsVersionSaved', kitsVersionCurrent);
   }

--- a/src/kit.ts
+++ b/src/kit.ts
@@ -981,7 +981,7 @@ export async function scanForKitsIfNeeded(context: vscode.ExtensionContext) : Pr
   // Scan also when there is no kits version saved in the state.
   if (!kitsVersionSaved || kitsVersionSaved !== kitsVersionCurrent) {
     await scanForKits();
-    context.workspaceState.update('kitsVersionSaved', kitsVersionCurrent);
+    context.globalState.update('kitsVersionSaved', kitsVersionCurrent);
   }
 }
 


### PR DESCRIPTION
Change the scope of the state variable that guards the silent scan for kits from workspace to global to avoid unnecessary scanning for each new folder.