### PR TITLE
CMake Presets in Muti Root

### DIFF
--- a/src/cmake-tools.ts
+++ b/src/cmake-tools.ts
@@ -167,7 +167,8 @@ export class CMakeTools implements vscode.Disposable, api.CMakeToolsAPI {
   async setConfigurePreset(configurePreset: string | null) {
     if (configurePreset) {
       log.debug(localize('resolving.config.preset', 'Resolving the selected configure preset'));
-      const expandedConfigurePreset = await preset.expandConfigurePreset(configurePreset,
+      const expandedConfigurePreset = await preset.expandConfigurePreset(this.folder.uri.fsPath,
+                                                                         configurePreset,
                                                                          lightNormalizePath(this.folder.uri.fsPath || '.'),
                                                                          await this.sourceDir,
                                                                          true);
@@ -221,7 +222,8 @@ export class CMakeTools implements vscode.Disposable, api.CMakeToolsAPI {
   async setBuildPreset(buildPreset: string | null) {
     if (buildPreset) {
       log.debug(localize('resolving.build.preset', 'Resolving the selected build preset'));
-      const expandedBuildPreset = await preset.expandBuildPreset(buildPreset,
+      const expandedBuildPreset = await preset.expandBuildPreset(this.folder.uri.fsPath,
+                                                                 buildPreset,
                                                                  lightNormalizePath(this.folder.uri.fsPath || '.'),
                                                                  await this.sourceDir,
                                                                  true,
@@ -271,7 +273,8 @@ export class CMakeTools implements vscode.Disposable, api.CMakeToolsAPI {
   async setTestPreset(testPreset: string | null) {
     if (testPreset) {
       log.debug(localize('resolving.test.preset', 'Resolving the selected test preset'));
-      const expandedTestPreset = await preset.expandTestPreset(testPreset,
+      const expandedTestPreset = await preset.expandTestPreset(this.folder.uri.fsPath,
+                                                               testPreset,
                                                                lightNormalizePath(this.folder.uri.fsPath || '.'),
                                                                await this.sourceDir,
                                                                true,

--- a/src/folders.ts
+++ b/src/folders.ts
@@ -10,7 +10,6 @@ import { KitsController } from '@cmt/kitsController';
 import rollbar from '@cmt/rollbar';
 import { disposeAll, setContextValue } from '@cmt/util';
 import { PresetsController } from '@cmt/presetsController';
-import * as preset from '@cmt/preset';
 
 nls.config({ messageFormat: nls.MessageFormat.bundle, bundleFormat: nls.BundleFormat.standalone })();
 const localize: nls.LocalizeFunc = nls.loadMessageBundle();
@@ -34,8 +33,8 @@ export class CMakeToolsFolder {
       }
     };
     cmakeTools.workspaceContext.config.onChange('useCMakePresets', useCMakePresetsChangedListener);
-    preset.onPresetsChanged(useCMakePresetsChangedListener);
-    preset.onUserPresetsChanged(useCMakePresetsChangedListener);
+    presetsController.onPresetsChanged(useCMakePresetsChangedListener);
+    presetsController.onUserPresetsChanged(useCMakePresetsChangedListener);
   }
 
   static async init(cmakeTools: CMakeTools) {


### PR DESCRIPTION
When I moved presets caches from presetsController.ts to presets.ts (since expansions may require access to other presets), the folder info was lost. Adding it back by making every function in presets.ts accept a folder parameter.