### PR TITLE
Audit for immediate effect of settings

### DIFF
--- a/src/cmake-tools.ts
+++ b/src/cmake-tools.ts
@@ -152,6 +152,21 @@ export class CMakeTools implements vscode.Disposable, api.CMakeToolsAPI {
   private readonly _codeModel = new Property<codemodel_api.CodeModelContent|null>(null);
   private _codeModelDriverSub: vscode.Disposable|null = null;
 
+  private readonly _communicationModeSub = this.workspaceContext.config.onChange('cmakeCommunicationMode', () => {
+    log.info(localize('communication.changed.restart.driver', "Restarting the CMake driver after a communication mode change."));
+    return this._reloadCMakeDriver();
+  });
+
+  private readonly _generatorSub = this.workspaceContext.config.onChange('generator', () => {
+    log.info(localize('generator.changed.restart.driver', "Restarting the CMake driver after a generator change."));
+    return this._reloadCMakeDriver();
+  });
+
+  private readonly _preferredGeneratorsSub = this.workspaceContext.config.onChange('preferredGenerators', () => {
+    log.info(localize('preferredGenerator.changed.restart.driver', "Restarting the CMake driver after a preferredGenerators change."));
+    return this._reloadCMakeDriver();
+  });
+
   /**
    * The variant manager keeps track of build variants. Has two-phase init.
    */
@@ -190,6 +205,9 @@ export class CMakeTools implements vscode.Disposable, api.CMakeToolsAPI {
     this._termCloseSub.dispose();
     if (this._launchTerminal) {
       this._launchTerminal.dispose();
+    }
+    for (const sub of [this._generatorSub, this._preferredGeneratorsSub, this._communicationModeSub]) {
+      sub.dispose();
     }
     rollbar.invokeAsync(localize('extension.dispose', 'Extension dispose'), () => this.asyncDispose());
   }
@@ -425,14 +443,14 @@ export class CMakeTools implements vscode.Disposable, api.CMakeToolsAPI {
   /**
    * Reload/restarts the CMake Driver
    */
-  // private async _reloadCMakeDriver() {
-  //   log.debug(localize('reloading.driver', 'Reloading CMake driver'));
-  //   const drv = await this._cmakeDriver;
-  //   log.debug(localize('disposing.old.driver', 'Diposing old CMake driver'));
-  //   await drv.asyncDispose();
-  //   return this._cmakeDriver = this._startNewCMakeDriver();
-  // }
-
+  private async _reloadCMakeDriver() {
+    const drv = await this._cmakeDriver;
+    if (drv) {
+      log.debug(localize('reloading.driver', 'Reloading CMake driver'));
+      await drv.asyncDispose();
+      return this._cmakeDriver = this._startNewCMakeDriver(await this.getCMakeExecutable());
+    }
+  }
   /**
    * Second phase of two-phase init. Called by `create`.
    */

--- a/src/util.ts
+++ b/src/util.ts
@@ -577,7 +577,6 @@ export function reportProgress(progress: ProgressHandle|undefined, message: stri
 
 export function chokidarOnAnyChange(watcher: chokidar.FSWatcher, listener: (path: string, stats?: fs.Stats | undefined) => void) {
   return watcher.on('add', listener)
-                .on('raw', listener)
                 .on('change', listener)
                 .on('unlink', listener);
 }


### PR DESCRIPTION
Ensure immediate effect for settings: cmakeCommunicationMode, generator and preferredGenerators.
More to be investigated and eventually fixed in a following commit.

Also reverted #1417 since we need to fix it in a different way.
Opened #1498 to track the alternative fix of the above PR.