### PR TITLE
Fix typo in CMakePresets.json schema

### DIFF
--- a/schemas/CMakePresets-schema.json
+++ b/schemas/CMakePresets-schema.json
@@ -455,7 +455,7 @@
                                           "Debug",
                                           "Release",
                                           "RelWithDebInfo",
-                                          "MinSizRel"
+                                          "MinSizeRel"
                                       ]
                                   },
                                   {


### PR DESCRIPTION
### This changes visible behavior

The following changes are proposed:

- MinSizRel => MinSizeRel

## The purpose of this change

The typo in the schema file prevents the use of presets if it contains in any configuration
```
     "cacheVariables": {
        "CMAKE_BUILD_TYPE": "MinSizeRel",
...
      }
```