### PR TITLE
Fix i18n Typo (See #794)

### DIFF
--- a/package.nls.json
+++ b/package.nls.json
@@ -67,7 +67,7 @@
     "cmake-tools.configuration.cmake.ctestPath.description": "Path to CTest executable. If null, will be inferred from cmake.cmakePath (recommended to leave null).",
     "cmake-tools.configuration.cmake.ctest.parallelJobs.description": "The number of parallel test jobs. Use zero to use the value of cmake.parallelJobs.",
     "cmake-tools.configuration.cmake.parseBuildDiagnostics.description": "Parse compiler output for warnings and errors.",
-    "cmake-tools.configuration.cmake.enabledOutputParsers.description": "Output parsers to use. Supported parsers 'cmake', 'gcc', 'gnuld' for GNULD-style inker output, 'msvc' for Microsoft Visual C++, and 'ghs' for the Green Hills compiler with --no_wrap_diagnostics --brief_diagnostics.",
+    "cmake-tools.configuration.cmake.enabledOutputParsers.description": "Output parsers to use. Supported parsers 'cmake', 'gcc', 'gnuld' for GNULD-style linker output, 'msvc' for Microsoft Visual C++, and 'ghs' for the Green Hills compiler with --no_wrap_diagnostics --brief_diagnostics.",
     "cmake-tools.configuration.cmake.debugConfig.description": "The debug configuration to use when debugging a target.",
     "cmake-tools.configuration.cmake.debugConfig.symbolSearchPath.description": "Visual Studio debugger symbol search paths.",
     "cmake-tools.configuration.cmake.debugConfig.additionalSOLibSearchPath.description": "Paths for GDB or LLDB to search for .so files.",


### PR DESCRIPTION
<!-- Thanks for your contribution! To make things easier, please fill out the template below. -->

<!-- Please delete any unused sections. -->

<!-- Delete the following heading if there is no corresponding issue -->
## This change addresses item #794

### This changes a typo in the `cmake-tools.configuration.cmake.enabledOutputParsers.description` localization entry.

The following changes are proposed:

| i18n    | Original Term | Proposed Term |
| ------- | ------------- | ------------- |
| **nls** | inker         | linker        |
| **chs** | inker         | ~~链接器~~ (Handled by i18n team)       |
| **trk** | inker         | ~~bağlayıcı~~ (Handled by i18n team)    |

## The purpose of this change

This is a typo and can (and has) affected various i18n files.

## Other Notes/Information

I'm not 100% sure that the correct terms were used for the `chs` and `trk` localization files as I don't speak either of those languages; I was able to confirm that the terms were used by native speakers in various forums, etc., but it would probably be best to have someone double check them.