### PR TITLE
Support substitution of vscode variables in ctestPath like in cmakePath

### DIFF
--- a/src/paths.ts
+++ b/src/paths.ts
@@ -158,7 +158,7 @@ class Paths {
   }
 
   async getCTestPath(wsc: DirectoryContext): Promise<string|null> {
-    const ctest_path = wsc.config.raw_ctestPath;
+    const ctest_path = await this.expandStringWithVSCodeVars(wsc.config.raw_ctestPath, wsc);
     if (!ctest_path || ctest_path == 'auto') {
       const cmake = await this.getCMakePath(wsc);
       if (cmake === null) {
@@ -186,28 +186,7 @@ class Paths {
   async getCMakePath(wsc: DirectoryContext): Promise<string|null> {
     this._ninjaPath = undefined;
 
-    const raw = await expandString(wsc.config.raw_cmakePath, {
-      vars: {
-        buildKit: '',
-        buildKitVendor: '',
-        buildKitTriple: '',
-        buildKitVersion: '',
-        buildKitHostOs: '',
-        buildKitTargetOs: '',
-        buildKitTargetArch: '',
-        buildKitVersionMajor: '',
-        buildKitVersionMinor: '',
-        buildType: '',
-        generator: '',
-        workspaceFolder: wsc.folder.uri.fsPath,
-        workspaceFolderBasename: path.basename(wsc.folder.uri.fsPath),
-        workspaceRoot: wsc.folder.uri.fsPath,
-        workspaceRootFolderName: path.basename(wsc.folder.uri.fsPath),
-        workspaceHash: util.makeHashString(wsc.folder.uri.fsPath),
-        userHome: this.userHome,
-      },
-    });
-
+    const raw = await this.expandStringWithVSCodeVars(wsc.config.raw_cmakePath, wsc);
     if (raw === 'auto' || raw === 'cmake') {
       // We start by searching $PATH for cmake
       const on_path = await this.which('cmake');
@@ -239,6 +218,30 @@ class Paths {
     }
 
     return raw;
+  }
+
+  async expandStringWithVSCodeVars(tmpl: string, wsc: DirectoryContext): Promise<string> {
+    return expandString(tmpl, {
+      vars: {
+        buildKit: '',
+        buildKitVendor: '',
+        buildKitTriple: '',
+        buildKitVersion: '',
+        buildKitHostOs: '',
+        buildKitTargetOs: '',
+        buildKitTargetArch: '',
+        buildKitVersionMajor: '',
+        buildKitVersionMinor: '',
+        buildType: '',
+        generator: '',
+        workspaceFolder: wsc.folder.uri.fsPath,
+        workspaceFolderBasename: path.basename(wsc.folder.uri.fsPath),
+        workspaceRoot: wsc.folder.uri.fsPath,
+        workspaceRootFolderName: path.basename(wsc.folder.uri.fsPath),
+        workspaceHash: util.makeHashString(wsc.folder.uri.fsPath),
+        userHome: this.userHome,
+      },
+    });
   }
 
   async vsCMakePaths(): Promise<VSCMakePaths> {

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -158,7 +158,7 @@ class Paths {
   }
 
   async getCTestPath(wsc: DirectoryContext): Promise<string|null> {
-    const ctest_path = await this.expandStringWithVSCodeVars(wsc.config.raw_ctestPath, wsc);
+    const ctest_path = await this.expandStringPath(wsc.config.raw_ctestPath, wsc);
     if (!ctest_path || ctest_path == 'auto') {
       const cmake = await this.getCMakePath(wsc);
       if (cmake === null) {
@@ -186,7 +186,7 @@ class Paths {
   async getCMakePath(wsc: DirectoryContext): Promise<string|null> {
     this._ninjaPath = undefined;
 
-    const raw = await this.expandStringWithVSCodeVars(wsc.config.raw_cmakePath, wsc);
+    const raw = await this.expandStringPath(wsc.config.raw_cmakePath, wsc);
     if (raw === 'auto' || raw === 'cmake') {
       // We start by searching $PATH for cmake
       const on_path = await this.which('cmake');
@@ -220,8 +220,8 @@ class Paths {
     return raw;
   }
 
-  async expandStringWithVSCodeVars(tmpl: string, wsc: DirectoryContext): Promise<string> {
-    return expandString(tmpl, {
+  async expandStringPath(raw_path: string, wsc: DirectoryContext): Promise<string> {
+    return expandString(raw_path, {
       vars: {
         buildKit: '',
         buildKitVendor: '',


### PR DESCRIPTION
<!-- Thanks for your contribution! To make things easier, please fill out the template below. -->

<!-- Please delete any unused sections. -->

<!-- Delete the following heading if there is no corresponding issue -->
## This change addresses item #785

### This changes ctestPath behavior

The following changes are proposed:

- Substitute VSCode variables for ctestPath in the same way as for cmakePath.

## The purpose of this change

Enables users to use variables like `${workspaceFolder}` in their ctestPath. cmakePath already allows this.
