### PR TITLE
Use non greedy search for the = sign when replacing cmake cache entries

### DIFF
--- a/src/cache.ts
+++ b/src/cache.ts
@@ -188,7 +188,7 @@ export class CMakeCache {
    * @param value Boolean value
    */
   private replace(content: string, key: string, value: string): string {
-    const re = key + ':.+=(.+)';
+    const re = key + ':.+?=(.+)';
     const found = content.match(re);
 
     if (found && found.length >= 2) {


### PR DESCRIPTION
## The purpose of this change
When editing the cmake cache through the UI, cmake cache entries which contain a = in the value are incorrectly split because of the greedy match operator used.
```
CMAKE_CXX_COMPILE_FLAGS:STRING=-mcpu=cortex-m4
```
This change makes sure the first = sign is used for the lookup of the cmake cache string.