### PR TITLE
Duplicate compiler flags should not be removed

### DIFF
--- a/src/cpptools.ts
+++ b/src/cpptools.ts
@@ -504,7 +504,7 @@ export class CppConfigurationProvider implements cpt.CustomConfigurationProvider
           /// 3. Any `fileGroup` that does not have the associated attribute will receive the `default`
           const grps = target.fileGroups || [];
           const includePath = [...new Set(util.flatMap(grps, grp => grp.includePath || []))].map(item => item.path);
-          const compileFlags = [...new Set(util.flatMap(grps, grp => shlex.split(grp.compileFlags || '')))];
+          const compileFlags = [...util.flatMap(grps, grp => shlex.split(grp.compileFlags || ''))];
           const defines = [...new Set(util.flatMap(grps, grp => grp.defines || []))];
           const sysroot = target.sysroot || '';
           for (const grp of target.fileGroups || []) {


### PR DESCRIPTION
It looks like CMake Tools is removing duplicate compiler flags from the browse config.  Compiler flags are contextual, so none should be removed.

For example, there are various compiler args that themselves receive the next arg.  (i.e. `-include`, `-x`, `-Xclang`, `-Xlinker`).  In my case, multiple `-Xclang` uses were generated by CMake.  `-Xclang -gcodeview -Xclang --dependent-lib=msvcrtd`.  After one of those `-Xclang`'s was removed, cpptools attempted to use the browse config to probe `clang.exe` with `-Xclang -gcodeview --dependent-lib=msvcrtd`, resulting in an error that `--dependent-lib=msvcrtd` was not recognized (as it's only valid after a `-Xclang`)

This appears to only be a problem with the browse config.  Individual custom configs appear to include duplicates.

