### PR TITLE
Add note about doc consolidation

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,12 +3,7 @@
 [CMake Tools](https://marketplace.visualstudio.com/items?itemName=vector-of-bool.cmake-tools) provides the native developer a full-featured, convenient, and
 powerful workflow for CMake-based projects in Visual Studio Code.
 
-## Maintainer Changes (6/26/20)
-
-We have integrated all of the docs from **vector-of-bool's** site, here!
-Docs for the extension will be maintained in this repo going forward.
-
-# Important doc links:
+## Important doc links
 
 - [CMake Tools quick start](https://code.visualstudio.com/docs/cpp/CMake-linux)
 - [Configure a project](docs/how-to.md#configure-a-project)
@@ -19,11 +14,6 @@ Docs for the extension will be maintained in this repo going forward.
 - [FAQ](docs/faq.md)
 - [Read the online documentation](docs/readme.md)
 - [Contribute](docs/contribute.md)
-
-## Maintainer changes (7/12/19)
-
-**vector-of-bool** has moved on to other things and Microsoft is now maintaining this extension. Thank you **vector-of-bool** for all of your hard work getting
-this extension to where it is today!
 
 ## Issues? Questions? Feature requests?
 

--- a/README.md
+++ b/README.md
@@ -3,22 +3,27 @@
 [CMake Tools](https://marketplace.visualstudio.com/items?itemName=vector-of-bool.cmake-tools) provides the native developer a full-featured, convenient, and
 powerful workflow for CMake-based projects in Visual Studio Code.
 
-## Maintainer Changes (7/12/19)
+## Maintainer Changes (6/26/20)
+
+We have integrated all of the docs from **vector-of-bool's** site, here!
+Docs for the extension will be maintained in this repo going forward.
+
+# Important doc links:
+
+- [CMake Tools quick start](https://code.visualstudio.com/docs/cpp/CMake-linux)
+- [Configure a project](docs/how-to.md#configure-a-project)
+- [Build a project](docs/how-to.md#build-a-project)
+- [Debug a project](docs/how-to.md#debug-a-project)
+- [Configure CMake Tools settings](docs/cmake-settings.md)
+- [How to](docs/how-to.md)
+- [FAQ](docs/faq.md)
+- [Read the online documentation](docs/readme.md)
+- [Contribute](docs/contribute.md)
+
+## Maintainer changes (7/12/19)
 
 **vector-of-bool** has moved on to other things and Microsoft is now maintaining this extension. Thank you **vector-of-bool** for all of your hard work getting
 this extension to where it is today!
-
-# Important Links:
-
-- [Getting started](https://vector-of-bool.github.io/docs/vscode-cmake-tools/getting_started.html)
-- [Configuring a project](https://vector-of-bool.github.io/docs/vscode-cmake-tools/configuring.html)
-- [Building a project](https://vector-of-bool.github.io/docs/vscode-cmake-tools/building.html)
-- [Configuring CMake Tools](https://vector-of-bool.github.io/docs/vscode-cmake-tools/settings.html)
-- [How do I...?](https://vector-of-bool.github.io/docs/vscode-cmake-tools/how_do_i.html)
-- [FAQ](https://vector-of-bool.github.io/docs/vscode-cmake-tools/faq.html)
-- [Read the online documentation](https://vector-of-bool.github.io/docs/vscode-cmake-tools/index.html)
-- [Contributing](https://vector-of-bool.github.io/docs/vscode-cmake-tools/development.html)
-- [Read the changelog](https://vector-of-bool.github.io/docs/vscode-cmake-tools/changelog.html)
 
 ## Issues? Questions? Feature requests?
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # CMake Tools
 
-[CMake Tools](https://marketplace.visualstudio.com/items?itemName=vector-of-bool.cmake-tools) provides the native developer a full-featured, convenient, and
-powerful workflow for CMake-based projects in Visual Studio Code.
+[CMake Tools](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cmake-tools) provides the native developer a full-featured, convenient, and powerful workflow for CMake-based projects in Visual Studio Code.
 
 ## Important doc links
 


### PR DESCRIPTION
<!-- Thanks for your contribution! To make things easier, please fill out the template below. -->

<!-- Please delete any unused sections. -->

### This changes the main readme.md to reflect doc consolidation.

The following changes are proposed:

- Modify readme.md to note that docs will now live here and point to some of the main topics

## The purpose of this change

Let people know that the extension docs live in this repo.