### PR TITLE
pass args when we Launch the executable without Debug

### DIFF
--- a/src/cmake-tools.ts
+++ b/src/cmake-tools.ts
@@ -1546,7 +1546,13 @@ export class CMakeTools implements vscode.Disposable, api.CMakeToolsAPI {
     if (!this._launchTerminal)
       this._launchTerminal = vscode.window.createTerminal(termOptions);
     const quoted = shlex.quote(executable.path);
-    this._launchTerminal.sendText(quoted);
+    
+    var launchArgs = ''
+    if (user_config && user_config.args) {
+        launchArgs = user_config.args.join(" ")
+    }
+
+    this._launchTerminal.sendText(quoted + " " + launchArgs);
     this._launchTerminal.show(true);
     return this._launchTerminal;
   }


### PR DESCRIPTION




## The purpose of this change

  When we launch the executable in the debuger, it uses the args parameter. But when we launch it without the debuger 
it doesn't. 

  This change provides the same behaviour and allow to pass args when we launch without debug the executable/
