### PR TITLE
Fix retention telemetry for multi root

### DIFF
--- a/src/cmake-tools.ts
+++ b/src/cmake-tools.ts
@@ -499,23 +499,23 @@ export class CMakeTools implements vscode.Disposable, api.CMakeToolsAPI {
     this._statusMessage.set(localize('ready.status', 'Ready'));
 
     this.extensionContext.subscriptions.push(vscode.workspace.onDidOpenTextDocument(async td => {
-      const str = td.uri.fsPath;
-      if (str.endsWith("CMakeLists.txt") || str.endsWith(".cmake")) {
+      const str = td.uri.fsPath.toLowerCase();
+      if (str.endsWith("cmakelists.txt") || str.endsWith(".cmake")) {
         telemetry.logEvent("cmakeFileOpen");
       }
     }));
 
     this.extensionContext.subscriptions.push(vscode.workspace.onDidSaveTextDocument(async td => {
-      const str = td.uri.fsPath;
+      const str = td.uri.fsPath.toLowerCase();
       const drv = await this.getCMakeDriverInstance();
 
       // If we detect a change in the CMake cache file, refresh the webview
-      if (this._cacheEditorWebview && drv && lightNormalizePath(str) === drv.cachePath) {
+      if (this._cacheEditorWebview && drv && lightNormalizePath(str) === drv.cachePath.toLowerCase()) {
         await this._cacheEditorWebview.refreshPanel();
       }
 
-      const sourceDirectory = await this.sourceDir;
-      if (str === path.join(sourceDirectory, "CMakeLists.txt")) {
+      const sourceDirectory = (await this.sourceDir).toLowerCase();
+      if (str === path.join(sourceDirectory, "cmakelists.txt")) {
         // CMakeLists.txt change event: its creation or deletion are relevant,
         // so update full/partial feature set view for this folder.
         await updateFullFeatureSetForFolder(this.folder);
@@ -540,29 +540,29 @@ export class CMakeTools implements vscode.Disposable, api.CMakeToolsAPI {
         // workspace folders versus outside any folder referenced by the current workspace.
         let outside: boolean = true;
         let fileType: string | undefined;
-        if (str.endsWith("CMakeLists.txt")) {
+        if (str.endsWith("cmakelists.txt")) {
           fileType = "CMakeLists";
 
           // The CMakeLists.txt belongs to the current active folder only if sourceDirectory points to it.
-          if (str === path.join(sourceDirectory, "CMakeLists.txt")) {
+          if (str === path.join(sourceDirectory, "cmakelists.txt")) {
             outside = false;
           }
-        } else if (str.endsWith("CMakeCache.txt")) {
+        } else if (str.endsWith("cmakecache.txt")) {
           fileType = "CMakeCache";
-          const binaryDirectory = await this.binaryDir;
+          const binaryDirectory = (await this.binaryDir).toLowerCase();
 
           // The CMakeCache.txt belongs to the current active folder only if binaryDirectory points to it.
-          if (str === path.join(binaryDirectory, "CMakeCache.txt")) {
+          if (str === path.join(binaryDirectory, "cmakecache.txt")) {
             outside = false;
           }
         } else if (str.endsWith(".cmake")) {
           fileType = ".cmake";
-          const binaryDirectory = await this.binaryDir;
+          const binaryDirectory = (await this.binaryDir).toLowerCase();
 
           // Instead of parsing how and from where a *.cmake file is included or imported
           // let's consider one inside the active folder if it's in the workspace folder,
           // sourceDirectory or binaryDirectory.
-          if (str.startsWith(this.folder.uri.fsPath) ||
+          if (str.startsWith(this.folder.uri.fsPath.toLowerCase()) ||
               str.startsWith(sourceDirectory) ||
               str.startsWith(binaryDirectory)) {
             outside = false;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -198,6 +198,10 @@ class ExtensionManager implements vscode.Disposable {
     return this._folders.get(folder);
   }
 
+  public isActiveFolder(cmt: CMakeToolsFolder): boolean {
+    return this._folders.activeFolder == cmt;
+  }
+
   /**
    * Create a new extension manager instance. There must only be one!
    * @param ctx The extension context
@@ -1367,6 +1371,11 @@ export async function activate(context: vscode.ExtensionContext) {
 export function enableFullFeatureSet(fullFeatureSet: boolean) {
   util.setContextValue("cmake:enableFullFeatureSet", fullFeatureSet);
   _EXT_MANAGER?.showStatusBar(fullFeatureSet);
+}
+
+export function isActiveFolder(folder: vscode.WorkspaceFolder): boolean | undefined {
+  const cmtFolder = _EXT_MANAGER?.getCMTFolder(folder);
+  return cmtFolder && _EXT_MANAGER?.isActiveFolder(cmtFolder);
 }
 
 // This method updates the full/partial view state of the given folder

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -199,7 +199,7 @@ class ExtensionManager implements vscode.Disposable {
   }
 
   public isActiveFolder(cmt: CMakeToolsFolder): boolean {
-    return this._folders.activeFolder == cmt;
+    return this._folders.activeFolder === cmt;
   }
 
   /**


### PR DESCRIPTION
Since any document changed from within VSCode notifies all the projects in a multi-root workspace, count only the one sent by the active folder. An alternative was to aggregate the notification results after all notifications have been received and processed but it would have been more complicated and since there is always an active folder (and only one) it's not necessary to go that route.

Additionally, add a boolean for the modified file being inside (or associated with) the active folder.