### PR TITLE
CMake Cache UI telemetry and fix bad merge

### DIFF
--- a/src/cache-view.ts
+++ b/src/cache-view.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode';
 import * as nls from 'vscode-nls';
+import * as telemetry from '@cmt/telemetry';
 import * as api from './api';
 import * as util from './util';
 
@@ -65,6 +66,7 @@ export class ConfigurationWebview {
   // Save from the UI table into the CMake cache file if there are any unsaved edits.
   async persistCacheEntries() {
     if (this.dirty) {
+      telemetry.logEvent("editCMakeCache", {command: "saveCMakeCacheUI"});
       await this.saveCmakeCache(this._options);
       vscode.window.showInformationMessage(localize('cmake.cache.saved', 'CMake options have been saved.'));
       // start configure

--- a/src/cmake-tools.ts
+++ b/src/cmake-tools.ts
@@ -71,7 +71,7 @@ export enum ConfigureTrigger {
   buttonNewKitsDefinition = "buttonNewKitsDefinition",
   compilation = "compilation",
   launch = "launch",
-  commandOpenConfiguration = "commandOpenConfiguration",
+  commandEditCacheUI = "commandEditCacheUI",
   commandConfigure = "commandConfigure",
   commandCleanConfigure = "commandCleanConfigure",
   commandConfigureAll = "commandConfigureAll",
@@ -514,11 +514,20 @@ export class CMakeTools implements vscode.Disposable, api.CMakeToolsAPI {
         await this._cacheEditorWebview.refreshPanel();
       }
 
-      const sourceDirectory = await this.sourceDir;
-      if (str.endsWith("CMakeLists.txt") || str.endsWith(".cmake")) {
-        telemetry.logEvent("cmakeFileWrite");
+      let fileType: string | undefined;
+      if (str.endsWith("CMakeLists.txt")) {
+        fileType = "CMakeLists";
+      } else if (str.endsWith("CMakeCache.txt")) {
+        fileType = "CMakeCache";
+      } else if (str.endsWith(".cmake")) {
+        fileType = ".cmake";
       }
 
+      if (fileType) {
+        telemetry.logEvent("cmakeFileWrite", {filetype: fileType});
+      }
+
+      const sourceDirectory = await this.sourceDir;
       if (str === path.join(sourceDirectory, "CMakeLists.txt")) {
         // CMakeLists.txt change event: its creation or deletion are relevant,
         // so update full/partial feature set view for this folder.
@@ -1053,9 +1062,9 @@ export class CMakeTools implements vscode.Disposable, api.CMakeToolsAPI {
   }
 
     /**
-   * Implementation of `cmake.openConfiguration`
+   * Implementation of `cmake.EditCacheUI`
    */
-  async openConfiguration(): Promise<number> {
+  async editCacheUI(): Promise<number> {
     if (!this._cacheEditorWebview) {
       const drv = await this.getCMakeDriverInstance();
       if (!drv) {
@@ -1064,7 +1073,7 @@ export class CMakeTools implements vscode.Disposable, api.CMakeToolsAPI {
       }
 
       this._cacheEditorWebview = new ConfigurationWebview(drv.cachePath, async () => {
-        await this.configureInternal(ConfigureTrigger.commandOpenConfiguration, [], ConfigureType.Cache);
+        await this.configureInternal(ConfigureTrigger.commandEditCacheUI, [], ConfigureType.Cache);
       });
       await this._cacheEditorWebview.initPanel();
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -903,7 +903,10 @@ class ExtensionManager implements vscode.Disposable {
 
   configureAll() { return this.mapCMakeToolsAll(cmt => cmt.configureInternal(ConfigureTrigger.commandCleanConfigureAll, [], ConfigureType.Normal), true); }
 
-  openConfiguration() { return this.mapCMakeToolsFolder(cmt => cmt.openConfiguration()); }
+  editCacheUI() {
+    telemetry.logEvent("editCMakeCache", {command: "editCMakeCacheUI"});
+    return this.mapCMakeToolsFolder(cmt => cmt.editCacheUI());
+  }
 
   build(folder?: vscode.WorkspaceFolder, name?: string) { return this.mapCMakeToolsFolder(cmt => cmt.build(name), folder, true); }
 
@@ -941,7 +944,7 @@ class ExtensionManager implements vscode.Disposable {
   }
 
   editCache(folder: vscode.WorkspaceFolder) {
-    telemetry.logEvent("editCMakeCache");
+    telemetry.logEvent("editCMakeCache", {command: "editCMakeCache"});
     return this.mapCMakeToolsFolder(cmt => cmt.editCache(), folder);
   }
 
@@ -1241,7 +1244,7 @@ async function setup(context: vscode.ExtensionContext, progress?: ProgressHandle
     'cleanRebuildAll',
     'configure',
     'configureAll',
-    'openConfiguration',
+    'editCacheUI',
     'ctest',
     'ctestAll',
     'stop',
@@ -1296,7 +1299,7 @@ async function setup(context: vscode.ExtensionContext, progress?: ProgressHandle
       vscode.commands.registerCommand('cmake.outline.stopAll', () => runCommand('stopAll')),
       vscode.commands.registerCommand('cmake.outline.cleanAll', () => runCommand('cleanAll')),
       vscode.commands.registerCommand('cmake.outline.cleanConfigureAll', () => runCommand('cleanConfigureAll')),
-      vscode.commands.registerCommand('cmake.outline.openConfiguration', () => runCommand('openConfiguration')),
+      vscode.commands.registerCommand('cmake.outline.editCacheUI', () => runCommand('editCacheUI')),
       vscode.commands.registerCommand('cmake.outline.cleanRebuildAll', () => runCommand('cleanRebuildAll')),
       // Commands for outline items:
       vscode.commands.registerCommand('cmake.outline.buildTarget',


### PR DESCRIPTION
Add new telemetry events and properties to existing events according to bullets 1,2 and 4 in work item https://github.com/microsoft/vscode-cmake-tools/issues/1723.
Also, the cache UI feature was completely disconnected from the palette (probably a bad merge happened at some point that reverted the "openConfiguration" to "editCacheUI" name change that was done originally).