### PR TITLE
Fix top crash - "Encoding not recognized: 'DOS-862' (searched as: 'dos862')

### DIFF
--- a/package.json
+++ b/package.json
@@ -1603,7 +1603,7 @@
     "typedoc": "^0.15.3",
     "typescript": "^3.7.2",
     "vscode": "^1.1.36",
-    "vscode-nls-dev": "^3.2.6",
+    "vscode-nls-dev": "^3.3.2",
     "webpack": "^4.39.2",
     "webpack-cli": "^3.3.7"
   },
@@ -1612,7 +1612,7 @@
     "chokidar": "^3.3.0",
     "es6-promisify": "~5.0.0",
     "handlebars": "^4.5.3",
-    "iconv-lite": "^0.4.21",
+    "iconv-lite": "^0.6.2",
     "js-yaml": "^3.6.1",
     "json5": "^0.5.1",
     "open": "^6.4.0",

--- a/src/proc.ts
+++ b/src/proc.ts
@@ -161,7 +161,7 @@ export function execute(command: string,
     if (options.encoding)
       child.stdout.setEncoding(options.encoding);
 
-    const encoding = options.outputEncoding ? options.outputEncoding:'utf8';
+    const encoding = options.outputEncoding && iconv.encodingExists(options.outputEncoding) ? options.outputEncoding : 'utf8';
 
     result = new Promise<ExecutionResult>(resolve => {
       if (child) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2445,12 +2445,19 @@ https-proxy-agent@^2.2.1, https-proxy-agent@^2.2.4:
     agent-base "^4.3.0"
     debug "^3.1.0"
 
-iconv-lite@^0.4.19, iconv-lite@^0.4.21:
+iconv-lite@^0.4.19:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
   integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
   dependencies:
     safer-buffer ">= 2.1.2 < 3"
+
+iconv-lite@^0.6.2:
+  version "0.6.2"
+  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.6.2.tgz#ce13d1875b0c3a674bd6a04b7f76b01b1b6ded01"
+  integrity sha512-2y91h5OpQlolefMPmUlivelittSWy0rP+oYVpn6A7GwVHNE8AWzoYOBNmlwks3LobaJxgHCYZAnyNo2GgpNRNQ==
+  dependencies:
+    safer-buffer ">= 2.1.2 < 3.0.0"
 
 ieee754@^1.1.4:
   version "1.1.13"
@@ -4206,7 +4213,7 @@ safe-regex@^1.1.0:
   dependencies:
     ret "~0.1.10"
 
-"safer-buffer@>= 2.1.2 < 3", safer-buffer@^2.0.2, safer-buffer@^2.1.0, safer-buffer@~2.1.0:
+"safer-buffer@>= 2.1.2 < 3", "safer-buffer@>= 2.1.2 < 3.0.0", safer-buffer@^2.0.2, safer-buffer@^2.1.0, safer-buffer@~2.1.0:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
@@ -4908,10 +4915,10 @@ typescript@3.7.x, typescript@^3.7.2:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.5.tgz#0692e21f65fd4108b9330238aac11dd2e177a1ae"
   integrity sha512-/P5lkRXkWHNAbcJIiHPfRoKqyd7bsyCma1hZNUGfn20qm64T6ZBlrzprymeu918H+mB/0rIg2gGK/BXkhhYgBw==
 
-typescript@^2.6.2:
-  version "2.9.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.9.2.tgz#1cbf61d05d6b96269244eb6a3bce4bd914e0f00c"
-  integrity sha512-Gr4p6nFNaoufRIY4NMdpQRNmgxVIGMs4Fcu/ujdYk3nAZqk7supzBE9idmvfZIlH/Cuj//dvi+019qEue9lV0w==
+typescript@^3.9.5:
+  version "3.9.6"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.6.tgz#8f3e0198a34c3ae17091b35571d3afd31999365a"
+  integrity sha512-Pspx3oKAPJtjNwE92YS05HQoY7z2SFyOpHo9MqJor3BXAGNaPUs83CuVp9VISFkSjyRfiTpmKuAYGJB7S7hOxw==
 
 uglify-js@^3.1.4:
   version "3.7.5"
@@ -5164,10 +5171,10 @@ vscode-extension-telemetry@^0.1.2:
   dependencies:
     applicationinsights "1.4.0"
 
-vscode-nls-dev@^3.2.6:
-  version "3.3.1"
-  resolved "https://registry.yarnpkg.com/vscode-nls-dev/-/vscode-nls-dev-3.3.1.tgz#15fc03e0c9ca5a150abb838690d9554ac06f77e4"
-  integrity sha512-fug18D7CXb8pv8JoQ0D0JmZaIYDQoKLiyZxkAy5P8Cln/FwlNsdzwQILDph62EdGY5pvsJ2Jd1T5qgHAExe/tg==
+vscode-nls-dev@^3.3.2:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/vscode-nls-dev/-/vscode-nls-dev-3.3.2.tgz#f15e0b627f948224a96dc0288da3c3b9c6dfae81"
+  integrity sha512-/YJY/LegZ0jsWFd8BforDmXpwWKprM7L3rL0kLEvjQxOJw6qtmnoUJorLIv0ZXjebeyhI3mc8hjmQr479ykLIQ==
   dependencies:
     ansi-colors "^3.2.3"
     clone "^2.1.1"
@@ -5177,7 +5184,7 @@ vscode-nls-dev@^3.2.6:
     iconv-lite "^0.4.19"
     is "^3.2.1"
     source-map "^0.6.1"
-    typescript "^2.6.2"
+    typescript "^3.9.5"
     vinyl "^2.1.0"
     xml2js "^0.4.19"
     yargs "^13.2.4"


### PR DESCRIPTION
We've seen crashes related to a few code pages and this particular code page crash is the top crash for the extension right now.  If the code page is not selectable, we will use utf8 instead.