### PR TITLE
Gcc/clang version analysis improvements

### DIFF
--- a/src/kit.ts
+++ b/src/kit.ts
@@ -130,7 +130,9 @@ async function getClangVersion(binPath: string): Promise<ClangVersion|null> {
     return null;
   }
   const lines = exec.stderr.split('\n');
-  const version_re = /^(?:Apple LLVM|.*clang) version ([^\s-]+)(?:[\s-]|$)/;
+  const versionWord: string = localize("version.word", "version");
+  const version_re_str: string = `^(?:Apple LLVM|.*clang) ${versionWord} ([^\s-]+)(?:[\s-]|$)`;
+  const version_re = RegExp(version_re_str, "mgi");
   let version: string = "";
   let fullVersion: string = "";
   for (const line of lines) {
@@ -194,12 +196,14 @@ export async function kitIfCompiler(bin: string, pr?: ProgressReporter): Promise
     }
 
     const compiler_version_output = exec.stderr.trim().split('\n');
-    const version_re = /^gcc version (.*?) .*/;
+    const versionWord: string = localize("version.word", "version");
+    const version_re_str: string = `^gcc(-| )${versionWord} (.*?) .*`;
+    const version_re = RegExp(version_re_str, "mgi");
     let version: string = "";
     for (const line of compiler_version_output) {
       const version_match = version_re.exec(line);
       if (version_match !== null) {
-        version = version_match[1];
+        version = version_match[2];
         break;
       }
     }

--- a/src/kit.ts
+++ b/src/kit.ts
@@ -131,12 +131,14 @@ async function getClangVersion(binPath: string): Promise<ClangVersion|null> {
   }
   const lines = exec.stderr.split('\n');
   const versionWord: string = localize("version.word", "version");
-  const version_re_str: string = `^(?:Apple LLVM|.*clang) ${versionWord} ([^\\s-]+)(?:[\\s-]|$)`;
-  const version_re = RegExp(version_re_str, "mgi");
+  const version_re_str_loc: string = `^(?:Apple LLVM|.*clang) ${versionWord} ([^\\s-]+)(?:[\\s-]|$)`;
+  const version_re_str_en: string = `^(?:Apple LLVM|.*clang) version ([^\\s-]+)(?:[\\s-]|$)`;
+  const version_re_loc = RegExp(version_re_str_loc, "mgi");
+  const version_re_en = RegExp(version_re_str_en, "mgi");
   let version: string = "";
   let fullVersion: string = "";
   for (const line of lines) {
-    const version_match = version_re.exec(line);
+    const version_match = version_re_en.exec(line) || version_re_loc.exec(line);
     if (version_match !== null) {
       version = version_match[1];
       fullVersion = line;
@@ -197,11 +199,13 @@ export async function kitIfCompiler(bin: string, pr?: ProgressReporter): Promise
 
     const compiler_version_output = exec.stderr.trim().split('\n');
     const versionWord: string = localize("version.word", "version");
-    const version_re_str: string = `^gcc(-| )${versionWord} (.*?) .*`;
-    const version_re = RegExp(version_re_str, "mgi");
+    const version_re_str_loc: string = `^gcc(-| )${versionWord} (.*?) .*`;
+    const version_re_str_en: string = `^gcc(-| )version (.*?) .*`;
+    const version_re_loc = RegExp(version_re_str_loc, "mgi");
+    const version_re_en = RegExp(version_re_str_en, "mgi");
     let version: string = "";
     for (const line of compiler_version_output) {
-      const version_match = version_re.exec(line);
+      const version_match = version_re_en.exec(line) || version_re_loc.exec(line);
       if (version_match !== null) {
         version = version_match[2];
         break;

--- a/src/kit.ts
+++ b/src/kit.ts
@@ -131,7 +131,7 @@ async function getClangVersion(binPath: string): Promise<ClangVersion|null> {
   }
   const lines = exec.stderr.split('\n');
   const versionWord: string = localize("version.word", "version");
-  const version_re_str: string = `^(?:Apple LLVM|.*clang) ${versionWord} ([^\s-]+)(?:[\s-]|$)`;
+  const version_re_str: string = `^(?:Apple LLVM|.*clang) ${versionWord} ([^\\s-]+)(?:[\\s-]|$)`;
   const version_re = RegExp(version_re_str, "mgi");
   let version: string = "";
   let fullVersion: string = "";


### PR DESCRIPTION
Fix for https://github.com/microsoft/vscode-cmake-tools/issues/1575.
Gcc/clang version analysis should account for localization of word "version", for case variations and accept a dash variant.
Examples of what was not working before:
gcc-Version 10.2.0 (GCC)
gcc 版本 10.2.0 (GCC)

