### PR TITLE
Default standard depends on cpptools provider version

### DIFF
--- a/src/cpptools.ts
+++ b/src/cpptools.ts
@@ -122,7 +122,7 @@ export function parseCompileFlags(cptVersion: cpt.Version, args: string[], lang?
   const can_use_gnu_std = (cptVersion >= cpt.Version.v4);
   const iter = args[Symbol.iterator]();
   const extraDefinitions: string[] = [];
-  let standard: StandardVersion | undefined;
+  let standard: StandardVersion | undefined = (cptVersion > cpt.Version.v4) ? undefined : (lang === 'C') ? 'c11' : 'c++17';
   let targetArch: Architecture = undefined;
   while (1) {
     const {done, value} = iter.next();

--- a/test/unit-tests/cpptools.test.ts
+++ b/test/unit-tests/cpptools.test.ts
@@ -27,7 +27,13 @@ suite('CppTools tests', () => {
     expect(info.extraDefinitions).to.eql(['FOO=BAR']);
     info = parseCompileFlags(cpptoolsVersion4, ['-DFOO=BAR', '/D', 'BAZ=QUX']);
     expect(info.extraDefinitions).to.eql(['FOO=BAR', 'BAZ=QUX']);
-    expect(info.standard).to.eql(undefined);
+    expect(info.standard).to.eql('c++17');
+    info = parseCompileFlags(cpptoolsVersion4, [], 'C');
+    expect(info.standard).to.eql('c11');
+    info = parseCompileFlags(cpptoolsVersion4, [], 'CXX');
+    expect(info.standard).to.eql('c++17');
+    info = parseCompileFlags(cpptoolsVersion4, [], 'CUDA');
+    expect(info.standard).to.eql('c++17');
     // Parse language standard
     info = parseCompileFlags(cpptoolsVersion4, ['-std=c++03']);
     expect(info.standard).to.eql('c++03');


### PR DESCRIPTION
Fixes #1786

Cpptools allows for configuration providers to optionally set the "standard" property.  But this allowance is only for version 5 and above.  For version 4 and earlier, we need to restore the old default values.