### PR TITLE
Allow code model minor version to be higher than expected

### DIFF
--- a/src/drivers/cmakefileapi/api_helpers.ts
+++ b/src/drivers/cmakefileapi/api_helpers.ts
@@ -106,7 +106,7 @@ export async function loadCodeModelContent(filename: string): Promise<index_api.
   const expected_version = {major: 2, minor: 0};
   const detected_version = codemodel.version;
 
-  if (detected_version.major != expected_version.major || detected_version.minor != expected_version.minor) {
+  if (detected_version.major != expected_version.major || detected_version.minor < expected_version.minor) {
     log.warning(localize(
         'code.model.version',
         'Code model version ({0}.{1}) of cmake-file-api is unexpected. Expecting ({2}.{3}). IntelliSense configuration may be incorrect.',


### PR DESCRIPTION
b6884ea5 allowed the cache object minor version to be higher than
expected, but did not do the same for the code model. Fix this.

Fixes: #1341
