### PR TITLE
Work around issue causing newlines in localized strings

### DIFF
--- a/jobs/loc/TranslationsImportExport.yml
+++ b/jobs/loc/TranslationsImportExport.yml
@@ -42,6 +42,7 @@ steps:
     LclSource: lclFilesfromPackage
     LclPackageId: 'LCL-JUNO-PROD-VCMAKE'
     isUseLfLineEndingsSelected: true
+    lsBuildXLocPackageVersion: '7.0.30510'
 
 - task: CmdLine@2
   inputs:


### PR DESCRIPTION
There is step in the loc pipeline adding \r's to strings. This change is to revert to a version of a package prior to the introduction of the issue.

This line will need to be removed once the issue has been fixed.
