### PR TITLE
Cache GUI localization and UI changes

### DIFF
--- a/src/cache-view.ts
+++ b/src/cache-view.ts
@@ -162,45 +162,17 @@ export class ConfigurationWebview {
               border: 1px solid var(--vscode-settings-dropdownBorder);
           }
 
-          .cmake-input-string {
-              position: relative;
-              background-color: var(--vscode-settings-textInputBackground);
-              color: var(--vscode-settings-textInputForeground);
-              width: 800px;
-              height: 25px;
+          input {
+            height: 17px;
+            padding: 6px;
+            border: solid 1px;
+            font-size: 13px;
+            font-family: Menlo, Monaco, Consolas, "Droid Sans Mono", "Courier New", monospace, "Droid Sans Fallback";
+            color: var(--vscode-settings-textInputForeground);
+            background: var(--vscode-settings-textInputBackground);
+            border: 1px solid var(--vscode-settings-textInputBorder);
           }
 
-          .cmake-input-string select {
-              position: absolute;
-              font-size: 13px;
-              font-family: sans-serif;
-              border: 1px solid var(--vscode-settings-textInputBorder);
-              height: 25px;
-              margin: auto;
-              color: var(--vscode-settings-textInputForeground);
-              background: var(--vscode-settings-textInputBackground);
-          }
-
-          .cmake-input-string input {
-              position: absolute;
-              top: 1px;
-              left: 1px;
-              right: 1px;
-              bottom: 1px;
-              height: 25px;
-              font-size: 13px;
-              border: none;
-              color: var(--vscode-settings-textInputForeground);
-              background: var(--vscode-settings-textInputBackground);
-          }
-
-          .cmake-input-string select:focus,
-          .cmake-input-string input:focus {
-              outline-offset: 0px;
-              border-color: var(--vscode-focusBorder);
-              contrastBorder: var(--vscode-focusBorder);
-              contrastActiveBorder: var(--vscode-focusBorder);
-          }
           .vscode-light .input-disabled {
               background-color:rgba(255, 255, 255, 0.4);
               color: rgb(138, 138, 138);
@@ -226,7 +198,6 @@ export class ConfigurationWebview {
               border-color: #000
           }
 
-
           .vscode-light {
               color: #1e1e1e
           }
@@ -236,12 +207,13 @@ export class ConfigurationWebview {
           .vscode-high-contrast {
               color: #fff
           }
-          .vscode-light table {
-            border: 1px solid;
+          .vscode-light table,
+          .vscode-high-contrast table {
+            border: 1px solid var(--vscode-settings-textInputBorder);
             border-collapse: collapse;
           }
           .vscode-dark table {
-            border: 1px solid;
+            border: 1px solid rgb(255,255,255,0.3);
             border-collapse: collapse;
           }
           .container {
@@ -252,17 +224,12 @@ export class ConfigurationWebview {
           }
           tr {
             height: 25px;
+          }
+          .vscode-light th {
+            background: rgba(0,0,0,.1);
+          }
+          .vscode-dark th {
             background: rgba(255,255,255,.1);
-            border-bottom: 1px solid rgba(255,255,255,0.045);
-          }
-          tr.content-tr:hover {
-            background: rgba(255, 255, 255, .25);
-          }
-          .vscode-light table > tr > th {
-            background: rgba(0, 0, 0, .69)
-          }
-          .vscode-dark table > tr > th {
-            background: rgba(255, 255, 255, .69)
           }
           input#search {
             width: 98%;
@@ -275,8 +242,7 @@ export class ConfigurationWebview {
           .invisible {
             display: none;
           }
-          .vscode-light button#save,
-          .vscode-dark button#save {
+          button#save {
             float: right;
             padding: 10px 25px;
             margin-top: 15px;
@@ -287,15 +253,13 @@ export class ConfigurationWebview {
             border: solid 1px var(--vscode-contrastBorder);
             transition: 100ms ease-in-out;
           }
-          .vscode-light button#save:hover,
-          .vscode-dark button#save:hover {
+          button#save:hover {
             cursor: pointer;
             background-color: var(--vscode-button-hoverBackground);
           }
-          .vscode-light button#save:focus,
-          .vscode-light button#save input:focus,
-          .vscode-light button#save select:focus,
-          .vscode-dark button#save:focus {
+          button#save:focus,
+          button#save input:focus,
+          button#save select:focus {
             outline: 1px solid -webkit-focus-ring-color;
             outline-offset: 2px;
             border-color: var(--vscode-focusBorder);
@@ -303,8 +267,7 @@ export class ConfigurationWebview {
             contrastBorder: var(--vscode-focusBorder);
             contrastActiveBorder: var(--vscode-focusBorder);
           }
-          .vscode-light button#save:active,
-          .vscode-dark button#save:active {
+          button#save:active {
             outline: none;
           }
 
@@ -404,7 +367,7 @@ export class ConfigurationWebview {
         <td></td>
         <td>${option.key}</td>
         <td>
-          <input class="cmake-input-string" id="${option.key}" value="${option.value}" style="width: 90%;"
+          <input id="${option.key}" value="${option.value}" style="width: 90%;"
                  type="text" onfocusout="editFocusOut('${option.key}')" onblur="editFocusOut('${option.key}')">
         </td>
       </tr>`;

--- a/src/cache-view.ts
+++ b/src/cache-view.ts
@@ -127,6 +127,81 @@ export class ConfigurationWebview {
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <title>${this.cmakeCacheEditorText}</title>
         <style>
+          .select-default {
+              width: 300px;
+              height: 25px;
+              font-size: 13px;
+              font-family:sans-serif;
+              color: var(--vscode-settings-dropdownForeground);
+              background: var(--vscode-settings-dropdownBackground);
+              border: 1px solid var(--vscode-settings-dropdownBorder);
+          }
+
+          .cmake-input-string {
+              position: relative;
+              background-color: var(--vscode-settings-textInputBackground);
+              color: var(--vscode-settings-textInputForeground);
+              width: 800px;
+              height: 25px;
+          }
+
+          .cmake-input-string select {
+              position: absolute;
+              font-size: 13px;
+              font-family: sans-serif;
+              border: 1px solid var(--vscode-settings-textInputBorder);
+              height: 25px;
+              margin: auto;
+              color: var(--vscode-settings-textInputForeground);
+              background: var(--vscode-settings-textInputBackground);
+          }
+
+          .cmake-input-string input {
+              position: absolute;
+              top: 1px;
+              left: 1px;
+              right: 1px;
+              bottom: 1px;
+              height: 25px;
+              font-size: 13px;
+              border: none;
+              color: var(--vscode-settings-textInputForeground);
+              background: var(--vscode-settings-textInputBackground);
+          }
+
+          .cmake-input-string select:focus,
+          .cmake-input-string input:focus {
+              outline-offset: 0px;
+              border-color: var(--vscode-focusBorder);
+              contrastBorder: var(--vscode-focusBorder);
+              contrastActiveBorder: var(--vscode-focusBorder);
+          }
+          .vscode-light .input-disabled {
+              background-color:rgba(255, 255, 255, 0.4);
+              color: rgb(138, 138, 138);
+              border: solid 1px rgb(201, 198, 198);
+          }
+
+          .vscode-dark .input-disabled {
+              background-color: rgba(255, 255, 255, 0.1);
+              color: rgb(167, 167, 167);
+          }
+
+          .vscode-high-contrast .input-disabled {
+               background-color: transparent;
+               color: #fff;
+               border: solid 1px rgb(255, 255, 255);
+          }
+
+          .vscode-high-contrast code > div {
+              background-color: #000
+          }
+
+          .vscode-high-contrast h1 {
+              border-color: #000
+          }
+
+
           .vscode-light {
               color: #1e1e1e
           }
@@ -151,7 +226,7 @@ export class ConfigurationWebview {
             margin: 30px auto;
           }
           tr {
-            height: 30px;
+            height: 25px;
             background: rgba(255,255,255,.1);
             border-bottom: 1px solid rgba(255,255,255,0.045);
           }
@@ -168,39 +243,76 @@ export class ConfigurationWebview {
             width: 98%;
             padding: 11px 0px 11px 11px;
             margin: 10px 0;
+            color: var(--vscode-settings-textInputForeground);
+            background: var(--vscode-settings-textInputBackground);
+            border: 1px solid var(--vscode-settings-textInputBorder);
           }
           .invisible {
             display: none;
           }
-          .vscode-light button#save {
-            float: right;
-            padding: 10px 25px;
-            margin-top: 15px;
-            background: none;
-            color: black;
-            text-transform: uppercase;
-            font-weight: bold;
-            border: 1px solid #1e1e1e;
-            transition: 100ms ease-in-out;
-          }
+          .vscode-light button#save,
           .vscode-dark button#save {
             float: right;
             padding: 10px 25px;
             margin-top: 15px;
-            background: none;
-            color: white;
+            background: var(--vscode-button-background);
+            color: var(--vscode-button-foreground);
             text-transform: uppercase;
             font-weight: bold;
-            border: 1px solid #ddd;
+            border: solid 1px var(--vscode-contrastBorder);
             transition: 100ms ease-in-out;
           }
-          .vscode-light button#save:hover {
-            cursor: pointer;
-            background: #ddd;
-          }
+          .vscode-light button#save:hover,
           .vscode-dark button#save:hover {
             cursor: pointer;
-            background: #333;
+            background-color: var(--vscode-button-hoverBackground);
+          }
+          .vscode-light button#save:focus,
+          .vscode-light button#save input:focus,
+          .vscode-light button#save select:focus,
+          .vscode-dark button#save:focus {
+            outline: 1px solid -webkit-focus-ring-color;
+            outline-offset: 2px;
+            border-color: var(--vscode-focusBorder);
+            border: var(--vscode-focusBorder);
+            contrastBorder: var(--vscode-focusBorder);
+            contrastActiveBorder: var(--vscode-focusBorder);
+          }
+          .vscode-light button#save:active,
+          .vscode-dark button#save:active {
+            outline: none;
+          }
+
+          checkbox:active,
+          checkbox {
+            color: var(--vscode-settings-checkboxForeground);
+            background: var(--vscode-settings-checkboxForeground);
+            border: var(--vscode-settings-checkboxBorder);
+          }
+
+          .vscode-light cmake-input-bool input:checked,
+          .vscode-dark cmake-input-bool {
+            color: var(--vscode-settings-checkboxForeground);
+            background: var(--vscode-settings-checkboxForeground);
+            border: var(--vscode-settings-checkboxBorder);
+          }
+
+          .cmake-input-bool input:checked,
+          .cmake-input-bool:active,
+          .cmake-input-bool {
+            color: var(--vscode-settings-checkboxForeground);
+            background: var(--vscode-settings-checkboxForeground);
+            border: var(--vscode-settings-checkboxBorder);
+          }
+          a:focus,
+          input:focus,
+          select:focus,
+          textarea:focus {
+              outline: 1px solid -webkit-focus-ring-color;
+              outline-offset: -1px;
+              border-color: var(--vscode-focusBorder);
+              contrastBorder: var(--vscode-focusBorder);
+              contrastActiveBorder: var(--vscode-focusBorder);
           }
         </style>
         <script>
@@ -240,7 +352,7 @@ export class ConfigurationWebview {
         <h1>${this.cmakeCacheEditorText}<span class="invisible" id="not-saved">*</span></h1>
         <input class="search" type="text" id="search" oninput="search()" placeholder="${searchButtonText}" autofocus>
         <table style="width:100%">
-          <tr style="height: 35px;">
+          <tr style="height: 25px;">
             <th style="width: 30px"></th>
             <th style="width: 1px; white-space: nowrap;">${keyColumnText}</th>
             <th>${valueColumnText}</th>

--- a/src/cache-view.ts
+++ b/src/cache-view.ts
@@ -18,9 +18,9 @@ export interface IOption {
  * This object manages the webview rendering.
  */
 export class ConfigurationWebview {
-
-  WINDOW_TITLE = 'CMake Cache Editor';
-  WINDOW_TITLE_UNSAVED = 'CMake Cache Editor*';
+  private readonly cmakeCacheEditorText = localize("cmake.cache.editor", "CMake Cache Editor");
+  WINDOW_TITLE = this.cmakeCacheEditorText;
+  WINDOW_TITLE_UNSAVED = `${this.cmakeCacheEditorText}*`;
 
   private readonly _panel: vscode.WebviewPanel;
   get panel() {
@@ -31,7 +31,7 @@ export class ConfigurationWebview {
       protected save: () => void) {
     this._panel = vscode.window.createWebviewPanel(
       'cmakeConfiguration', // Identifies the type of the webview. Used internally
-      'CMake Cache Editor', // Title of the panel displayed to the user
+      this.cmakeCacheEditorText, // Title of the panel displayed to the user
       vscode.ViewColumn.One, // Editor column to show the new webview panel in.
       {
         // this is needed for the html view to trigger events in the extension
@@ -112,13 +112,20 @@ export class ConfigurationWebview {
    */
   getWebviewMarkup(options: IOption[]) {
     const key = '%TABLE_ROWS%';
+    const searchButtonText = localize("search", "Search");
+    const saveButtonText = localize("save", "Save");
+    const keyColumnText = localize ("key", "Key");
+    const valueColumnText = localize("value", "Value");
+    const onButtonText = localize("on", "ON");
+    const offButtonText = localize("off", "OFF");
+
     let html = `
     <!DOCTYPE html>
     <html lang="en">
     <head>
         <meta charset="UTF-8">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <title>CMake Cache Editor</title>
+        <title>${this.cmakeCacheEditorText}</title>
         <style>
           .vscode-light {
               color: #1e1e1e
@@ -200,7 +207,7 @@ export class ConfigurationWebview {
           const vscode = acquireVsCodeApi();
           function toggleKey(id) {
             const label = document.getElementById('LABEL_' + id);
-            label.textContent = label.textContent == 'ON' ? 'OFF' : 'ON';
+            label.textContent = label.textContent == '${onButtonText}' ? '${offButtonText}' : '${onButtonText}';
             vscode.postMessage(false);
             document.getElementById('not-saved').classList.remove('invisible');
           }
@@ -229,14 +236,14 @@ export class ConfigurationWebview {
     </head>
     <body>
       <div class="container">
-        <button id="save" onclick="save()">Save</button>
-        <h1>CMake Cache Editor<span class="invisible" id="not-saved">*</span></h1>
-        <input class="search" type="text" id="search" oninput="search()" placeholder="Search" autofocus>
+        <button id="save" onclick="save()">${saveButtonText}</button>
+        <h1>${this.cmakeCacheEditorText}<span class="invisible" id="not-saved">*</span></h1>
+        <input class="search" type="text" id="search" oninput="search()" placeholder="${searchButtonText}" autofocus>
         <table style="width:100%">
           <tr style="height: 35px;">
             <th style="width: 30px"></th>
-            <th style="width: 1px; white-space: nowrap;">Key</th>
-            <th>Value</th>
+            <th style="width: 1px; white-space: nowrap;">${keyColumnText}</th>
+            <th>${valueColumnText}</th>
           </tr>
           ${key}
         </table>
@@ -253,7 +260,7 @@ export class ConfigurationWebview {
         <td>
           <input class="cmake-input-bool" id="${option.key}" onclick="toggleKey('${option.key}')"
                  type="checkbox" ${util.isTruthy(option.value) ? 'checked' : ''}>
-          <label id="LABEL_${option.key}" for="${option.key}">${util.isTruthy(option.value) ? 'ON' : 'OFF'}</label>
+          <label id="LABEL_${option.key}" for="${option.key}">${util.isTruthy(option.value) ? `${onButtonText}` : `${offButtonText}`}</label>
         </td>
       </tr>`;
       } else {

--- a/src/cache-view.ts
+++ b/src/cache-view.ts
@@ -130,9 +130,9 @@ export class ConfigurationWebview {
       const fromCache = localize('from.cache', 'From Cache');
       if (conflictsExist) {
         result = await vscode.window.showWarningMessage(
-          localize('merge.cache.edits', "The CMake cache has been modified outside this webview " +
-            "and there are conflicts with the current unsaved edits." +
-            "Which values do you want to keep?"), ignore, fromCache, fromUI);
+          localize('merge.cache.edits', "The CMake cache has been modified outside this webview \
+                                         and there are conflicts with the current unsaved edits. \
+                                         Which values do you want to keep?"), ignore, fromCache, fromUI);
         if (result === fromUI) {
           this._options = mergedOptions;
           await this.persistCacheEntries();


### PR DESCRIPTION
Make sure all the strings in the cache GUI are localized.
Change the UI appearance so that the web view looks more similar with CppTools.
I was not able so far to change the following:
- the active border (the border when any UI element is in focus). For CppTools is blue, for CMake Tools is a yellow/orange but I tried to change it in various ways without success
- the checkboxes have a blue background when set and remain in sync with the current theme when not set. CppTools checkboxes are in sync with the current theme also when set.