### PR TITLE
Lowercase compiler path for getting IntelliSense mode

### DIFF
--- a/src/cpptools.ts
+++ b/src/cpptools.ts
@@ -205,7 +205,7 @@ export function getIntelliSenseMode(cptVersion: cpt.Version, compiler_path: stri
   const can_use_arm = (cptVersion >= cpt.Version.v4);
   const compiler_name = path.basename(compiler_path || "").toLocaleLowerCase();
   if (compiler_name === 'cl.exe') {
-    const clArch = path.basename(path.dirname(compiler_path));
+    const clArch = path.basename(path.dirname(compiler_path)).toLocaleLowerCase();
     switch (clArch) {
       case 'arm64':
         return can_use_arm ? 'msvc-arm64' : 'msvc-x64';

--- a/test/unit-tests/cpptools.test.ts
+++ b/test/unit-tests/cpptools.test.ts
@@ -91,9 +91,9 @@ suite('CppTools tests', () => {
     expect(mode).to.eql('msvc-x64');
     mode = getIntelliSenseMode(cpptoolsVersion4, 'bin//Hostx64//x86//cl.exe', undefined);
     expect(mode).to.eql('msvc-x86');
-    mode = getIntelliSenseMode(cpptoolsVersion4, 'bin//Hostx64//arm//cl.exe', undefined);
+    mode = getIntelliSenseMode(cpptoolsVersion4, 'bin//Hostx64//ARM//cl.exe', undefined);
     expect(mode).to.eql('msvc-arm');
-    mode = getIntelliSenseMode(cpptoolsVersion4, 'bin//Hostx64//arm64//cl.exe', undefined);
+    mode = getIntelliSenseMode(cpptoolsVersion4, 'bin//Hostx64//ARM64//cl.exe', undefined);
     expect(mode).to.eql('msvc-arm64');
     mode = getIntelliSenseMode(cpptoolsVersion4, 'cl.exe', undefined);
     expect(mode).to.eql('msvc-x64');


### PR DESCRIPTION
<!-- Thanks for your contribution! To make things easier, please fill out the template below. -->

### This changes configuration for IntelliSense mode for MSVC.

The following changes are proposed:

- When determining the IntelliSense mode for an MSVC compiler, the architecture hint is retrieved from the path of the compiler. If the resulting architecture hint is not in lowercased, then the IntelliSense mode fallbacks to the default value. This is because the logic expects the hint to be in a a lowercased value.

## The purpose of this change

This change fixes the described issued above by making the compiler path lowercased so that the architecture hint from the compiler path can be compared correctly with the available IntelliSense mode architectures for MSVC.
