### PR TITLE
CppTools-API v5 integration

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -658,7 +658,7 @@ class ExtensionManager implements vscode.Disposable {
     );
     rollbar.invokeAsync(localize('update.code.model.for.cpptools', 'Update code model for cpptools'), {}, async () => {
       if (!this._cppToolsAPI) {
-        this._cppToolsAPI = await cpt.getCppToolsApi(cpt.Version.v4);
+        this._cppToolsAPI = await cpt.getCppToolsApi(cpt.Version.v5);
       }
       if (this._cppToolsAPI && cmt.codeModel && cmt.activeKit) {
         const codeModel = cmt.codeModel;

--- a/test/unit-tests/cpptools.test.ts
+++ b/test/unit-tests/cpptools.test.ts
@@ -19,9 +19,14 @@ suite('CppTools tests', () => {
     // Parse definition
     const cpptoolsVersion3 = Version.v3;
     const cpptoolsVersion4 = Version.v4;
+    const cpptoolsVersion5 = Version.v5;
+
+    // Verify CppTools API version 5
+    let info = parseCompileFlags(cpptoolsVersion5, ['-target', 'arm-arm-none-eabi']);
+    expect(info.targetArch).to.eql(undefined);
 
     // Verify CppTools API version 4
-    let info = parseCompileFlags(cpptoolsVersion4, ['-DFOO=BAR']);
+    info = parseCompileFlags(cpptoolsVersion4, ['-DFOO=BAR']);
     expect(info.extraDefinitions).to.eql(['FOO=BAR']);
     info = parseCompileFlags(cpptoolsVersion4, ['-D', 'FOO=BAR']);
     expect(info.extraDefinitions).to.eql(['FOO=BAR']);
@@ -79,9 +84,16 @@ suite('CppTools tests', () => {
   test('Get IntelliSenseMode', () => {
     const cpptoolsVersion3 = Version.v3;
     const cpptoolsVersion4 = Version.v4;
+    const cpptoolsVersion5 = Version.v5;
+
+    // Verify CppToolsAPI version 5
+    let mode = getIntelliSenseMode(cpptoolsVersion5, 'cl.exe', undefined);
+    expect(mode).to.eql(undefined);
+    mode = getIntelliSenseMode(cpptoolsVersion5, 'clang', undefined);
+    expect(mode).to.eql(undefined);
 
     // Verify CppTools API version 4
-    let mode = getIntelliSenseMode(cpptoolsVersion4, 'armclang', 'arm');
+    mode = getIntelliSenseMode(cpptoolsVersion4, 'armclang', 'arm');
     expect(mode).to.eql('clang-arm');
     mode = getIntelliSenseMode(cpptoolsVersion4, 'armclang', 'arm64');
     expect(mode).to.eql('clang-arm64');

--- a/test/unit-tests/cpptools.test.ts
+++ b/test/unit-tests/cpptools.test.ts
@@ -24,6 +24,10 @@ suite('CppTools tests', () => {
     // Verify CppTools API version 5
     let info = parseCompileFlags(cpptoolsVersion5, ['-target', 'arm-arm-none-eabi']);
     expect(info.targetArch).to.eql(undefined);
+    info = parseCompileFlags(cpptoolsVersion5, ['-std=gnu++14']);
+    expect(info.standard).to.eql('gnu++14');
+    info = parseCompileFlags(cpptoolsVersion5, []);
+    expect(info.standard).to.eql(undefined);
 
     // Verify CppTools API version 4
     info = parseCompileFlags(cpptoolsVersion4, ['-DFOO=BAR']);
@@ -46,6 +50,10 @@ suite('CppTools tests', () => {
     expect(info.standard).to.eql('gnu++14');
     info = parseCompileFlags(cpptoolsVersion4, ['-std=c17']);
     expect(info.standard).to.eql('c17');
+    info = parseCompileFlags(cpptoolsVersion4, ['-std=c++123']);
+    expect(info.standard).to.eql('c++17');
+    info = parseCompileFlags(cpptoolsVersion4, ['-std=c123'], 'C');
+    expect(info.standard).to.eql('c11');
     // Parse target architecture
     info = parseCompileFlags(cpptoolsVersion4, ['--target=aarch64-arm-none-eabi']);
     expect(info.targetArch).to.eql('arm64');


### PR DESCRIPTION
<!-- Thanks for your contribution! To make things easier, please fill out the template below. -->

<!-- Please delete any unused sections. -->

<!-- Delete the following heading if there is no corresponding issue -->
## This change addresses item #1624

### This changes IntelliSenseMode and Standard values as optional (undefined) for CppTools-API v5+

The following changes are proposed:

- Return undefined IntelliSenseMode for CppTools-API v5+
- If Standard C or C++ cannot be parsed, returns undefined for CppTools-API v5+

## The purpose of this change

CppTools-API v5 integration
