### PR TITLE
override the locale when querying compiler versions

### DIFF
--- a/.github/workflows/build-vsix.yml
+++ b/.github/workflows/build-vsix.yml
@@ -2,7 +2,9 @@ name: Build VSIX
 
 on:
   push:
-    branches: [ develop ]
+    branches:
+      - develop
+      - bobbrow/gccLocale
 
 jobs:
   build:

--- a/.github/workflows/build-vsix.yml
+++ b/.github/workflows/build-vsix.yml
@@ -2,9 +2,7 @@ name: Build VSIX
 
 on:
   push:
-    branches:
-      - develop
-      - bobbrow/gccLocale
+    branches: [ develop ]
 
 jobs:
   build:

--- a/src/kit.ts
+++ b/src/kit.ts
@@ -153,11 +153,7 @@ interface CompilerVersion {
 
 export async function getCompilerVersion(vendor: CompilerVendorEnum, binPath: string): Promise<CompilerVersion|null> {
   log.debug(localize('testing.compiler.binary', 'Testing {0} binary: {1}', vendor, binPath));
-  const environment: proc.EnvironmentVariables = {
-    LANG: "C",
-    LC_ALL: "C"
-  };
-  const exec = await proc.execute(binPath, ['-v'], undefined, { environment }).result;
+  const exec = await proc.execute(binPath, ['-v'], undefined, { overrideLocale: true }).result;
   if (exec.retc !== 0) {
     log.debug(localize('bad.compiler.binary', 'Bad {0} binary ("-v" returns non-zero): {1}', vendor, binPath));
     return null;
@@ -177,7 +173,6 @@ export async function getCompilerVersion(vendor: CompilerVendorEnum, binPath: st
   let fullVersion: string = "";
   const lines = exec.stderr.trim().split('\n');
   for (const line of lines) {
-    log.debug(`[${vendor}] ${line}`);
     const version_match = version_re.exec(line);
     if (version_match !== null && version === '') {
       version = version_match[version_match_index];

--- a/src/kit.ts
+++ b/src/kit.ts
@@ -177,6 +177,7 @@ export async function getCompilerVersion(vendor: CompilerVendorEnum, binPath: st
   let fullVersion: string = "";
   const lines = exec.stderr.trim().split('\n');
   for (const line of lines) {
+    log.debug(`[${vendor}] ${line}`);
     const version_match = version_re.exec(line);
     if (version_match !== null && version === '') {
       version = version_match[version_match_index];

--- a/src/proc.ts
+++ b/src/proc.ts
@@ -82,6 +82,7 @@ export interface ExecutionOptions {
   encoding?: BufferEncoding;
   outputEncoding?: string;
   useTask?: boolean;
+  overrideLocale?: boolean;
 }
 
 export function buildCmdStr(command: string, args?: string[]): string {
@@ -114,7 +115,15 @@ export function execute(command: string,
   if (!options) {
     options = {};
   }
-  const final_env = util.mergeEnvironment(process.env as EnvironmentVariables, options.environment || {});
+  const localeOverride: EnvironmentVariables = {
+    LANG: "C",
+    LC_ALL: "C"
+  };
+  const final_env = util.mergeEnvironment(
+    process.env as EnvironmentVariables,
+    options.environment || {},
+    options.overrideLocale ? localeOverride : {});
+
   const spawn_opts: proc.SpawnOptions = {
     env: final_env,
     shell: !!options.shell,


### PR DESCRIPTION
<!-- Thanks for your contribution! To make things easier, please fill out the template below. -->

<!-- Please delete any unused sections. -->

<!-- Delete the following heading if there is no corresponding issue -->
## This change addresses item #1821

This changes how compilers are queried when scanning for kits.

#### The following changes are proposed:
Set LANG and LC_ALL to "C" in the environment before invoking gcc or clang.
