### PR TITLE
Set application run directory to executable path

### DIFF
--- a/src/cmake-tools.ts
+++ b/src/cmake-tools.ts
@@ -1370,6 +1370,7 @@ export class CMakeTools implements vscode.Disposable, api.CMakeToolsAPI {
     }
     const termOptions: vscode.TerminalOptions = {
       name: 'CMake/Launch',
+      cwd: path.dirname(executable.path),
     };
     if (process.platform == 'win32') {
       // Use cmd.exe on Windows

--- a/src/debugger.ts
+++ b/src/debugger.ts
@@ -60,7 +60,7 @@ async function createGDBDebugConfiguration(debuggerPath: string, target: Executa
     type: 'cppdbg',
     name: `Debug ${target.name}`,
     request: 'launch',
-    cwd: '${workspaceFolder}',
+    cwd: '${fileDirname}',
     args: [],
     MIMode: 'gdb',
     miDebuggerPath: debuggerPath,


### PR DESCRIPTION
## This change addresses item #1395

### This changes run and debugging behavior

The following changes are proposed:

- Run and debug directory set to the application directory.

## The purpose of this change

Now, if the application writes files, then it will not write them to the workspace folder. It will also work correctly if it uses shared objects (plugins), which are copied to its folder. This is how it works in most IDE's.

## Other Notes/Information

I applied changed suggested by @alan-wr. But it works for run without debug. It looks like `cwd: '${workspaceFolder}',` not expanded.

[Testing project.zip](https://github.com/microsoft/vscode-cmake-tools/files/5030816/Test.zip)
