### PR TITLE
Correctly identify compiler information for telemetry

### DIFF
--- a/src/drivers/driver.ts
+++ b/src/drivers/driver.ts
@@ -882,7 +882,22 @@ export abstract class CMakeDriver implements vscode.Disposable {
     const compilerDir = path.parse(compilerPath).dir;
 
     // Find an equivalent in the compilers allowed list.
-    const compiler = this.compilerAllowList.find(comp => compilerName.includes(comp.name));
+    // To avoid finding "cl" instead of "clang" or "g++" instead of "clang++",
+    // sort the array from lengthier to shorter, so that the find operation
+    // would return the most precise match.
+    // The find condition must be "includes" instead of "equals"
+    // (which wouldn't otherwise need the sort) to avoid implementing separate handling
+    // for comiler file name prefixes and suffixes related to targeted architecture.
+    const sortedCompilerAllowList = this.compilerAllowList.sort((a, b) => {
+      if (a.name.length == b.name.length) {
+        return 0;
+      } else if (a.name.length > b.name.length) {
+        return -1;
+      } else {
+        return 1;
+      }
+    });
+    const compiler = sortedCompilerAllowList.find(comp => compilerName.includes(comp.name));
 
     // Mask any unrecognized compiler as "other" to hide private information
     let allowedCompilerName = compiler ? compiler.name : "other";


### PR DESCRIPTION
Fix the telemetry reporting for compiler name information: we were reporting "cl" instead of "clang" or "g++" instead of "clang++" (and other false results when dealing with compiler names that are substrings of other compiler names).

We have an allow-list of known compiler names against which we compare the compiler name when read from the C/CXX elements in the selected kit. The find operation needs to use the string "includes" instead of a much simpler "equals" (which would not have manifested this bug) so that we have simpler implementation for checking the target specific prefixes and suffixes (aarch64, arm, eabi, etc...). And the "includes" condition needs to operate on a string array that is sorted from lengthiest to shortest to avoid the above problem.