### PR TITLE
Clarify issue in CHANGELOG. Fix launch executable command.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ Bug fixes:
 - Dependencies package versions upgrade. [PR #1475](https://github.com/microsoft/vscode-cmake-tools/pull/1475) [@lygstate](https://github.com/lygstate)
 - Add vendor hostOs targetOs targetArch versionMajor versionMinor attributes for kit. [PR #1337](https://github.com/microsoft/vscode-cmake-tools/pull/1337) [@lygstate](https://github.com/lygstate)
 - Always correctly build target executable path. [PR #1674](https://github.com/microsoft/vscode-cmake-tools/pull/1674) [@falbrechtskirchinger](https://github.com/falbrechtskirchinger)
-- Use variables instead of hardcoded values for system path references. [PR #1690](https://github.com/microsoft/vscode-cmake-tools/pull/1690)
+- Use variables instead of hardcoded values for system path references. [#883](https://github.com/microsoft/vscode-cmake-tools/issues/883)(https://github.com/Zingam)
 - ctestPath should allow the same substitutions as cmakePath. [#785](https://github.com/microsoft/vscode-cmake-tools/issues/785) [@FakeTruth](https://github.com/FakeTruth)
 - Change the order of available kits such that folder kits come first. [#1736](https://github.com/microsoft/vscode-cmake-tools/issues/1736)
 - Fix "Configuring project" infinite loop when using "Locate" on a project without CMakeLists.txt. [#1704](https://github.com/microsoft/vscode-cmake-tools/issues/1704)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ Bug fixes:
 - Dependencies package versions upgrade. [PR #1475](https://github.com/microsoft/vscode-cmake-tools/pull/1475) [@lygstate](https://github.com/lygstate)
 - Add vendor hostOs targetOs targetArch versionMajor versionMinor attributes for kit. [PR #1337](https://github.com/microsoft/vscode-cmake-tools/pull/1337) [@lygstate](https://github.com/lygstate)
 - Always correctly build target executable path. [PR #1674](https://github.com/microsoft/vscode-cmake-tools/pull/1674) [@falbrechtskirchinger](https://github.com/falbrechtskirchinger)
-- Use variables instead of hardcoded values for system path references. [#883](https://github.com/microsoft/vscode-cmake-tools/issues/883)(https://github.com/Zingam)
+- Use variables instead of hardcoded values for system path references. [#883](https://github.com/microsoft/vscode-cmake-tools/issues/883) [@Zingam](https://github.com/Zingam)
 - ctestPath should allow the same substitutions as cmakePath. [#785](https://github.com/microsoft/vscode-cmake-tools/issues/785) [@FakeTruth](https://github.com/FakeTruth)
 - Change the order of available kits such that folder kits come first. [#1736](https://github.com/microsoft/vscode-cmake-tools/issues/1736)
 - Fix "Configuring project" infinite loop when using "Locate" on a project without CMakeLists.txt. [#1704](https://github.com/microsoft/vscode-cmake-tools/issues/1704)

--- a/src/drivers/cmakefileapi/api_helpers.ts
+++ b/src/drivers/cmakefileapi/api_helpers.ts
@@ -133,16 +133,12 @@ async function convertTargetObjectFileToExtensionTarget(build_dir: string, file_
     executable_path = targetObject.artifacts.find(artifact => artifact.path.endsWith(targetObject.nameOnDisk));
     if (executable_path) {
       executable_path = convertToAbsolutePath(executable_path.path, build_dir);
-      if (!await fs.exists(executable_path)) {
-        // Will be empty after cmake configuration
-        executable_path = "";
-      }
     }
   }
 
   return {
     name: targetObject.name,
-    filepath: executable_path ? executable_path : 'Utility target',
+    filepath: executable_path,
     targetType: targetObject.type,
     type: 'rich' as 'rich'
   } as api.RichTarget;


### PR DESCRIPTION
It looks that this wasn't actually a regression (although I don't remember seeing the symptom) so I won't object if we triage it for 1.8.
In many scenarios, the first time would launch an executable we wouldn't have its real path as a command but "Utility target" which is not recognized by the shell. Since now build before run is defaulted to true, the binary will be present when invoked, even if when evaluated it wasn't yet there. And even if build before run is false, I don't understand why we would ever want "Utility target" as a command for launch executable, let me know if I miss anything.