### PR TITLE
Fix use of wrong xlf for loc

### DIFF
--- a/translations_auto_pr.js
+++ b/translations_auto_pr.js
@@ -74,7 +74,7 @@ sleep(10000);
 let rootSourcePath = `${locRepoPath}\\Src\\VSCodeExt`;
 let directories = fs.readdirSync(rootSourcePath, { withFileTypes: true }).filter(dirent => dirent.isDirectory()).map(dirent => dirent.name);
 directories.forEach(folderName => {
-    let sourcePath = `${rootSourcePath}\\${folderName}\\vscode-cpptools.xlf`;
+    let sourcePath = `${rootSourcePath}\\${folderName}\\vscode-${locProjectName}.xlf`;
     let destinationPath = `./vscode-translations-import/${folderName}/vscode-extensions/vscode-${locProjectName}.xlf`;
     console.log(`Copying "${sourcePath}" to "${destinationPath}"`);
     fs.copySync(sourcePath, destinationPath);


### PR DESCRIPTION
Fixes use of a hard-coded string I missed when porting the updated PR script from cpptools.

For the moment, I've paused the loc PR pipeline, until I'm done with some changes to this process in cpptools.  Once that is ready, I will bring the CMake Tools loc pipeline back online.   That should happen within the next couple days.
