### PR TITLE
Fix parsing of target architecture flags with values that include `arm64`

### DIFF
--- a/src/cpptools.ts
+++ b/src/cpptools.ts
@@ -254,6 +254,11 @@ export function getIntelliSenseMode(cptVersion: cpt.Version, compiler_path: stri
       case 'x86':
         return 'gcc-x86';
       case 'x64':
+        return 'gcc-x64';
+      case 'arm64':
+        return can_use_arm ? 'gcc-arm64' : 'gcc-x64';
+      case 'arm':
+        return can_use_arm ? 'gcc-arm' : 'gcc-x86';
       default:
         return 'gcc-x64';
     }

--- a/src/cpptools.ts
+++ b/src/cpptools.ts
@@ -101,9 +101,15 @@ function parseTargetArch(target: string): Architecture {
     case 'amd64':
     case 'x86_64':
       return 'x64';
+    case 'aarch64':
+    case 'arm64':
+      return 'arm64';
+    case 'arm':
+      return 'arm';
   }
   // Check triple target value
-  if (target.indexOf('aarch64') >= 0 || target.indexOf('armv8-a') >= 0 || target.indexOf('armv8.') >= 0) {
+  if (target.indexOf('aarch64') >= 0 || target.indexOf('arm64') >= 0
+    || target.indexOf('armv8-a') >= 0 || target.indexOf('armv8.') >= 0) {
     return 'arm64';
   } else if (target.indexOf('arm') >= 0 || is_arm_32(target)) {
     return 'arm';
@@ -134,6 +140,7 @@ export function parseCompileFlags(cptVersion: cpt.Version, args: string[], lang?
       const {done, value} = iter.next();
       if (done) {
         // TODO: whitelist architecture values and add telemetry
+        //targetArch = value.toLowerCase();
         continue;
       }
       targetArch = parseTargetArch(value.toLowerCase());

--- a/src/cpptools.ts
+++ b/src/cpptools.ts
@@ -140,7 +140,6 @@ export function parseCompileFlags(cptVersion: cpt.Version, args: string[], lang?
       const {done, value} = iter.next();
       if (done) {
         // TODO: whitelist architecture values and add telemetry
-        //targetArch = value.toLowerCase();
         continue;
       }
       targetArch = parseTargetArch(value.toLowerCase());

--- a/test/unit-tests/cpptools.test.ts
+++ b/test/unit-tests/cpptools.test.ts
@@ -83,10 +83,16 @@ suite('CppTools tests', () => {
     expect(mode).to.eql('clang-arm');
     mode = getIntelliSenseMode(cpptoolsVersion4, 'clang', 'x64');
     expect(mode).to.eql('clang-x64');
+    mode = getIntelliSenseMode(cpptoolsVersion4, 'clang', 'arm64');
+    expect(mode).to.eql('clang-arm64');
     mode = getIntelliSenseMode(cpptoolsVersion4, 'clang', 'arm');
     expect(mode).to.eql('clang-arm');
     mode = getIntelliSenseMode(cpptoolsVersion4, 'gcc', undefined);
     expect(mode).to.eql('gcc-x64');
+    mode = getIntelliSenseMode(cpptoolsVersion4, 'gcc', 'arm64');
+    expect(mode).to.eql('gcc-arm64');
+    mode = getIntelliSenseMode(cpptoolsVersion4, 'gcc', 'arm');
+    expect(mode).to.eql('gcc-arm');
     mode = getIntelliSenseMode(cpptoolsVersion4, 'g++', 'x86');
     expect(mode).to.eql('gcc-x86');
     mode = getIntelliSenseMode(cpptoolsVersion4, 'arm-none-eabi-g++', undefined);

--- a/test/unit-tests/cpptools.test.ts
+++ b/test/unit-tests/cpptools.test.ts
@@ -38,12 +38,18 @@ suite('CppTools tests', () => {
     // Parse target architecture
     info = parseCompileFlags(cpptoolsVersion4, ['--target=aarch64-arm-none-eabi']);
     expect(info.targetArch).to.eql('arm64');
+    info = parseCompileFlags(cpptoolsVersion4, ['-target', 'arm64-arm-none-eabi']);
+    expect(info.targetArch).to.eql('arm64');
     info = parseCompileFlags(cpptoolsVersion4, ['-target', 'arm-arm-none-eabi']);
     expect(info.targetArch).to.eql('arm');
     info = parseCompileFlags(cpptoolsVersion4, ['-arch=x86_64']);
     expect(info.targetArch).to.eql('x64');
     info = parseCompileFlags(cpptoolsVersion4, ['-arch', 'aarch64']);
     expect(info.targetArch).to.eql('arm64');
+    info = parseCompileFlags(cpptoolsVersion4, ['-arch', 'arm64']);
+    expect(info.targetArch).to.eql('arm64');
+    info = parseCompileFlags(cpptoolsVersion4, ['-arch', 'arm']);
+    expect(info.targetArch).to.eql('arm');
     info = parseCompileFlags(cpptoolsVersion4, ['-arch', 'i686']);
     expect(info.targetArch).to.eql('x86');
     info = parseCompileFlags(cpptoolsVersion4, ['/arch:x86_64']);


### PR DESCRIPTION
<!-- Thanks for your contribution! To make things easier, please fill out the template below. -->

<!-- Please delete any unused sections. -->

<!-- Delete the following heading if there is no corresponding issue -->
## This change addresses item #1735

- The value `arm64` used for target architecture flags would get parsed as `arm` which resulted in sending the incorrect IntelliSenseMode to the vscode-cpptools extension.
- If gcc compiler is used, it would return clang compiler for IntelliSenseMode instead of gcc.

### This changes

- Code that parses value of target architecture flags. If value includes `arm64`, then it will return `arm64` architecture instead of `arm` to use as the architecture variant of the IntelliSenseMode.
- Code that returns IntelliSenseMode based on compiler path input will return `gcc-<arch>` IntelliSenseMode if gcc compiler is used.

## The purpose of this change

<!-- If not linked to an issue, describe the purpose of this change. Otherwise,
delete this section. -->
To return the correct compiler-architecture variant for IntelliSenseMode to vscode-cpptools extension.

## Other Notes/Information

<!-- Write whatever you feel is relevant -->
