### PR TITLE
Don't use for..in for array iteration

### DIFF
--- a/src/preset.ts
+++ b/src/preset.ts
@@ -878,13 +878,13 @@ async function expandBuildPresetHelper(preset: BuildPreset,
     if (util.isString(preset.targets)) {
       preset.targets = await expandString(preset.targets, expansionOpts);
     } else {
-      for (const index in preset.targets) {
+      for (let index = 0; index < preset.targets?.length; index++) {
         preset.targets[index] = await expandString(preset.targets[index], expansionOpts);
       }
     }
   }
   if (preset.nativeToolOptions) {
-    for (const index in preset.nativeToolOptions) {
+    for (let index = 0; index < preset.nativeToolOptions?.length; index++) {
       preset.nativeToolOptions[index] = await expandString(preset.nativeToolOptions[index], expansionOpts);
     }
   }
@@ -1030,7 +1030,7 @@ async function expandTestPresetHelper(preset: TestPreset,
 
   // Expand other fields
   if (preset.overwriteConfigurationFile) {
-    for (const index in preset.overwriteConfigurationFile) {
+    for (let index = 0; index < preset.overwriteConfigurationFile?.length; index++) {
       preset.overwriteConfigurationFile[index] = await expandString(preset.overwriteConfigurationFile[index], expansionOpts);
     }
   }

--- a/src/preset.ts
+++ b/src/preset.ts
@@ -878,13 +878,13 @@ async function expandBuildPresetHelper(preset: BuildPreset,
     if (util.isString(preset.targets)) {
       preset.targets = await expandString(preset.targets, expansionOpts);
     } else {
-      for (let index = 0; index < preset.targets?.length; index++) {
+      for (let index = 0; index < preset.targets.length; index++) {
         preset.targets[index] = await expandString(preset.targets[index], expansionOpts);
       }
     }
   }
   if (preset.nativeToolOptions) {
-    for (let index = 0; index < preset.nativeToolOptions?.length; index++) {
+    for (let index = 0; index < preset.nativeToolOptions.length; index++) {
       preset.nativeToolOptions[index] = await expandString(preset.nativeToolOptions[index], expansionOpts);
     }
   }
@@ -1030,7 +1030,7 @@ async function expandTestPresetHelper(preset: TestPreset,
 
   // Expand other fields
   if (preset.overwriteConfigurationFile) {
-    for (let index = 0; index < preset.overwriteConfigurationFile?.length; index++) {
+    for (let index = 0; index < preset.overwriteConfigurationFile.length; index++) {
       preset.overwriteConfigurationFile[index] = await expandString(preset.overwriteConfigurationFile[index], expansionOpts);
     }
   }

--- a/src/taskprovider.ts
+++ b/src/taskprovider.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 import * as vscode from 'vscode';
-import { isString } from 'util';
+import {isString} from './util';
 
 type TaskCommands = Record<string, string | string[] | null>;
 interface CMakeTaskDefinition extends vscode.TaskDefinition {


### PR DESCRIPTION
This fixes an issue while trying to set a build preset.  for..in should not be used when iterating through an array.  It will return back other properties (e.g. attached functions) that you don't intend to index out of the array object.