### PR TITLE
change default for configureOnOpen in codespaces

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -10,6 +10,7 @@ import * as os from 'os';
 import * as telemetry from '@cmt/telemetry';
 import * as vscode from 'vscode';
 import * as nls from 'vscode-nls';
+import { replace } from 'sinon';
 
 nls.config({messageFormat: nls.MessageFormat.bundle, bundleFormat: nls.BundleFormat.standalone})();
 const localize: nls.LocalizeFunc = nls.loadMessageBundle();
@@ -227,7 +228,12 @@ export class ConfigurationReader implements vscode.Disposable {
   get testEnvironment() { return this.configData.testEnvironment; }
   get defaultVariants(): Object { return this.configData.defaultVariants; }
   get ctestArgs(): string[] { return this.configData.ctestArgs; }
-  get configureOnOpen() { return this.configData.configureOnOpen; }
+  get configureOnOpen() {
+    if (util.isCodespaces() && this.configData.configureOnOpen === null) {
+      return true;
+    }
+    return this.configData.configureOnOpen;
+  }
   get configureOnEdit() { return this.configData.configureOnEdit; }
   get skipConfigureIfCachePresent() { return this.configData.skipConfigureIfCachePresent; }
   get useCMakeServer(): boolean { return this.configData.useCMakeServer; }

--- a/src/config.ts
+++ b/src/config.ts
@@ -10,7 +10,6 @@ import * as os from 'os';
 import * as telemetry from '@cmt/telemetry';
 import * as vscode from 'vscode';
 import * as nls from 'vscode-nls';
-import { replace } from 'sinon';
 
 nls.config({messageFormat: nls.MessageFormat.bundle, bundleFormat: nls.BundleFormat.standalone})();
 const localize: nls.LocalizeFunc = nls.loadMessageBundle();

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -367,6 +367,7 @@ class ExtensionManager implements vscode.Disposable {
                                              await scanForKitsIfNeeded(cmt);
 
     let should_configure = cmt.workspaceContext.config.configureOnOpen;
+    let codespaces_first_configureOnOpen: boolean = false;
     if (should_configure === null && process.env['CMT_TESTING'] !== '1') {
       interface Choice1 {
         title: string;
@@ -415,6 +416,9 @@ class ExtensionManager implements vscode.Disposable {
                 });
       rollbar.takePromise(localize('persist.config.on.open.setting', 'Persist config-on-open setting'), {}, persist_pr);
       should_configure = chosen.doConfigure;
+      if (util.isCodespaces()) {
+        codespaces_first_configureOnOpen = true;
+      }
     }
 
     const optsVars: ExpansionVars = {
@@ -450,7 +454,9 @@ class ExtensionManager implements vscode.Disposable {
         // We've opened a new workspace folder, and the user wants us to
         // configure it now.
         log.debug(localize('configuring.workspace.on.open', 'Configuring workspace on open {0}', ws.uri.toString()));
-        await this.configureInternal(ConfigureTrigger.configureOnOpen, cmt);
+        if (!util.isCodespaces() || codespaces_first_configureOnOpen) {
+          await this.configureInternal(ConfigureTrigger.configureOnOpen, cmt);
+        }
       } else if (silentScanForKitsNeeded) {
         // This popup will show up the first time after deciding not to configure, if a version change has been detected
         // in the kits definition. This may happen during a CMake Tools extension upgrade.

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -367,7 +367,6 @@ class ExtensionManager implements vscode.Disposable {
                                              await scanForKitsIfNeeded(cmt);
 
     let should_configure = cmt.workspaceContext.config.configureOnOpen;
-    let codespaces_first_configureOnOpen: boolean = false;
     if (should_configure === null && process.env['CMT_TESTING'] !== '1') {
       interface Choice1 {
         title: string;
@@ -416,9 +415,6 @@ class ExtensionManager implements vscode.Disposable {
                 });
       rollbar.takePromise(localize('persist.config.on.open.setting', 'Persist config-on-open setting'), {}, persist_pr);
       should_configure = chosen.doConfigure;
-      if (util.isCodespaces()) {
-        codespaces_first_configureOnOpen = true;
-      }
     }
 
     const optsVars: ExpansionVars = {
@@ -454,9 +450,7 @@ class ExtensionManager implements vscode.Disposable {
         // We've opened a new workspace folder, and the user wants us to
         // configure it now.
         log.debug(localize('configuring.workspace.on.open', 'Configuring workspace on open {0}', ws.uri.toString()));
-        if (!util.isCodespaces() || codespaces_first_configureOnOpen) {
-          await this.configureInternal(ConfigureTrigger.configureOnOpen, cmt);
-        }
+        await this.configureInternal(ConfigureTrigger.configureOnOpen, cmt);
       } else if (silentScanForKitsNeeded) {
         // This popup will show up the first time after deciding not to configure, if a version change has been detected
         // in the kits definition. This may happen during a CMake Tools extension upgrade.

--- a/src/util.ts
+++ b/src/util.ts
@@ -610,3 +610,7 @@ export function isNullOrUndefined(x?: any): boolean {
 export function isWorkspaceFolder(x?: any): boolean {
   return 'uri' in x && 'name' in x && 'index' in x;
 }
+
+export function isCodespaces(): boolean {
+  return !!process.env["CODESPACES"];
+}


### PR DESCRIPTION
bug fix: https://github.com/microsoft/vscode-cmake-tools/issues/1676

for codespace users the `configureOnOpen` will be set to `true` if it is `null` (i.e. not set in the settings by user).

for other users, the previous behavior will stay the same. If they have not set up the `configureOnOpen` in the settings, we will pop up 2 UI's like before, 1) Would you like to configure project?, and 2) Always configure projects upon opening?

