### PR TITLE
Environment fixes for debug but mostly for launch.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -272,7 +272,7 @@ const lintReporter = results => {
 
   results.forEach(result => {
     if (result.errorCount || result.warningCount) {
-        const filePath = result.filePath.replaceAll('\\', '/');
+        const filePath = result.filePath.replace(/\\/g, '/');
         errorCount += result.errorCount;
         warningCount += result.warningCount;
         fixableErrorCount += result.fixableErrorCount;

--- a/src/cmake-tools.ts
+++ b/src/cmake-tools.ts
@@ -30,7 +30,7 @@ import {CMakeGenerator, Kit} from './kit';
 import {LegacyCMakeDriver} from '@cmt/drivers/legacy-driver';
 import * as logging from './logging';
 import {fs} from './pr';
-import {buildCmdStr} from './proc';
+import {buildCmdStr, EnvironmentVariables} from './proc';
 import {Property} from './prop';
 import rollbar from './rollbar';
 import * as telemetry from './telemetry';
@@ -1856,9 +1856,9 @@ export class CMakeTools implements vscode.Disposable, api.CMakeToolsAPI {
     const user_config = this.workspaceContext.config.debugConfig;
     Object.assign(debug_config, user_config);
     // Add environment variables from buildPreset.
-    if (this.buildPreset?.environment) {
-      const build_preset_environment = await drv.getConfigureEnvironment();
-      debug_config.environment = debug_config.environment ? debug_config.environment.concat(util.splitEnvironmentVars(build_preset_environment)) : {};
+    if (this.configurePreset?.environment) {
+      const configure_preset_environment = await drv.getConfigureEnvironment();
+      debug_config.environment = debug_config.environment ? debug_config.environment.concat(util.splitEnvironmentVars(configure_preset_environment)) : {};
     }
 
     log.debug(localize('starting.debugger.with', 'Starting debugger with following configuration.'), JSON.stringify({
@@ -1901,31 +1901,45 @@ export class CMakeTools implements vscode.Disposable, api.CMakeToolsAPI {
       // a target.
       return null;
     }
-    const user_config = this.workspaceContext.config.debugConfig;
-    const drv = await this.getCMakeDriverInstance();
+
+    let user_config = this.workspaceContext.config.debugConfig;
+    let launchEnv: EnvironmentVariables = {};
+
     // Add environment variables from buildPreset.
-    if (drv && this.buildPreset?.environment) {
-      const build_preset_environment = await drv.getConfigureEnvironment();
-      user_config.environment = user_config.environment ? user_config.environment.concat(util.splitEnvironmentVars(build_preset_environment)) : {};
+    const drv = await this.getCMakeDriverInstance();
+    if (user_config.environment) {
+      let debugConfigEnvironment: [{name: string, value: string}] = user_config.environment;
+      debugConfigEnvironment.forEach (envVar => {
+        launchEnv[envVar.name] = envVar.value;
+      });
     }
+
+    if (drv && this.configurePreset?.environment) {
+      const configure_preset_environment = await drv.getConfigureEnvironment();
+      launchEnv = util.mergeEnvironment(launchEnv, configure_preset_environment);
+    }
+
     const termOptions: vscode.TerminalOptions = {
       name: 'CMake/Launch',
+      env: launchEnv,
       cwd: (user_config && user_config.cwd) || path.dirname(executable.path)
     };
+
     if (process.platform === 'win32') {
       // Use cmd.exe on Windows
       termOptions.shellPath = paths.windows.ComSpec;
     }
+
     if (!this._launchTerminal) {
       this._launchTerminal = vscode.window.createTerminal(termOptions);
     }
-    const quoted = shlex.quote(executable.path);
 
     let launchArgs = '';
     if (user_config && user_config.args) {
         launchArgs = user_config.args.join(" ");
     }
 
+    const quoted = shlex.quote(executable.path);
     this._launchTerminal.sendText(`${quoted} ${launchArgs}`);
     this._launchTerminal.show(true);
     return this._launchTerminal;

--- a/src/cmake-tools.ts
+++ b/src/cmake-tools.ts
@@ -1902,13 +1902,13 @@ export class CMakeTools implements vscode.Disposable, api.CMakeToolsAPI {
       return null;
     }
 
-    let user_config = this.workspaceContext.config.debugConfig;
+    const user_config = this.workspaceContext.config.debugConfig;
     let launchEnv: EnvironmentVariables = {};
 
     // Add environment variables from buildPreset.
     const drv = await this.getCMakeDriverInstance();
     if (user_config.environment) {
-      let debugConfigEnvironment: [{name: string, value: string}] = user_config.environment;
+      const debugConfigEnvironment: [{name: string; value: string}] = user_config.environment;
       debugConfigEnvironment.forEach (envVar => {
         launchEnv[envVar.name] = envVar.value;
       });

--- a/src/cmake-tools.ts
+++ b/src/cmake-tools.ts
@@ -1855,7 +1855,7 @@ export class CMakeTools implements vscode.Disposable, api.CMakeToolsAPI {
     // Add debug configuration from settings.
     const user_config = this.workspaceContext.config.debugConfig;
     Object.assign(debug_config, user_config);
-    // Add environment variables from buildPreset.
+    // Add environment variables from configurePreset.
     if (this.configurePreset?.environment) {
       const configure_preset_environment = await drv.getConfigureEnvironment();
       debug_config.environment = debug_config.environment ? debug_config.environment.concat(util.splitEnvironmentVars(configure_preset_environment)) : {};
@@ -1905,7 +1905,6 @@ export class CMakeTools implements vscode.Disposable, api.CMakeToolsAPI {
     const user_config = this.workspaceContext.config.debugConfig;
     let launchEnv: EnvironmentVariables = {};
 
-    // Add environment variables from buildPreset.
     const drv = await this.getCMakeDriverInstance();
     if (user_config.environment) {
       const debugConfigEnvironment: [{name: string; value: string}] = user_config.environment;
@@ -1914,6 +1913,7 @@ export class CMakeTools implements vscode.Disposable, api.CMakeToolsAPI {
       });
     }
 
+    // Add environment variables from configurePreset.
     if (drv && this.configurePreset?.environment) {
       const configure_preset_environment = await drv.getConfigureEnvironment();
       launchEnv = util.mergeEnvironment(launchEnv, configure_preset_environment);


### PR DESCRIPTION
The debug scenario was having a non critical bug (wrong preset environment checked before merging the configure environment into the VSCode debugger).

The launch scenario was broken when presets are on, because the assignment into user_config.environment would throw an exception about assigning into read-only property. Besides that, the new calculated environment was not sent to the VSCode terminal. Also, the VSCode terminal sees the environment as a map (same as presets and processes) and not as an array of "name"/"value" that we need to send to the VSCode debugger. So this is why we have some differences in how the environment is processed and passed further in the debug versus the launch scenario.

I plan to also add a test to verify the final environment before debug/launch but I didn't get to this yet. Sending out the fix PR first.