### PR TITLE
Fix webpack watch

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -27,10 +27,10 @@
                     "background": {
                         "activeOnStart": true,
                         "beginsPattern": {
-                            "regexp": "Compilation (.*?)starting…"
+                            "regexp": "asset"
                         },
                         "endsPattern": {
-                            "regexp": "Compilation (.*?)finished"
+                            "regexp": "webpack (.*?) compiled (.*?) ms"
                         }
                     }
                 }

--- a/package.json
+++ b/package.json
@@ -1655,7 +1655,7 @@
   },
   "scripts": {
     "vscode:prepublish": "yarn run compile-production",
-    "compile": "yarn install && webpack --mode development --watch",
+    "compile": "yarn install && webpack --mode development --watch --progress",
     "compile-production": "yarn install && yarn run translations-generate && webpack --env BUILD_VSCODE_NLS=true --mode production",
     "translations-export": "gulp translations-export",
     "translations-generate": "gulp translations-generate",

--- a/package.json
+++ b/package.json
@@ -1655,7 +1655,7 @@
   },
   "scripts": {
     "vscode:prepublish": "yarn run compile-production",
-    "compile": "yarn install && webpack --mode development --watch --info-verbosity verbose",
+    "compile": "yarn install && webpack --mode development --watch",
     "compile-production": "yarn install && yarn run translations-generate && webpack --env BUILD_VSCODE_NLS=true --mode production",
     "translations-export": "gulp translations-export",
     "translations-generate": "gulp translations-generate",


### PR DESCRIPTION
Option "--info-verbosity" has been removed from the new webpack version, and I didn't find a very good beginning output to match...

Sample output (succeeded):
```
asset main.js 2.33 MiB [compared for emit] (name: main) 1 related asset
runtime modules 88 bytes 1 module
modules by path ./node_modules/ 1.49 MiB
  javascript modules 1.4 MiB
    cacheable modules 1.4 MiB 261 modules
    modules by path ./node_modules/diagnostic-channel-publishers/dist/src/ sync ^.*//lib// 320 bytes 2 modules
  json modules 93.2 KiB
    modules by path ./node_modules/iconv-lite/encodings/tables/*.json 86.7 KiB 8 modules
    modules by path ./node_modules/ajv/dist/refs/*.json 3.07 KiB 2 modules
modules by path ./src/ 554 KiB
  modules by path ./src/*.ts 419 KiB 34 modules
  modules by path ./src/diagnostics/*.ts 24 KiB 9 modules
  modules by path ./src/drivers/ 107 KiB 7 modules
  ./src/installs/visual-studio.ts 2.14 KiB [built] [code generated]
  ./src/cmake/cmake-executable.ts 1.68 KiB [built] [code generated]
23 modules
webpack 5.22.0 compiled with 3 warnings in 9420 ms
```

Sample output (failed):
```
asset main.js 2.33 MiB [emitted] (name: main) 1 related asset
cached modules 1.96 MiB [cached] 383 modules
runtime modules 88 bytes 1 module
cacheable modules 71.6 KiB
  ./src/extension.ts 54.8 KiB [built] [code generated] [1 error]
  ./src/status.ts 16.8 KiB [built] [code generated]

ERROR in D:\CMakeTools\src\extension.ts
./src/extension.ts 1066:20-35
[tsl] ERROR in D:\CMakeTools\src\extension.ts(1066,21)
      TS2551: Property 'hideBuildButton' does not exist on type 'StatusBar'. Did you mean 'hiderBuildButton'?

webpack 5.22.0 compiled with 1 error and 3 warnings in 3169 ms
```