### PR TITLE
Fixed typo mistake about check return code.

### DIFF
--- a/src/cmake-tools.ts
+++ b/src/cmake-tools.ts
@@ -706,7 +706,7 @@ export class CMakeTools implements vscode.Disposable, api.CMakeToolsAPI {
                 if (retc === 0) {
                   await this._refreshCompileDatabase(drv.expansionOptions);
                 }
-                if (retc !== 2) {
+                if (retc !== -2) {
                   // Partial activation mode is required only for -2 error code,
                   // which represents a missing CMakeLists.txt
                   await enableFullFeatureSet(true, this.folder);


### PR DESCRIPTION
This typo causes the "CMakeLists missing" popup to not be properly ignored.