### PR TITLE
Allow cmake.debugConfig to override the cwd for "run without debugging"

### DIFF
--- a/src/cmake-tools.ts
+++ b/src/cmake-tools.ts
@@ -1368,9 +1368,10 @@ export class CMakeTools implements vscode.Disposable, api.CMakeToolsAPI {
       // a target.
       return null;
     }
+    const user_config = this.workspaceContext.config.debugConfig;
     const termOptions: vscode.TerminalOptions = {
       name: 'CMake/Launch',
-      cwd: path.dirname(executable.path),
+      cwd: (user_config && user_config.cwd) || path.dirname(executable.path),
     };
     if (process.platform == 'win32') {
       // Use cmd.exe on Windows


### PR DESCRIPTION
#1395