### PR TITLE
Fix issue with git cleanup in loc auto-pr script

### DIFF
--- a/translations_auto_pr.js
+++ b/translations_auto_pr.js
@@ -153,7 +153,10 @@ octokit.pulls.list({ owner: repoOwner, repo: repoName }).then(({data}) => {
     console.log(`Restoring default git permissions`);
     cp.execSync('git remote remove origin');
     cp.execSync(`git remote add origin https://github.com/${repoOwner}/${repoName}.git`);
-    
+
+    console.log(`Run 'git fetch' against updated remote`);
+    cp.execSync('git fetch');
+
     console.log(`Switching back to develop (git checkout develop)`);
     cp.execSync('git checkout develop');
 


### PR DESCRIPTION
After changing the remote back to the default (without auth token in it), it's necessary to run `git fetch` before switching branches.