### PR TITLE
Don't ever use the RC compiler as the compilerPath

### DIFF
--- a/src/cpptools.ts
+++ b/src/cpptools.ts
@@ -391,7 +391,7 @@ export class CppConfigurationProvider implements cpt.CustomConfigurationProvider
   private _buildConfigurationData(fileGroup: codemodel_api.CodeModelFileGroup, opts: CodeModelParams, target: TargetDefaults, sysroot: string):
       cpt.SourceFileConfiguration {
     // If the file didn't have a language, default to C++
-    const lang = fileGroup.language;
+    const lang = fileGroup.language === "RC" ? undefined : fileGroup.language;
     // Try the group's language's compiler, then the C++ compiler, then the C compiler.
     const comp_cache = opts.cache.get(`CMAKE_${lang}_COMPILER`) || opts.cache.get('CMAKE_CXX_COMPILER')
         || opts.cache.get('CMAKE_C_COMPILER');


### PR DESCRIPTION
We found this bug while investigating another issue with arm intelliSenseModes.

rc.exe was being selected by CMake Tools as the compilerPath for the browse path when building a certain project and using CMake Server mode.  This results in an incorrect browse path for cpptools.