### PR TITLE
Change which might fix CRLF issues in localized strings

### DIFF
--- a/jobs/loc/TranslationsImportExport.yml
+++ b/jobs/loc/TranslationsImportExport.yml
@@ -41,6 +41,7 @@ steps:
     patVariable: '$(OneLocBuildPat)'
     LclSource: lclFilesfromPackage
     LclPackageId: 'LCL-JUNO-PROD-VCMAKE'
+    isUseLfLineEndingsSelected: true
 
 - task: CmdLine@2
   inputs:


### PR DESCRIPTION
We're still in the process of investigating the issue causing `\r` to be added to localized strings.

We want to rule out this setting as potentially addressing the issue.
