### PR TITLE
the "paths" member of "target" object could be a relative path to the top-level source directory

### DIFF
--- a/src/drivers/cmakefileapi/api_helpers.ts
+++ b/src/drivers/cmakefileapi/api_helpers.ts
@@ -208,7 +208,7 @@ function convertToExtCodeModelFileGroup(root_paths: index_api.CodeModelKind.Path
   const src_path = convertToAbsolutePath(targetObject.paths.source, root_paths.source);
   targetObject.sources.forEach(sourcefile => {
     const file_abs_path = convertToAbsolutePath(sourcefile.path, root_paths.source);
-    const file_path = path.relative(src_path, file_abs_path).replace('\\', '/');
+    const file_path = path.relative(src_path, file_abs_path).replace(/\\/g, '/');
     if (sourcefile.compileGroupIndex !== undefined) {
       fileGroup[sourcefile.compileGroupIndex].sources.push(file_path);
     } else {


### PR DESCRIPTION
Refer to https://cmake.org/cmake/help/git-stage/manual/cmake-file-api.7.html#codemodel-version-2-target-object,
If the directory is inside the top-level source directory then the path is specified relative to that directory.
We must convert the path and the source file to absolute and then get the relative path.
