### PR TITLE
Fix presets using server API

### DIFF
--- a/src/expand.ts
+++ b/src/expand.ts
@@ -54,6 +54,10 @@ export interface PresetContextVars extends RequiredExpansionContextVars {
   presetName: string;
 }
 
+export interface MinimalPresetContextVars extends RequiredExpansionContextVars {
+  [key: string]: string;
+}
+
 /**
  * Options to control the behavior of `expandString`.
  */
@@ -61,7 +65,7 @@ export interface ExpansionOptions {
   /**
    * Plain `${variable}` style expansions.
    */
-  vars: KitContextVars | PresetContextVars;
+  vars: KitContextVars | PresetContextVars | MinimalPresetContextVars;
   /**
    * Override the values used in `${env:var}`-style and `${env.var}`-style expansions.
    *


### PR DESCRIPTION
## This change addresses item #2026

Source dir is required to evaluate presets. Presets contain generator info. Generator info is required for server api. Source dir currently requires driver. So this becomes a circular dependency. And I changed cmake-tools.sourceDir to use config.sourceDir instead.

Since generator could be changed, including changing to null, when switching between using kits and presets, and between different presets, added a function to shut down the driver, instead of restarting.