### PR TITLE
support parsing substring and also substrings with single quote and space

### DIFF
--- a/src/compdb.ts
+++ b/src/compdb.ts
@@ -16,25 +16,21 @@ interface BaseCompileCommand {
   output?: string;
 }
 
-interface StringCompileCommand extends BaseCompileCommand {
+export interface ArgsCompileCommand extends BaseCompileCommand {
   command: string;
+  arguments?: string[];
 }
-
-interface ArgsCompileCommand extends BaseCompileCommand {
-  arguments: string[];
-}
-
-export type CompileCommand = StringCompileCommand|ArgsCompileCommand;
 
 export class CompilationDatabase {
   private readonly _infoByFilePath: Map<string, ArgsCompileCommand>;
-  constructor(infos: CompileCommand[]) {
+  constructor(infos: ArgsCompileCommand[]) {
     this._infoByFilePath = infos.reduce(
         (acc, cur) => acc.set(util.platformNormalizePath(cur.file), {
           directory: cur.directory,
           file: cur.file,
           output: cur.output,
-          arguments: 'arguments' in cur ? cur.arguments : [...shlex.split(cur.command)],
+          command: cur.command,
+          arguments: cur.arguments ? cur.arguments : [...shlex.split(cur.command)],
         }),
         new Map<string, ArgsCompileCommand>(),
     );
@@ -48,7 +44,7 @@ export class CompilationDatabase {
     }
     const data = await fs.readFile(dbpath);
     try {
-      const content = JSON.parse(data.toString()) as CompileCommand[];
+      const content = JSON.parse(data.toString()) as ArgsCompileCommand[];
       return new CompilationDatabase(content);
     } catch (e) {
       log.warning(localize('error.parsing.compilation.database', 'Error parsing compilation database "{0}": {1}', dbpath, util.errorToString(e)));

--- a/src/drivers/driver.ts
+++ b/src/drivers/driver.ts
@@ -9,7 +9,7 @@ import * as api from '@cmt/api';
 import {CMakeExecutable} from '@cmt/cmake/cmake-executable';
 import * as codepages from '@cmt/code-pages';
 import {ConfigureTrigger} from "@cmt/cmake-tools";
-import {CompileCommand} from '@cmt/compdb';
+import {ArgsCompileCommand} from '@cmt/compdb';
 import {ConfigurationReader} from '@cmt/config';
 import {CMakeBuildConsumer, CompileOutputConsumer} from '@cmt/diagnostics/build';
 import {CMakeOutputConsumer} from '@cmt/diagnostics/cmake';
@@ -22,7 +22,6 @@ import paths from '@cmt/paths';
 import {fs} from '@cmt/pr';
 import * as proc from '@cmt/proc';
 import rollbar from '@cmt/rollbar';
-import * as shlex from '@cmt/shlex';
 import * as telemetry from '@cmt/telemetry';
 import * as util from '@cmt/util';
 import {ConfigureArguments, VariantOption} from '@cmt/variant';
@@ -267,34 +266,29 @@ export abstract class CMakeDriver implements vscode.Disposable {
    * Launch the given compilation command in an embedded terminal.
    * @param cmd The compilation command from a compilation database to run
    */
-  runCompileCommand(cmd: CompileCommand): vscode.Terminal {
-    if ('command' in cmd) {
-      const args = [...shlex.split(cmd.command)];
-      return this.runCompileCommand({directory: cmd.directory, file: cmd.file, arguments: args});
-    } else {
-      const env = this.getEffectiveSubprocessEnvironment();
-      const key = `${cmd.directory}${JSON.stringify(env)}`;
-      let existing = this._compileTerms.get(key);
-      if (existing && this.config.clearOutputBeforeBuild) {
-        this._compileTerms.delete(key);
-        existing.dispose();
-        existing = undefined;
-      }
-      if (!existing) {
-        const shellPath = process.platform === 'win32' ? 'cmd.exe' : undefined;
-        const term = vscode.window.createTerminal({
-          name: localize('file.compilation', 'File Compilation'),
-          cwd: cmd.directory,
-          env,
-          shellPath,
-        });
-        this._compileTerms.set(key, term);
-        existing = term;
-      }
-      existing.show();
-      existing.sendText(cmd.arguments.map(s => shlex.quote(s)).join(' ') + '\r\n');
-      return existing;
+  runCompileCommand(cmd: ArgsCompileCommand): vscode.Terminal {
+    const env = this.getEffectiveSubprocessEnvironment();
+    const key = `${cmd.directory}${JSON.stringify(env)}`;
+    let existing = this._compileTerms.get(key);
+    if (existing && this.config.clearOutputBeforeBuild) {
+      this._compileTerms.delete(key);
+      existing.dispose();
+      existing = undefined;
     }
+    if (!existing) {
+      const shellPath = process.platform === 'win32' ? 'cmd.exe' : undefined;
+      const term = vscode.window.createTerminal({
+        name: localize('file.compilation', 'File Compilation'),
+        cwd: cmd.directory,
+        env,
+        shellPath,
+      });
+      this._compileTerms.set(key, term);
+      existing = term;
+    }
+    existing.show();
+    existing.sendText(cmd.command + '\r\n');
+    return existing;
   }
 
   /**

--- a/test/unit-tests/shlex.test.ts
+++ b/test/unit-tests/shlex.test.ts
@@ -1,29 +1,50 @@
 import * as shlex from '@cmt/shlex';
-import {expect} from '@test/util';
+import { expect } from '@test/util';
 
-function splitWin(str: string): string[] { return [...shlex.split(str, {mode: 'windows'})]; }
+function splitWin(str: string): string[] { return [...shlex.split(str, { mode: 'windows' })]; }
 
-// function splitUnix(str: string): string[] { return [...shlex.split(str, {mode: 'posix'})]; }
+function splitUnix(str: string): string[] { return [...shlex.split(str, { mode: 'posix' })]; }
 
 suite('shlex testing', () => {
   test('Windows shell splitting', () => {
     const pairs: [string, string[]][] = [
       ['foo', ['foo']],
       ['foo bar', ['foo', 'bar']],
-      ['"foo" bar', ['foo', 'bar']],
       ['', []],
-      ['""', ['']],
-      [`'quote arg'`, [`'quote`, `arg'`]],
-      ['Something    ', ['Something']],
-      ['"   fail"', ['   fail']],
-      ['    arg', ['arg']],
+      ['""', ['""']],
+      ['    Something    ', ['Something']],
       ['foo     bar', ['foo', 'bar']],
-      ['"C:\\Program Files" something', ['C:\\Program Files', 'something']],
-      ['foo "" bar', ['foo', '', 'bar']],
+      ['"C:\\Program Files" something', ['"C:\\Program Files"', 'something']],
+      ['foo "" bar', ['foo', '""', 'bar']],
+      [`\"'fo o'\" bar`, [`\"'fo o'\"`, 'bar']],
+      [`'quote arg'`, [`'quote`, `arg'`]],
+      ['"   fail"', ['"   fail"']],
+      [`-DAWESOME=\"\\\"'fo o' bar\\\"\"`, [`-DAWESOME=\"\\\"'fo o' bar\\\"\"`]],
     ];
 
     for (const [cmd, expected] of pairs) {
       expect(splitWin(cmd)).to.eql(expected, `Bad parse for string: ${cmd}`);
+    }
+  });
+  test('Posix shell splitting', () => {
+    const pairs: [string, string[]][] = [
+      ['foo', ['foo']],
+      ['foo bar', ['foo', 'bar']],
+      ['', []],
+      ['""', ['""']],
+      [`''`, [`''`]],
+      ['    Something    ', ['Something']],
+      ['foo     bar', ['foo', 'bar']],
+      ['"C:\\Program Files" something', ['"C:\\Program Files"', 'something']],
+      ['foo "" bar', ['foo', '""', 'bar']],
+      [`"fo o" bar`, [`"fo o"`, 'bar']],
+      [`'quote arg'`, [`'quote arg'`]],
+      ['"   fail"', ['"   fail"']],
+      [`-DAWESOME=\"\\\"fo o bar\\\"\"`, [`-DAWESOME=\"\\\"fo o bar\\\"\"`]],
+    ];
+
+    for (const [cmd, expected] of pairs) {
+      expect(splitUnix(cmd)).to.eql(expected, `Bad parse for string: ${cmd}`);
     }
   });
 });


### PR DESCRIPTION
Add support parsing define variables that are in the form of a string, e.g., and also variables that include a space in the string:

```
target_compile_definitions(testPRa PUBLIC AWESOME="'pr a'")
target_compile_definitions(testPRb PUBLIC AWESOME="'pr b'")
set(CMAKE_CXX_COMPILER "c:/program files (x86)/mingw-w64/i686-8.1.0-posix-dwarf-rt_v6-rev0/mingw32/bin/g++.exe")

```
bug:
main:
https://github.com/microsoft/vscode-cmake-tools/issues/969
https://github.com/microsoft/vscode-cmake-tools/issues/1414

duplicates:
https://github.com/microsoft/vscode-cmake-tools/issues/1493
https://github.com/microsoft/vscode-cmake-tools/issues/1565