### PR TITLE
Fixing broken links to contributing file

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 - [How to](docs/how-to.md)
 - [FAQ](docs/faq.md)
 - [Read the online documentation](docs/README.md)
-- [Contribute](docs/contribute.md)
+- [Contribute](CONTRIBUTING.md)
 
 ## Issues? Questions? Feature requests?
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -89,7 +89,7 @@ CMake Tools is an extension designed to make it easy to work with CMake-based pr
 * [How does CMake Tools work with C and C++ IntelliSense?](faq.md#how-does-cmake-tools-work-with-c-and-c-intellisense)
 * [How do I perform common tasks](faq.md#how-do-i-perform-common-tasks)
 
-[How to contribute](contribute.md)
-* [Developer Reference](contribute.md#developer-reference)
-* [Build the CMake Tools extension](contribute.md#build-the-cmake-tools-extension)
-* [Coding guidelines](contribute.md#coding-guidelines)
+[How to contribute](../CONTRIBUTING.md)
+* [Developer Reference](../CONTRIBUTING.md#developer-reference)
+* [Build the CMake Tools extension](../CONTRIBUTING.md#build-the-cmake-tools-extension)
+* [Coding guidelines](../CONTRIBUTING.md#coding-guidelines)


### PR DESCRIPTION
Today I came across a broken link to the project's contribution guideline. After investigating, I noticed that the referenced file was deleted on 72ded8e425c4163afaa40a633611c1b173426426 and the links to this file were not updated. Thus, in this pull request, I updated two markdown files to point to the existing CONTRIBUTING.md file in the project's root folder.  