### PR TITLE
fix regex for reading from CMAKE cache

### DIFF
--- a/src/cache.ts
+++ b/src/cache.ts
@@ -188,7 +188,7 @@ export class CMakeCache {
    * @param value Boolean value
    */
   private replace(content: string, key: string, value: string): string {
-    const re = key + ':.+=(.+)';
+    const re = key + ':[^=]+=(.+)';
     const found = content.match(re);
 
     if (found && found.length >= 2) {

--- a/src/kit.ts
+++ b/src/kit.ts
@@ -814,7 +814,7 @@ async function tryCreateNewVCEnvironment(inst: VSInstallation, hostArch: string,
   const majorVersion = parseInt(inst.installationVersion);
   if (version) {
     const generatorName: string|undefined = VsGenerators[version[1]];
-    let host: string = hostArch.toLowerCase().replace(/ /g, "").startsWith("host=") ? hostArch : "host=" + hostArch;
+    const host: string = hostArch.toLowerCase().replace(/ /g, "").startsWith("host=") ? hostArch : "host=" + hostArch;
     if (generatorName) {
       log.debug(` ${localize('generator.present', 'Generator Present: {0}', generatorName)}`);
       kit.preferredGenerator = {

--- a/src/kit.ts
+++ b/src/kit.ts
@@ -814,13 +814,14 @@ async function tryCreateNewVCEnvironment(inst: VSInstallation, hostArch: string,
   const majorVersion = parseInt(inst.installationVersion);
   if (version) {
     const generatorName: string|undefined = VsGenerators[version[1]];
+    let host: string = hostArch.toLowerCase().replace(/ /g, "").startsWith("host=") ? hostArch : "host=" + hostArch;
     if (generatorName) {
       log.debug(` ${localize('generator.present', 'Generator Present: {0}', generatorName)}`);
       kit.preferredGenerator = {
         name: generatorName,
         platform: generatorPlatformFromVSArch[targetArch] as string || targetArch,
         // CMake generator toolsets support also different versions (via -T version=).
-        toolset: majorVersion < 15 ? undefined : "host=" + hostArch
+        toolset: majorVersion < 15 ? undefined : host
       };
     }
     log.debug(` ${localize('selected.preferred.generator.name', 'Selected Preferred Generator Name: {0} {1}', generatorName, JSON.stringify(kit.preferredGenerator))}`);


### PR DESCRIPTION
bug fix: https://github.com/microsoft/vscode-cmake-tools/issues/1613

the bug in creating "host=" was caused by a regex that didn't locate "=" correctly