### PR TITLE
Inject environment merged from all sources into the string expansion …

### DIFF
--- a/src/drivers/driver.ts
+++ b/src/drivers/driver.ts
@@ -549,6 +549,7 @@ export abstract class CMakeDriver implements vscode.Disposable {
     return this.doRefreshExpansions(async () => {
       log.debug('Run _refreshExpansions cb');
       const opts = this.expansionOptions;
+      opts.envOverride = await this.getConfigureEnvironment();
       this._sourceDirectory = await util.normalizeAndVerifySourceDir(await expand.expandString(this.config.sourceDirectory, opts));
 
       if (!this.useCMakePresets) {


### PR DESCRIPTION
https://github.com/microsoft/vscode-cmake-tools/issues/1250 is not fixed with 1.7.
I either had a loophole in testing the original PR that targeted the issue or it regressed with more recent PRs.
This fix is ensuring an up to date environment is sent every time we expand a string.