### PR TITLE
Fix multiple silent kit scans in a multi-root workspace

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -365,8 +365,9 @@ class ExtensionManager implements vscode.Disposable {
 
     // Silent re-scan when detecting a breaking change in the kits definition.
     // Do this only for the first folder, to avoid multiple rescans taking place in a multi-root workspace.
-    const silentScanForKitsNeeded: boolean = vscode.workspace.workspaceFolders![0] === cmt.folder &&
-                                            await scanForKitsIfNeeded(cmt.extensionContext);
+    const silentScanForKitsNeeded: boolean = vscode.workspace.workspaceFolders !== undefined &&
+                                             vscode.workspace.workspaceFolders[0] === cmt.folder &&
+                                             await scanForKitsIfNeeded(cmt.extensionContext);
 
     let should_configure = cmt.workspaceContext.config.configureOnOpen;
     if (should_configure === null && process.env['CMT_TESTING'] !== '1') {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -364,7 +364,9 @@ class ExtensionManager implements vscode.Disposable {
     const cmt = info.cmakeTools;
 
     // Silent re-scan when detecting a breaking change in the kits definition.
-    const silentScanForKitsNeeded: boolean = await scanForKitsIfNeeded(cmt.extensionContext);
+    // Do this only for the first folder, to avoid multiple rescans taking place in a multi-root workspace.
+    const silentScanForKitsNeeded: boolean = vscode.workspace.workspaceFolders![0] === cmt.folder &&
+                                            await scanForKitsIfNeeded(cmt.extensionContext);
 
     let should_configure = cmt.workspaceContext.config.configureOnOpen;
     if (should_configure === null && process.env['CMT_TESTING'] !== '1') {

--- a/src/kit.ts
+++ b/src/kit.ts
@@ -1000,7 +1000,7 @@ export async function scanForKitsIfNeeded(context: vscode.ExtensionContext) : Pr
 
   // Scan also when there is no kits version saved in the state.
   if ((!kitsVersionSaved || kitsVersionSaved !== kitsVersionCurrent) &&
-       process.env['CMT_TESTING'] !== '1') {
+       process.env['CMT_TESTING'] !== '1' && !kitsController.KitsController.isScanningForKits()) {
     log.info(localize('silent.kits.rescan', 'Detected kits definition version change from {0} to {1}. Silently scanning for kits.', kitsVersionSaved, kitsVersionCurrent));
     await kitsController.KitsController.scanForKits();
     context.globalState.update('kitsVersionSaved', kitsVersionCurrent);

--- a/src/kitsController.ts
+++ b/src/kitsController.ts
@@ -43,6 +43,7 @@ export class KitsController {
   static userKits: Kit[] = [];
 
   private static checkingHaveKits = false;
+  public static isScanningForKits() { return this.checkingHaveKits; }
 
   folderKits: Kit[] = [];
 


### PR DESCRIPTION
Since the silent kits scanning is called at the end of opening a folder, a multi-root project will trigger unnecessarily more than one kits scanning.
The fix in this PR is to check if there is already a scan in progress but that was not enough because for a multi root project, the multiple scans are first triggered but the boolean gets set later and we still have more than one scanning processes, depending on various timings.
In addition to check for scans in progress, the call to silent scan is made only for the first folder.
Another alternative would be to move the silent scan earlier in the extension activation (or outside the scope of a folder) since this operation has nothing to do with a folder specifically. I remembered the issues with the first approach and thought that checking first folder only is not that bad.

https://github.com/microsoft/vscode-cmake-tools/issues/1302
