### PR TITLE
support non-trivial command-lines for Compile Active File

### DIFF
--- a/src/compdb.ts
+++ b/src/compdb.ts
@@ -1,5 +1,3 @@
-import * as shlex from '@cmt/shlex';
-
 import {createLogger} from './logging';
 import {fs} from './pr';
 import * as util from './util';
@@ -16,7 +14,7 @@ interface BaseCompileCommand {
   output?: string;
 }
 
-interface StringCompileCommand extends BaseCompileCommand {
+export interface StringCompileCommand extends BaseCompileCommand {
   command: string;
 }
 
@@ -27,16 +25,16 @@ interface ArgsCompileCommand extends BaseCompileCommand {
 export type CompileCommand = StringCompileCommand|ArgsCompileCommand;
 
 export class CompilationDatabase {
-  private readonly _infoByFilePath: Map<string, ArgsCompileCommand>;
-  constructor(infos: CompileCommand[]) {
+  private readonly _infoByFilePath: Map<string, StringCompileCommand>;
+  constructor(infos: StringCompileCommand[]) {
     this._infoByFilePath = infos.reduce(
         (acc, cur) => acc.set(util.platformNormalizePath(cur.file), {
           directory: cur.directory,
           file: cur.file,
           output: cur.output,
-          arguments: 'arguments' in cur ? cur.arguments : [...shlex.split(cur.command)],
+          command: cur.command,
         }),
-        new Map<string, ArgsCompileCommand>(),
+        new Map<string, StringCompileCommand>(),
     );
   }
 
@@ -48,7 +46,7 @@ export class CompilationDatabase {
     }
     const data = await fs.readFile(dbpath);
     try {
-      const content = JSON.parse(data.toString()) as CompileCommand[];
+      const content = JSON.parse(data.toString()) as StringCompileCommand[];
       return new CompilationDatabase(content);
     } catch (e) {
       log.warning(localize('error.parsing.compilation.database', 'Error parsing compilation database "{0}": {1}', dbpath, util.errorToString(e)));

--- a/src/drivers/driver.ts
+++ b/src/drivers/driver.ts
@@ -9,7 +9,7 @@ import * as api from '@cmt/api';
 import {CMakeExecutable} from '@cmt/cmake/cmake-executable';
 import * as codepages from '@cmt/code-pages';
 import {ConfigureTrigger} from "@cmt/cmake-tools";
-import {CompileCommand} from '@cmt/compdb';
+import {StringCompileCommand} from '@cmt/compdb';
 import {ConfigurationReader} from '@cmt/config';
 import {CMakeBuildConsumer, CompileOutputConsumer} from '@cmt/diagnostics/build';
 import {CMakeOutputConsumer} from '@cmt/diagnostics/cmake';
@@ -22,7 +22,6 @@ import paths from '@cmt/paths';
 import {fs} from '@cmt/pr';
 import * as proc from '@cmt/proc';
 import rollbar from '@cmt/rollbar';
-import * as shlex from '@cmt/shlex';
 import * as telemetry from '@cmt/telemetry';
 import * as util from '@cmt/util';
 import {ConfigureArguments, VariantOption} from '@cmt/variant';
@@ -267,11 +266,7 @@ export abstract class CMakeDriver implements vscode.Disposable {
    * Launch the given compilation command in an embedded terminal.
    * @param cmd The compilation command from a compilation database to run
    */
-  runCompileCommand(cmd: CompileCommand): vscode.Terminal {
-    if ('command' in cmd) {
-      const args = [...shlex.split(cmd.command)];
-      return this.runCompileCommand({directory: cmd.directory, file: cmd.file, arguments: args});
-    } else {
+  runCompileCommand(cmd: StringCompileCommand): vscode.Terminal {
       const env = this.getEffectiveSubprocessEnvironment();
       const key = `${cmd.directory}${JSON.stringify(env)}`;
       let existing = this._compileTerms.get(key);
@@ -292,9 +287,8 @@ export abstract class CMakeDriver implements vscode.Disposable {
         existing = term;
       }
       existing.show();
-      existing.sendText(cmd.arguments.map(s => shlex.quote(s)).join(' ') + '\r\n');
+      existing.sendText(cmd.command + '\r\n');
       return existing;
-    }
   }
 
   /**


### PR DESCRIPTION
In particular macro definitions containing quotes and spaces.
The code was trying to be too clever, splitting the commandline into arguments and re-merging (the split args weren't even used/modified).
Just let the shell do its job.
NB: this doesn't fix https://github.com/microsoft/vscode-cmake-tools/issues/1227#issuecomment-706111287

@bobbrow @andreeis