### PR TITLE
bump the version to 1.7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "cmake-tools",
   "displayName": "CMake Tools",
   "description": "Extended CMake support in Visual Studio Code",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "publisher": "ms-vscode",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Since 1.6.0 has released, we need to update the version number so that the Actions builds can be installed and not have users auto-update back to 1.6.0.