### PR TITLE
Write lint message to stderr

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -266,7 +266,7 @@ gulp.task('lint', function () {
     // Un-comment these parts for applying auto-fix.
     return gulp.src(allTypeScript)
         .pipe(eslint({ configFile: ".eslintrc.js" /*, fix: true */}))
-        .pipe(eslint.format())
+        .pipe(eslint.format(undefined, process.stderr))
         //.pipe(gulp.dest(file => file.base))
         .pipe(eslint.failAfterError());
 });


### PR DESCRIPTION
This resolves @bobbrow 's concern in #1967. Turns out gulp-eslint has a way to write to stderr.

First parameter is formatter. Passing undefined makes it to use the default.