### PR TITLE
Fix typo in FAQ

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -43,5 +43,5 @@ Will CMake Tools Ever Support ``<XYZ>``?
 ****************************************
 
 Only if you voice support for it as a `GitHub issue
-<https://github.com/vector-of-bool/vscode-cmake-tools/issues>`_. Open an feature
+<https://github.com/vector-of-bool/vscode-cmake-tools/issues>`_. Open a feature
 request or search for and provide feedback for an existing one!


### PR DESCRIPTION
### This changes [documentation](https://vector-of-bool.github.io/docs/vscode-cmake-tools/faq.html#will-cmake-tools-ever-support-xyz)

The following changes are proposed:

"an" -> "a"

## The purpose of this change

Obeying [rules of English grammar](https://www.englishclub.com/pronunciation/a-an.htm).