### PR TITLE
Do not care about the bat call result

### DIFF
--- a/src/kit.ts
+++ b/src/kit.ts
@@ -528,18 +528,20 @@ async function collectDevBatVars(devbat: string, args: string[], major_version: 
     `@echo off`,
     `cd /d "%~dp0"`,
     `set "VS${major_version}0COMNTOOLS=${common_dir}"`,
-    `call "${devbat}" ${args.join(' ')} || exit`,
+    `set "INCLUDE="`,
+    `call "${devbat}" ${args.join(' ')}`,
     `cd /d "%~dp0"`, /* Switch back to original drive */
   ];
   for (const envvar of MSVC_ENVIRONMENT_VARIABLES) {
     bat.push(`echo ${envvar} := %${envvar}% >> ${envfname}`);
   }
+  const batContent = bat.join('\r\n');
   const batpath = path.join(paths.tmpDir, batfname);
   const envpath = path.join(paths.tmpDir, envfname);
   try {
     await fs.unlink(envpath);
   } catch (error) {}
-  await fs.writeFile(batpath, bat.join('\r\n'));
+  await fs.writeFile(batpath, batContent);
   const res = await proc.execute(batpath, [], null, {shell: true, silent: true}).result;
   await fs.unlink(batpath);
   const output = (res.stdout) ? res.stdout + (res.stderr || '') : res.stderr;
@@ -552,7 +554,9 @@ async function collectDevBatVars(devbat: string, args: string[], major_version: 
   } catch (error) { log.error(error); }
 
   if (!env || env === '') {
-    console.log(`Error running ${devbat} ${args.join(' ')} with:`, output);
+    log.error(localize('script.run.error',
+        'Error running:{0} with args:{1}\nOutput are:\n{2}\nBat content are:\n{3}',
+        devbat, args.join(' '), output, batContent));
     return;
   }
 
@@ -567,7 +571,9 @@ async function collectDevBatVars(devbat: string, args: string[], major_version: 
           return acc;
         }, new Map());
   if (vars.get('INCLUDE') === '') {
-    console.log(`Error running ${devbat} ${args.join(' ')}, cannot find INCLUDE`);
+    log.error(localize('script.run.error.check',
+        'Error running:{0} with args:{1}\nCannot find INCLUDE within:\n{2}\nBat content are:\n{3}',
+        devbat, args.join(' '), env, batContent));
     return;
   }
   log.debug(localize('ok.running', 'OK running {0} {1}, env vars: {2}', devbat, args.join(' '), JSON.stringify([...vars])));


### PR DESCRIPTION
Thirdparty software would cause
call "C:\Program Files (x86)\Microsoft Visual Studio 11.0\VC\vcvarsall.bat" x86
to be called but with error code
and the env are still set properly.
The following are the execute result:
```
configuration might not be installed.

C:\Users\大乖>call "C:\Program Files (x86)\Microsoft Visual Studio 11.0\VC\vcvarsall.bat" x86
'MySQL' 不是内部或外部命令，也不是可运行的程序
或批处理文件。
'MySQL' 不是内部或外部命令，也不是可运行的程序
或批处理文件。
```

<!-- Thanks for your contribution! To make things easier, please fill out the template below. -->

<!-- Please delete any unused sections. -->

<!-- Delete the following heading if there is no corresponding issue -->
## This change addresses item #[[put issue number here to generate a link]]

### This changes [[visible behavior/performance/documentation/etc.]]

The following changes are proposed:

- <!-- Put something here -->
- <!-- And maybe here -->
- <!-- Add or remove bullets as you need -->

## The purpose of this change

<!-- If not linked to an issue, describe the purpose of this change. Otherwise,
delete this section. -->

## Other Notes/Information

<!-- Write whatever you feel is relevant -->
