### PR TITLE
Change the order that kits are presented

### DIFF
--- a/test/helpers/test/default-environment.ts
+++ b/test/helpers/test/default-environment.ts
@@ -54,6 +54,7 @@ export class DefaultEnvironment {
       if (options?.placeHolder == selections[0].identifier) {
         return Promise.resolve(selections[0].handleQuickPick(items));
       }
+      console.trace();
       return Promise.reject(`Unknown quick pick "${options?.placeHolder}"`);
     };
     this.sandbox.stub(vscode.window, 'showQuickPick').callsFake(fakeShowQuickPick);


### PR DESCRIPTION
<!-- Thanks for your contribution! To make things easier, please fill out the template below. -->

<!-- Please delete any unused sections. -->

<!-- Delete the following heading if there is no corresponding issue -->
## This change addresses item #1736

### This changes visible behavior

The following changes are proposed:

Kits will now be presented in the following order:
* special kits ("scan" and "unspecified")
* folder kits (from ${workspaceFolder}/.vscode/cmake-kits.json, etc)
* `cmake.additionalKits` (from settings.json)
* user kits (from scanning)

