### PR TITLE
Fix cmake.configureOnOpen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # What's New?
 
+## 1.8.1
+Bug fixes:
+- `cmake.configureOnOpen` setting is ignored. [#2088](https://github.com/microsoft/vscode-cmake-tools/issues/2088)
+- User-defined preset not shown when inheriting from `CMakePresets.json`. [#2082](https://github.com/microsoft/vscode-cmake-tools/issues/2082)
+
 ## 1.8.0
 Improvements:
 - Last selected target isn't read on start up. [#1148](https://github.com/microsoft/vscode-cmake-tools/issues/1148)

--- a/src/cmake-tools.ts
+++ b/src/cmake-tools.ts
@@ -66,6 +66,7 @@ export enum ConfigureTrigger {
   runTests = "runTests",
   badHomeDir = "badHomeDir",
   configureOnOpen = "configureOnOpen",
+  configureWithCache = "configureWithCache",
   quickStart = "quickStart",
   setVariant = "setVariant",
   cmakeListsChange = "cmakeListsChange",

--- a/src/drivers/cmfileapi-driver.ts
+++ b/src/drivers/cmfileapi-driver.ts
@@ -40,7 +40,7 @@ const log = logging.createLogger('cmakefileapi-driver');
 export class CMakeFileApiDriver extends CMakeDriver {
 
   get isCacheConfigSupported(): boolean {
-    return true;
+    return fs.existsSync(this.getCMakeFileApiPath());
   }
 
   private constructor(cmake: CMakeExecutable,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -589,7 +589,7 @@ class ExtensionManager implements vscode.Disposable {
           await this.configureExtensionInternal(ConfigureTrigger.buttonNewKitsDefinition, cmt);
         } else {
           log.debug(localize('using.cache.to.configure.workspace.on.open', 'Using cache to configure workspace on open {0}', ws.uri.toString()));
-          await this.configureExtensionInternal(ConfigureTrigger.configureOnOpen, cmt);
+          await this.configureExtensionInternal(ConfigureTrigger.configureWithCache, cmt);
         }
       }
     }

--- a/src/pr.ts
+++ b/src/pr.ts
@@ -26,6 +26,10 @@ export function exists(fspath: string): Promise<boolean> {
   return new Promise<boolean>((resolve, _reject) => { fs_.exists(fspath, res => resolve(res)); });
 }
 
+export function existsSync(fspath: string): boolean {
+  return fs_.existsSync(fspath);
+}
+
 export const readFile = promisify(fs_.readFile);
 
 export const writeFile = promisify(fs_.writeFile);


### PR DESCRIPTION
cmake.configureOnOpen is not respected after the "configure from existing cache" feature was added. The feature took us down the configuration path, but did not exit early when it was discovered that there was no cache to configure from.