### PR TITLE
Force to use JSON as the language mode of presets files

### DIFF
--- a/src/folders.ts
+++ b/src/folders.ts
@@ -59,8 +59,10 @@ export class CMakeToolsFolder {
             }
           });
         } else {
-          cmtFolder._onDidOpenTextDocumentListener?.dispose();
-          cmtFolder._onDidOpenTextDocumentListener = undefined;
+          if (cmtFolder._onDidOpenTextDocumentListener) {
+            cmtFolder._onDidOpenTextDocumentListener.dispose();
+            cmtFolder._onDidOpenTextDocumentListener = undefined;
+          }
         }
 
         cmtFolder._onUseCMakePresetsChangedEmitter.fire(usingCMakePresets);
@@ -94,7 +96,9 @@ export class CMakeToolsFolder {
   get onUseCMakePresetsChanged() { return this._onUseCMakePresetsChangedEmitter.event; }
 
   dispose() {
-    this._onDidOpenTextDocumentListener?.dispose();
+    if (this._onDidOpenTextDocumentListener) {
+      this._onDidOpenTextDocumentListener.dispose();
+    }
     this.cmakeTools.dispose();
     this.kitsController.dispose();
   }

--- a/src/folders.ts
+++ b/src/folders.ts
@@ -3,6 +3,7 @@
  */ /** */
 import * as vscode from 'vscode';
 import * as nls from 'vscode-nls';
+import * as path from 'path';
 
 import * as util from '@cmt/util';
 import CMakeTools from '@cmt/cmake-tools';
@@ -16,35 +17,62 @@ const localize: nls.LocalizeFunc = nls.loadMessageBundle();
 
 export class CMakeToolsFolder {
   private _wasUsingCMakePresets: boolean | undefined;
+  private _onDidOpenTextDocumentListener: vscode.Disposable | undefined;
+  private _disposables: vscode.Disposable[] = [];
 
   private readonly _onUseCMakePresetsChangedEmitter = new vscode.EventEmitter<boolean>();
 
   private constructor(readonly cmakeTools: CMakeTools,
                       readonly kitsController: KitsController,
-                      readonly presetsController: PresetsController) {
-    const useCMakePresetsChangedListener = async () => {
-      const usingCMakePresets = this.useCMakePresets;
-      if (usingCMakePresets !== this._wasUsingCMakePresets) {
-        this._wasUsingCMakePresets = usingCMakePresets;
-        await setContextValue('useCMakePresets', usingCMakePresets);
-        await cmakeTools.setUseCMakePresets(usingCMakePresets);
-        await CMakeToolsFolder.initializeKitOrPresetsInCmt(this);
-        this._onUseCMakePresetsChangedEmitter.fire(usingCMakePresets);
-      }
-    };
-    cmakeTools.workspaceContext.config.onChange('useCMakePresets', useCMakePresetsChangedListener);
-    presetsController.onPresetsChanged(useCMakePresetsChangedListener);
-    presetsController.onUserPresetsChanged(useCMakePresetsChangedListener);
-  }
+                      readonly presetsController: PresetsController) { }
 
   static async init(cmakeTools: CMakeTools) {
     const kitsController = await KitsController.init(cmakeTools);
-    const cmtFolder = new CMakeToolsFolder(cmakeTools, kitsController, await PresetsController.init(cmakeTools, kitsController));
-    const usingCMakePresets = cmtFolder.useCMakePresets;
-    cmtFolder._wasUsingCMakePresets = usingCMakePresets;
-    await setContextValue('useCMakePresets', usingCMakePresets);
-    await cmakeTools.setUseCMakePresets(usingCMakePresets);
-    await CMakeToolsFolder.initializeKitOrPresetsInCmt(cmtFolder);
+    const presetsController = await PresetsController.init(cmakeTools, kitsController);
+    const cmtFolder = new CMakeToolsFolder(cmakeTools, kitsController, presetsController);
+
+    const useCMakePresetsChangedListener = async () => {
+      const usingCMakePresets = cmtFolder.useCMakePresets;
+      if (usingCMakePresets !== cmtFolder._wasUsingCMakePresets) {
+        cmtFolder._wasUsingCMakePresets = usingCMakePresets;
+        await setContextValue('useCMakePresets', usingCMakePresets);
+        await cmakeTools.setUseCMakePresets(usingCMakePresets);
+        await CMakeToolsFolder.initializeKitOrPresetsInCmt(cmtFolder);
+
+        if (usingCMakePresets) {
+          const presetsFileHasWrongLanguageId = (document: vscode.TextDocument) => {
+            const fileName = path.basename(document.uri.fsPath);
+            return (fileName === 'CMakePresets.json' || fileName === 'CMakeUserPresets.json') &&
+                document.languageId !== 'json';
+          };
+
+          cmtFolder._onDidOpenTextDocumentListener = vscode.workspace.onDidOpenTextDocument(document => {
+            if (presetsFileHasWrongLanguageId(document)) {
+              // setTextDocumentLanguage will trigger onDidOpenTextDocument
+              void vscode.languages.setTextDocumentLanguage(document, 'json');
+            }
+          });
+
+          vscode.workspace.textDocuments.forEach(document => {
+            if (presetsFileHasWrongLanguageId(document)) {
+              void vscode.languages.setTextDocumentLanguage(document, 'json');
+            }
+          });
+        } else {
+          cmtFolder._onDidOpenTextDocumentListener?.dispose();
+          cmtFolder._onDidOpenTextDocumentListener = undefined;
+        }
+
+        cmtFolder._onUseCMakePresetsChangedEmitter.fire(usingCMakePresets);
+      }
+    };
+
+    await useCMakePresetsChangedListener();
+
+    cmtFolder._disposables.push(cmakeTools.workspaceContext.config.onChange('useCMakePresets', useCMakePresetsChangedListener));
+    cmtFolder._disposables.push(presetsController.onPresetsChanged(useCMakePresetsChangedListener));
+    cmtFolder._disposables.push(presetsController.onUserPresetsChanged(useCMakePresetsChangedListener));
+
     return cmtFolder;
   }
 
@@ -66,6 +94,7 @@ export class CMakeToolsFolder {
   get onUseCMakePresetsChanged() { return this._onUseCMakePresetsChangedEmitter.event; }
 
   dispose() {
+    this._onDidOpenTextDocumentListener?.dispose();
     this.cmakeTools.dispose();
     this.kitsController.dispose();
   }

--- a/src/folders.ts
+++ b/src/folders.ts
@@ -40,24 +40,20 @@ export class CMakeToolsFolder {
         await CMakeToolsFolder.initializeKitOrPresetsInCmt(cmtFolder);
 
         if (usingCMakePresets) {
-          const presetsFileHasWrongLanguageId = (document: vscode.TextDocument) => {
+          const setPresetsFileLanguageMode = (document: vscode.TextDocument) => {
             const fileName = path.basename(document.uri.fsPath);
-            return (fileName === 'CMakePresets.json' || fileName === 'CMakeUserPresets.json') &&
-                document.languageId !== 'json';
-          };
-
-          cmtFolder._onDidOpenTextDocumentListener = vscode.workspace.onDidOpenTextDocument(document => {
-            if (presetsFileHasWrongLanguageId(document)) {
+            if ((fileName === 'CMakePresets.json' || fileName === 'CMakeUserPresets.json') &&
+                document.languageId !== 'json') {
               // setTextDocumentLanguage will trigger onDidOpenTextDocument
               void vscode.languages.setTextDocumentLanguage(document, 'json');
             }
-          });
+          };
 
-          vscode.workspace.textDocuments.forEach(document => {
-            if (presetsFileHasWrongLanguageId(document)) {
-              void vscode.languages.setTextDocumentLanguage(document, 'json');
-            }
-          });
+          cmtFolder._onDidOpenTextDocumentListener = vscode.workspace.onDidOpenTextDocument(document =>
+            setPresetsFileLanguageMode(document)
+          );
+
+          vscode.workspace.textDocuments.forEach(document => setPresetsFileLanguageMode(document));
         } else {
           if (cmtFolder._onDidOpenTextDocumentListener) {
             cmtFolder._onDidOpenTextDocumentListener.dispose();


### PR DESCRIPTION
<!-- Thanks for your contribution! To make things easier, please fill out the template below. -->

<!-- Please delete any unused sections. -->

<!-- Delete the following heading if there is no corresponding issue -->
## This change addresses item #2035

The behavior is as expected, i.e. the language mode of presets files is always set to JSON, but there's a bug in VS Code currently: https://github.com/microsoft/vscode/issues/130436
