### PR TITLE
Fix #1285 - ninjaPath is undefined but tested against null

### DIFF
--- a/src/kit.ts
+++ b/src/kit.ts
@@ -703,11 +703,11 @@ async function varsForVSInstallation(inst: VSInstallation, hostArch: string, tar
     variables.set('CC', 'cl.exe');
     variables.set('CXX', 'cl.exe');
 
-    if (null !== paths.ninjaPath) {
+    if (paths.ninjaPath) {
       let envPATH = variables.get('PATH');
       if (undefined !== envPATH) {
         const env_paths = envPATH.split(';');
-        const ninja_path = path.dirname(paths.ninjaPath);
+        const ninja_path = path.dirname(paths.ninjaPath!);
         const ninja_base_path = env_paths.find(path_el => path_el === ninja_path);
         if (undefined === ninja_base_path) {
           envPATH = envPATH.concat(';' + ninja_path);

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -11,15 +11,15 @@ import {expandString} from './expand';
 import {fs} from './pr';
 
 interface VSCMakePaths {
-  cmake: string | null;
-  ninja: string | null;
+  cmake?: string;
+  ninja?: string;
 }
 
 /**
  * Directory class.
  */
 class Paths {
-  private _ninjaPath : string | null = null;
+  private _ninjaPath?: string;
 
   /**
    * The current user's home directory
@@ -129,7 +129,7 @@ class Paths {
   }
 
   async getCMakePath(wsc: DirectoryContext): Promise<string|null> {
-    this._ninjaPath = null;
+    this._ninjaPath = undefined;
 
     const raw = await expandString(wsc.config.raw_cmakePath, {
       vars: {
@@ -164,10 +164,10 @@ class Paths {
 
         // Look for bundled CMake executables in Visual Studio install paths
         const bundled_tools_paths = await this.vsCMakePaths();
-        if (null !== bundled_tools_paths.cmake) {
+        if (bundled_tools_paths.cmake) {
           this._ninjaPath = bundled_tools_paths.ninja;
 
-          return bundled_tools_paths.cmake;
+          return bundled_tools_paths.cmake!;
         }
       }
       return null;
@@ -177,7 +177,7 @@ class Paths {
   }
 
   async vsCMakePaths(): Promise<VSCMakePaths> {
-    const vsCMakePaths = {} as VSCMakePaths;
+    const vsCMakePaths: VSCMakePaths = {};
 
     const vs_installations = await vsInstallations();
     if (vs_installations.length > 0) {


### PR DESCRIPTION
## This change addresses item #1285 

There is a chance that the ninja path is undefined, but the Kits logic expects a null. This change cleans up the types so that we only have to test for undefined.