### PR TITLE
Forgot one more scenario for when we want partial feature set enabled

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -418,6 +418,9 @@ class ExtensionManager implements vscode.Disposable {
       log.debug(localize('configuring.workspace.on.open', 'Configuring workspace on open {0}', ws.uri.toString()));
       // Ensure that there is a kit. This is required for new instances.
       if (!await this._ensureActiveKit(cmt)) {
+        // If no kit is selected, the configure process will not continue and we don't want to enable
+        // the full feature set of CMake Tools.
+        await enableFullFeatureSet(false);
         return;
       }
       await cmt.configure();


### PR DESCRIPTION
Enable only the reduced features set of CMake Tools when there is no kit chosen from the "Select a kit" quick pick (which pops up immediately after opening a fresh folder that hasn't been successfully configured before).