### PR TITLE
launch a program in multiroot 

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1099,6 +1099,9 @@ class ExtensionManager implements vscode.Disposable {
       if (cmtFolder) {
         return fn(cmtFolder.cmakeTools);
       }
+      else {
+        rollbar.error(localize('no.active.folder', 'No active folder.'));
+      }
     } else {
       rollbar.error(localize('invalid.folder', 'Invalid folder.'));
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1098,8 +1098,7 @@ class ExtensionManager implements vscode.Disposable {
       const cmtFolder = this._folders.get(workspaceFolder);
       if (cmtFolder) {
         return fn(cmtFolder.cmakeTools);
-      }
-      else {
+      } else {
         rollbar.error(localize('no.active.folder', 'No active folder.'));
       }
     } else {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1098,8 +1098,6 @@ class ExtensionManager implements vscode.Disposable {
       const cmtFolder = this._folders.get(workspaceFolder);
       if (cmtFolder) {
         return fn(cmtFolder.cmakeTools);
-      } else {
-        rollbar.error(localize('no.active.folder', 'No active folder.'));
       }
     } else {
       rollbar.error(localize('invalid.folder', 'Invalid folder.'));

--- a/src/util.ts
+++ b/src/util.ts
@@ -648,9 +648,7 @@ export function isArrayOfString(x: any): x is string[] {
 }
 
 export function isNullOrUndefined(x?: any): boolean {
-  // Double equals provides the correct answer for 'null' and 'undefined'
-  // http://www.ecma-international.org/ecma-262/6.0/index.html#sec-abstract-equality-comparison
-  return x === null;
+  return (x === null || x === undefined);
 }
 
 export function isWorkspaceFolder(x?: any): boolean {


### PR DESCRIPTION
bug fix: https://github.com/microsoft/vscode-cmake-tools/issues/2091


the input of this function is not a folder when we are launching. but there was a check inside this function that checks if its a single root project, that is why it was working before. 
https://github.com/microsoft/vscode-cmake-tools/blob/114b910bf0c136ac50b7e78d44e3c4133bd4aff0/src/extension.ts#L1096