### PR TITLE
Fix variable value regexp and add test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # What's New?
 
+## 1.5.1
+Bug Fixes:
+- Fix regular expression for variables values used in settings and kits json. [#1526](https://github.com/microsoft/vscode-cmake-tools/issues/1526) [#1525](https://github.com/microsoft/vscode-cmake-tools/issues/1525)
+- Add a setting to control whether the Touch Bar is visible or not. [PR 1529#](https://github.com/microsoft/vscode-cmake-tools/pull/1529)
+
 ## 1.5.0
 Improvements:
 - Support variables for Kit.toolchainFile. [PR #991](https://github.com/microsoft/vscode-cmake-tools/pull/991) [#1056](https://github.com/microsoft/vscode-cmake-tools/issues/1056) [@blakehurd](https://github.com/blakehurd)/[@bobbrow](https://github.com/bobbrow)

--- a/package.json
+++ b/package.json
@@ -1680,7 +1680,7 @@
     "@types/xml2js": "^0.0.28",
     "chai": "^4.1.2",
     "chai-as-promised": "^7.1.1",
-    "chai-string": "^1.5.1",
+    "chai-string": "^1.5.0",
     "clang-format": "^1.2.2",
     "event-stream": "^4.0.1",
     "fs-extra": "^8.1.0",

--- a/package.json
+++ b/package.json
@@ -1680,7 +1680,7 @@
     "@types/xml2js": "^0.0.28",
     "chai": "^4.1.2",
     "chai-as-promised": "^7.1.1",
-    "chai-string": "^1.5.0",
+    "chai-string": "^1.5.1",
     "clang-format": "^1.2.2",
     "event-stream": "^4.0.1",
     "fs-extra": "^8.1.0",

--- a/src/expand.ts
+++ b/src/expand.ts
@@ -92,7 +92,11 @@ export async function expandString(tmpl: string, opts: ExpansionOptions) {
     }
   }
 
-  const env_re = /\$\{env:(.+)\}/g;
+  // Regular expression for variable value (between the variable suffix and the next ending curly bracket):
+  // .+? matches any character (except line terminators) between one and unlimited times,
+  // as few times as possible, expanding as needed (lazy)
+  const varValueRegexp = ".+?";
+  const env_re = RegExp(`\\$\\{env:(${varValueRegexp})\\}`, "g");
   while ((mat = env_re.exec(tmpl))) {
     const full = mat[0];
     const varname = mat[1];
@@ -100,7 +104,7 @@ export async function expandString(tmpl: string, opts: ExpansionOptions) {
     subs.set(full, repl);
   }
 
-  const env_re2 = /\$\{env\.(.+)\}/g;
+  const env_re2 = RegExp(`\\$\\{env\\.(${varValueRegexp})\\}`, "g");
   while ((mat = env_re2.exec(tmpl))) {
     const full = mat[0];
     const varname = mat[1];
@@ -109,7 +113,7 @@ export async function expandString(tmpl: string, opts: ExpansionOptions) {
   }
 
   if (vscode.workspace.workspaceFolders && vscode.workspace.workspaceFolders.length > 0) {
-    const folder_re = /\$\{workspaceFolder:(.+)\}/g;
+    const folder_re = RegExp(`\\$\\{workspaceFolder:(${varValueRegexp})\\}`, "g");
     while (mat = folder_re.exec(tmpl)) {
       const full = mat[0];
       const folderName = mat[1];
@@ -122,7 +126,7 @@ export async function expandString(tmpl: string, opts: ExpansionOptions) {
 
   if (opts.variantVars) {
     const variants = opts.variantVars;
-    const variant_regex = /\$\{variant:(.+)\}/g;
+    const variant_regex = RegExp(`\\$\\{variant:(${varValueRegexp})\\}`, "g");
     while ((mat = variant_regex.exec(tmpl))) {
       const full = mat[0];
       const varname = mat[1];
@@ -131,7 +135,7 @@ export async function expandString(tmpl: string, opts: ExpansionOptions) {
     }
   }
 
-  const command_re = /\$\{command:(.+)\}/g;
+  const command_re = RegExp(`\\$\\{command:(${varValueRegexp})\\}`, "g");
   while ((mat = command_re.exec(tmpl))) {
     const full = mat[0];
     const command = mat[1];

--- a/test/unit-tests/kitmanager.test.ts
+++ b/test/unit-tests/kitmanager.test.ts
@@ -42,6 +42,7 @@ suite('Kits test', async () => {
 
     expect(kits.filter(k => "ToolchainKit 2" === k.name)[0].toolchainFile).to.eq("Test/toolchain.cmake");
     expect(kits.filter(k => "ToolchainKit 3" === k.name)[0].toolchainFile).to.eq(`${folderName}/toolchain.cmake`);
+    expect(kits.filter(k => "ToolchainKit 4" === k.name)[0].toolchainFile).to.eq(`${folderName}/Test/toolchain.cmake`);
   });
 
   test('Test load env vars from shell script', async() => {

--- a/test/unit-tests/kitmanager.test.ts
+++ b/test/unit-tests/kitmanager.test.ts
@@ -30,6 +30,7 @@ suite('Kits test', async () => {
       'ToolchainKit 1',
       'ToolchainKit 2',
       'ToolchainKit 3',
+      'ToolchainKit 4',
       'VSCode Kit 1',
       'VSCode Kit 2',
     ]);

--- a/test/unit-tests/test_kit.json
+++ b/test/unit-tests/test_kit.json
@@ -35,8 +35,8 @@
     {
       "name": "ToolchainKit 4",
       "toolchainFile": "${workspaceFolder:test-project-without-cmakelists}/${env:CMAKE_TOOLS_TEST_SOME_ENV_VAR}/toolchain.cmake"
-  },
-  {
+    },
+    {
         "name": "VSCode Kit 1",
         "visualStudio": "Visual Studio 2015",
         "visualStudioArchitecture": "x86"

--- a/test/unit-tests/test_kit.json
+++ b/test/unit-tests/test_kit.json
@@ -33,6 +33,10 @@
         "toolchainFile": "${workspaceFolder:test-project-without-cmakelists}/toolchain.cmake"
     },
     {
+      "name": "ToolchainKit 4",
+      "toolchainFile": "${workspaceFolder:test-project-without-cmakelists}/${env:CMAKE_TOOLS_TEST_SOME_ENV_VAR}/toolchain.cmake"
+  },
+  {
         "name": "VSCode Kit 1",
         "visualStudio": "Visual Studio 2015",
         "visualStudioArchitecture": "x86"


### PR DESCRIPTION
This fixes https://github.com/microsoft/vscode-cmake-tools/issues/1525 and https://github.com/microsoft/vscode-cmake-tools/issues/1526. 

When '?' was missing from the regexp, using variables in settings or kits (any of our supported variables) was fine as long as there was one. The problem we found was when more than one variable would be used on the same line. The one scenario added to the kits test is enough to cover this problem.