### PR TITLE
reorder some logic in the debugger override case

### DIFF
--- a/src/expand.ts
+++ b/src/expand.ts
@@ -120,7 +120,7 @@ export async function expandString(tmpl: string, opts: ExpansionOptions) {
   return replaceAll(result, '${dollar}', '$');
 }
 
-export async function expandStringHelper(tmpl: string, opts: ExpansionOptions) {
+async function expandStringHelper(tmpl: string, opts: ExpansionOptions) {
   const envPreNormalize = opts.envOverride ? opts.envOverride : process.env as EnvironmentVariables;
   const env = mergeEnvironment(envPreNormalize);
   const repls = opts.vars;


### PR DESCRIPTION
When searching for a debugger in the "quick debug" case, it's possible the user tries to override the guessing by providing their own path to a debugger. However, if their compiler is not found in the cache, this override attempt will be thwarted.

This PR reorders some of the logic to ensure that we attempt to use the override before the cache is checked.

> Note that this only matters for non-MSVC debugging, so some code above the override check is not moved.