### PR TITLE
The 'path' member of 'target' or 'source' could be relative

### DIFF
--- a/src/drivers/cmakefileapi/api_helpers.ts
+++ b/src/drivers/cmakefileapi/api_helpers.ts
@@ -187,7 +187,9 @@ function convertToAbsolutePath(input_path: string, base_path: string) {
   return path.normalize(absolute_path);
 }
 
-function convertToExtCodeModelFileGroup(targetObject: index_api.CodeModelKind.TargetObject): CodeModelFileGroup[] {
+function convertToExtCodeModelFileGroup(
+    root_paths: index_api.CodeModelKind.PathInfo,
+    targetObject: index_api.CodeModelKind.TargetObject): CodeModelFileGroup[] {
   const fileGroup: CodeModelFileGroup[] = !targetObject.compileGroups ? [] : targetObject.compileGroups.map(group => {
     const compileFlags
         = group.compileCommandFragments ? group.compileCommandFragments.map(frag => frag.fragment).join(' ') : '';
@@ -205,8 +207,10 @@ function convertToExtCodeModelFileGroup(targetObject: index_api.CodeModelKind.Ta
   const defaultIndex = fileGroup.push({sources: [], isGenerated: false} as CodeModelFileGroup) - 1;
 
 
+  const src_path = convertToAbsolutePath(targetObject.paths.source, root_paths.source);
   targetObject.sources.forEach(sourcefile => {
-    const file_path = path.relative(targetObject.paths.source, sourcefile.path).replace('\\', '/');
+    const file_abs_path = convertToAbsolutePath(sourcefile.path, root_paths.source);
+    const file_path = path.relative(src_path, file_abs_path).replace(/\\/g, '/');
     if (sourcefile.compileGroupIndex !== undefined) {
       fileGroup[sourcefile.compileGroupIndex].sources.push(file_path);
     } else {
@@ -222,7 +226,7 @@ function convertToExtCodeModelFileGroup(targetObject: index_api.CodeModelKind.Ta
 async function loadCodeModelTarget(root_paths: index_api.CodeModelKind.PathInfo, jsonfile: string) {
   const targetObject = await loadTargetObject(jsonfile);
 
-  const fileGroups = convertToExtCodeModelFileGroup(targetObject);
+  const fileGroups = convertToExtCodeModelFileGroup(root_paths, targetObject);
 
   // This implementation expects that there is only one sysroot in a target.
   // The ServerAPI only has provided one sysroot. In the FileAPI,

--- a/test/unit-tests/driver/driver-codemodel-tests.ts
+++ b/test/unit-tests/driver/driver-codemodel-tests.ts
@@ -187,7 +187,7 @@ export function makeCodeModelDriverTestsuite(
 
       // compile flags for file groups
       if (process.platform === 'win32') {
-        expect(compile_information!.compileFlags).to.eq('/DWIN32 /D_WINDOWS /W3 /GR /EHsc /MDd /Zi /Ob0 /Od /RTC1  ');
+        expect(compile_information!.compileFlags?.trim()).to.eq('/DWIN32 /D_WINDOWS /W3 /GR /EHsc /MDd /Zi /Ob0 /Od /RTC1');
       }
     }).timeout(90000);
 
@@ -223,7 +223,7 @@ export function makeCodeModelDriverTestsuite(
 
       // compile flags for file groups
       if (process.platform === 'win32') {
-        expect(target!.fileGroups![0].compileFlags).to.eq('/DWIN32 /D_WINDOWS /W3 /MDd /Zi /Ob0 /Od /RTC1  ');
+        expect(target!.fileGroups![0].compileFlags?.trim()).to.eq('/DWIN32 /D_WINDOWS /W3 /MDd /Zi /Ob0 /Od /RTC1');
       }
     }).timeout(90000);
 

--- a/test/unit-tests/driver/workspace/not_in_root_project/cmake/CMakeLists.txt
+++ b/test/unit-tests/driver/workspace/not_in_root_project/cmake/CMakeLists.txt
@@ -1,0 +1,4 @@
+cmake_minimum_required(VERSION 3.0.0)
+project(NotInRoot VERSION 0.1.0)
+
+add_executable(NotInRoot ../main.cpp)

--- a/test/unit-tests/driver/workspace/not_in_root_project/main.cpp
+++ b/test/unit-tests/driver/workspace/not_in_root_project/main.cpp
@@ -1,0 +1,3 @@
+int main(int, char**) {
+    return 0;
+}


### PR DESCRIPTION
Fix #1504

Refer to https://cmake.org/cmake/help/git-stage/manual/cmake-file-api.7.html#codemodel-version-2-target-object.
The target path and source file path could be relative, so the convertToExtCodeModelFileGroup() must convert the paths to absolute first.