### PR TITLE
Don't localize the VS Clang kit name

### DIFF
--- a/src/drivers/driver.ts
+++ b/src/drivers/driver.ts
@@ -387,7 +387,7 @@ export abstract class CMakeDriver implements vscode.Disposable {
    * @param keywordSetting Variant Keywords for identification of a variant option
    */
   async setVariant(opts: VariantOption, keywordSetting: Map<string, string>|null) {
-    log.debug(localize('setting.new.variant', 'Setting new variant {0}', opts.long || '(Unnamed)'));
+    log.debug(localize('setting.new.variant', 'Setting new variant {0}', opts.short || '(Unnamed)'));
     this._variantBuildType = opts.buildType || this._variantBuildType;
     this._variantConfigureSettings = opts.settings || this._variantConfigureSettings;
     this._variantLinkage = opts.linkage || null;

--- a/src/kit.ts
+++ b/src/kit.ts
@@ -904,9 +904,7 @@ async function scanDirForClangForMSVCKits(dir: string, vsInstalls: VSInstallatio
       if (binPath.startsWith(`${vs.installationPath}\\VC\\Tools\\Llvm\\${clangArch}bin`) &&
       util.checkFileExists(util.lightNormalizePath(binPath))) {
         clangKits.push({
-          name: localize({key: 'clang.for.vsmsvc',
-                          comment: ["Clang should stay at the beginning of the string as it is used in UI sorting"]},
-                        'Clang {0} {1} with {2} ({3})', version.version, clang_cli, install_name, vs_arch),
+          name: `Clang ${version.version} ${clang_cli} (${install_name} - ${vs_arch})`,
           visualStudio: kitVSName(vs),
           visualStudioArchitecture: vs_arch,
           compilers: {


### PR DESCRIPTION
The localization of the VS Clang kit is not being done correctly despite the hint message.  I'm removing the need for these kits to be localized by removing "with" from the string so that "Clang" can always be at the beginning and users can have consistent sorting.

I'm also updating a debug log message based on some interactions I had with Xinyu.