### PR TITLE
compdb: opt to use any compile_commands.json in build dir

### DIFF
--- a/package.json
+++ b/package.json
@@ -1440,6 +1440,12 @@
           "description": "%cmake-tools.configuration.cmake.emscriptenSearchDirs.description%",
           "scope": "window"
         },
+        "cmake.collectCompileCommands": {
+          "type": "boolean",
+          "default": false,
+          "description": "%cmake-tools.configuration.cmake.collectCompileCommands.description%",
+          "scope": "resource"
+        },
         "cmake.copyCompileCommands": {
           "type": "string",
           "default": null,

--- a/package.nls.json
+++ b/package.nls.json
@@ -107,6 +107,7 @@
     "cmake-tools.configuration.cmake.mingwSearchDirs.description": "Directories where MinGW may be installed.",
     "cmake-tools.configuration.cmake.searchDirs.items.description": "Path to a directory.",
     "cmake-tools.configuration.cmake.emscriptenSearchDirs.description": "Directories where Emscripten may be installed.",
+    "cmake-tools.configuration.cmake.collectCompileCommands.description": "Recursively collect all compile_commands.json found in the cmake.buildDirectory.",
     "cmake-tools.configuration.cmake.copyCompileCommands.description": "Copy compile_commands.json to this location after a successful configure.",
     "cmake-tools.configuration.cmake.configureOnOpen.description": "Automatically configure CMake project directories when they are opened.",
     "cmake-tools.configuration.cmake.configureOnEdit.description": "Automatically configure CMake project directories when cmake.sourceDirectory or CMakeLists.txt content are saved.",

--- a/src/compdb.ts
+++ b/src/compdb.ts
@@ -38,17 +38,36 @@ export class CompilationDatabase {
 
   get(fspath: string) { return this._infoByFilePath.get(util.platformNormalizePath(fspath)); }
 
-  public static async fromFilePath(dbpath: string): Promise<CompilationDatabase|null> {
-    if (!await fs.exists(dbpath)) {
-      return null;
+  public static async fromFilePaths(dbpaths: string[]): Promise<CompilationDatabase|null> {
+    const db: ArgsCompileCommand[] = [];
+
+    for (const dbpath of dbpaths) {
+      if (!await fs.exists(dbpath)) {
+        continue;
+      }
+
+      const data = await fs.readFile(dbpath);
+      try {
+        const content = JSON.parse(data.toString()) as ArgsCompileCommand[];
+        db.push(...content);
+      } catch (e) {
+        log.warning(localize('error.parsing.compilation.database', 'Error parsing compilation database "{0}": {1}', dbpath, util.errorToString(e)));
+        return null;
+      }
     }
-    const data = await fs.readFile(dbpath);
-    try {
-      const content = JSON.parse(data.toString()) as ArgsCompileCommand[];
-      return new CompilationDatabase(content);
-    } catch (e) {
-      log.warning(localize('error.parsing.compilation.database', 'Error parsing compilation database "{0}": {1}', dbpath, util.errorToString(e)));
-      return null;
+
+    if (db.length > 0) {
+      return new CompilationDatabase(db);
     }
+
+    return null;
+  }
+
+  public static toJson(db: CompilationDatabase|null): string {
+    if (db === null) {
+      return '[]';
+    }
+
+    return JSON.stringify([...db._infoByFilePath.values()].map(({file, command, directory}) => ({file, command, directory})));
   }
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -120,6 +120,7 @@ export interface ExtensionConfigurationSettings {
   testEnvironment: HardEnv;
   mingwSearchDirs: string[];
   emscriptenSearchDirs: string[];
+  collectCompileCommands: boolean;
   copyCompileCommands: string|null;
   configureOnOpen: boolean|null;
   configureOnEdit: boolean;
@@ -303,6 +304,7 @@ export class ConfigurationReader implements vscode.Disposable {
   get mingwSearchDirs(): string[] { return this.configData.mingwSearchDirs; }
   get additionalKits(): string[] { return this.configData.additionalKits; }
   get emscriptenSearchDirs(): string[] { return this.configData.emscriptenSearchDirs; }
+  get collectCompileCommands(): boolean { return this.configData.collectCompileCommands; }
   get copyCompileCommands(): string|null { return this.configData.copyCompileCommands; }
   get ignoreKitEnv(): boolean { return this.configData.ignoreKitEnv; }
   get buildTask(): boolean { return this.configData.buildTask; }
@@ -352,6 +354,7 @@ export class ConfigurationReader implements vscode.Disposable {
     testEnvironment: new vscode.EventEmitter<HardEnv>(),
     mingwSearchDirs: new vscode.EventEmitter<string[]>(),
     emscriptenSearchDirs: new vscode.EventEmitter<string[]>(),
+    collectCompileCommands: new vscode.EventEmitter<boolean>(),
     copyCompileCommands: new vscode.EventEmitter<string|null>(),
     configureOnOpen: new vscode.EventEmitter<boolean|null>(),
     configureOnEdit: new vscode.EventEmitter<boolean>(),

--- a/src/pr.ts
+++ b/src/pr.ts
@@ -7,6 +7,7 @@ import * as util from 'util';
 const promisify = util.promisify;
 
 import * as fs_ from 'fs';
+import { walk as walk_ } from '@nodelib/fs.walk';
 import * as path from 'path';
 
 import * as rimraf from 'rimraf';
@@ -39,6 +40,8 @@ export const mkdtemp = promisify(fs_.mkdtemp);
 export const rename = promisify(fs_.rename);
 
 export const stat = promisify(fs_.stat);
+
+export const walk = promisify(walk_);
 
 /**
  * Try and stat() a file. If stat() fails for *any reason*, returns `null`.

--- a/test/unit-tests/config.test.ts
+++ b/test/unit-tests/config.test.ts
@@ -37,6 +37,7 @@ function createConfig(conf: Partial<ExtensionConfigurationSettings>): Configurat
     testEnvironment: {},
     mingwSearchDirs: [],
     emscriptenSearchDirs: [],
+    collectCompileCommands: false,
     copyCompileCommands: null,
     configureOnOpen: null,
     configureOnEdit: true,


### PR DESCRIPTION
### This changes visible behavior

The following changes are proposed:

Add an option to collect all `compile_commands.json` from the build directory and merge them into one for consumption by `vscode-cpptools`.

## The purpose of this change

The option "Collect Compile Commands" will merge all `compile_commands.json` from the build directory into a new JSON file. This functionality is an enabler for IntelliSense in ExternalProject based "superbuilds".

## Other Notes/Information

In order to get IntelliSense support with superbuilds, few settings are required:

```json
{
    "cmake.collectCompileCommands": true,
    "cmake.copyCompileCommands": "${workspaceFolder}/build/combined_compile_commands.json",
    "C_Cpp.default.compileCommands": "${workspaceFolder}/build/combined_compile_commands.json",
}
```
