### PR TITLE
Fix debugging with presets

### DIFF
--- a/src/cmake-tools.ts
+++ b/src/cmake-tools.ts
@@ -1860,7 +1860,7 @@ export class CMakeTools implements vscode.Disposable, api.CMakeToolsAPI {
     // Add environment variables from configurePreset.
     if (this.configurePreset?.environment) {
       const configure_preset_environment = await drv.getConfigureEnvironment();
-      debug_config.environment = debug_config.environment ? debug_config.environment.concat(util.splitEnvironmentVars(configure_preset_environment)) : {};
+      debug_config.environment = debug_config.environment ? debug_config.environment.concat(util.splitEnvironmentVars(configure_preset_environment)) : [];
     }
 
     log.debug(localize('starting.debugger.with', 'Starting debugger with following configuration.'), JSON.stringify({


### PR DESCRIPTION
The wrong type was being returned for the debug environment when no environment was set and using CMake Presets.