### PR TITLE
Hide "Unknown language: ..." occurring for CUDA source files

### DIFF
--- a/src/cpptools.ts
+++ b/src/cpptools.ts
@@ -165,7 +165,7 @@ export function parseCompileFlags(cptVersion: cpt.Version, args: string[], lang?
       extraDefinitions.push(def);
     } else if (value.startsWith('-std=') || lower.startsWith('-std:') || lower.startsWith('/std:')) {
       const std = value.substring(5);
-      if (lang === 'CXX' || lang === 'OBJCXX' ) {
+      if (lang === 'CXX' || lang === 'OBJCXX' || lang === 'CUDA' ) {
         const s = parseCppStandard(std, can_use_gnu_std);
         if (s === null) {
           log.warning(localize('unknown.control.gflag.cpp', 'Unknown C++ standard control flag: {0}', value));

--- a/src/cpptools.ts
+++ b/src/cpptools.ts
@@ -190,7 +190,7 @@ export function parseCompileFlags(cptVersion: cpt.Version, args: string[], lang?
           standard = s;
         }
       } else {
-        log.warning(localize('unknown language', 'Unknown language: {0}', value));
+        log.warning(localize('unknown language', 'Unknown language: {0}', lang));
       }
     }
   }


### PR DESCRIPTION
**Addresses the useless message "Unknown language..." shown for CUDA source files, cf #1428**

**Details**: when parsing compiler flags, in particular for the C++ standard flag, we need to account for CUDA. According to the nvcc documentation here: https://docs.nvidia.com/cuda/cuda-compiler-driver-nvcc/index.html#options-for-altering-compiler-linker-behavior-std , nvcc accepts the same C++ standard command line options than gcc/clang. Thus we can simply handle it as for C++, and this avoid getting the message "Unknown language: -std=c++14" (for example) once for each *.cu

**Test**: Here is a sample folder containing `CMakeLists.txt` and `main.cu`: [test-cmake-tools-cuda.zip](https://github.com/microsoft/vscode-cmake-tools/files/5428063/test-cmake-tools-cuda.zip)