### PR TITLE
Auto select build and test preset when switching configure preset

### DIFF
--- a/src/cmake-tools.ts
+++ b/src/cmake-tools.ts
@@ -160,8 +160,10 @@ export class CMakeTools implements vscode.Disposable, api.CMakeToolsAPI {
 
   private async resetPresets() {
     await this.workspaceContext.state.setConfigurePresetName(null);
-    await this.workspaceContext.state.setBuildPresetName(null);
-    await this.workspaceContext.state.setTestPresetName(null);
+    if (this.configurePreset) {
+      await this.workspaceContext.state.setBuildPresetName(this.configurePreset.name, null);
+      await this.workspaceContext.state.setTestPresetName(this.configurePreset.name, null);
+    }
     this._configurePreset.set(null);
     this._buildPreset.set(null);
     this._testPreset.set(null);
@@ -264,7 +266,7 @@ export class CMakeTools implements vscode.Disposable, api.CMakeToolsAPI {
           this._statusMessage.set(localize('reloading.status', 'Reloading...'));
           await drv.setBuildPreset(expandedBuildPreset);
           this.updateDriverAndTargetInTaskProvider(drv);
-          await this.workspaceContext.state.setBuildPresetName(buildPreset);
+          await this.workspaceContext.state.setBuildPresetName(expandedBuildPreset.configurePreset, buildPreset);
           this._statusMessage.set(localize('ready.status', 'Ready'));
         } catch (error: any) {
           void vscode.window.showErrorMessage(localize('unable.to.set.build.preset', 'Unable to set build preset "{0}".', error));
@@ -274,11 +276,13 @@ export class CMakeTools implements vscode.Disposable, api.CMakeToolsAPI {
         }
       } else {
         // Remember the selected build preset for the next session.
-        await this.workspaceContext.state.setBuildPresetName(buildPreset);
+        await this.workspaceContext.state.setBuildPresetName(expandedBuildPreset.configurePreset, buildPreset);
       }
     } else {
       this._buildPreset.set(null);
-      await this.workspaceContext.state.setBuildPresetName(buildPreset);
+      if (this.configurePreset) {
+        await this.workspaceContext.state.setBuildPresetName(this.configurePreset.name, null);
+      }
     }
   }
 
@@ -319,7 +323,7 @@ export class CMakeTools implements vscode.Disposable, api.CMakeToolsAPI {
         try {
           this._statusMessage.set(localize('reloading.status', 'Reloading...'));
           await drv.setTestPreset(expandedTestPreset);
-          await this.workspaceContext.state.setTestPresetName(testPreset);
+          await this.workspaceContext.state.setTestPresetName(expandedTestPreset.configurePreset, testPreset);
           this._statusMessage.set(localize('ready.status', 'Ready'));
         } catch (error: any) {
           void vscode.window.showErrorMessage(localize('unable.to.set.test.preset', 'Unable to set test preset "{0}".', error));
@@ -329,11 +333,13 @@ export class CMakeTools implements vscode.Disposable, api.CMakeToolsAPI {
         }
       } else {
         // Remember the selected test preset for the next session.
-        await this.workspaceContext.state.setTestPresetName(testPreset);
+        await this.workspaceContext.state.setTestPresetName(expandedTestPreset.configurePreset, testPreset);
       }
     } else {
       this._testPreset.set(null);
-      await this.workspaceContext.state.setTestPresetName(testPreset);
+      if (this.configurePreset) {
+        await this.workspaceContext.state.setTestPresetName(this.configurePreset.name, null);
+      }
     }
   }
 

--- a/src/folders.ts
+++ b/src/folders.ts
@@ -105,14 +105,6 @@ export class CMakeToolsFolder {
       if (configurePreset) {
         await folder.presetsController.setConfigurePreset(configurePreset);
       }
-      const buildPreset = folder.cmakeTools.workspaceContext.state.buildPresetName;
-      if (buildPreset) {
-        await folder.presetsController.setBuildPreset(buildPreset);
-      }
-      const testPreset = folder.cmakeTools.workspaceContext.state.testPresetName;
-      if (testPreset) {
-        await folder.presetsController.setTestPreset(testPreset);
-      }
     } else {
       // Check if the CMakeTools remembers what kit it was last using in this dir:
       const kit_name = folder.cmakeTools.workspaceContext.state.activeKitName;

--- a/src/preset.ts
+++ b/src/preset.ts
@@ -1144,6 +1144,8 @@ async function expandBuildPresetHelper(folder: string,
       if (preset.inheritConfigureEnvironment !== false) { // Check false explicitly since defaults to true
         inheritedEnv = util.mergeEnvironment(inheritedEnv, configurePreset.environment! as EnvironmentVariables);
       }
+    } else {
+      return null;
     }
   }
 
@@ -1340,6 +1342,8 @@ async function expandTestPresetHelper(folder: string,
       if (preset.inheritConfigureEnvironment !== false) { // Check false explicitly since defaults to true
         inheritedEnv = util.mergeEnvironment(inheritedEnv, configurePreset.environment! as EnvironmentVariables);
       }
+    } else {
+      return null;
     }
   }
 

--- a/src/presetsController.ts
+++ b/src/presetsController.ts
@@ -652,18 +652,49 @@ export class PresetsController {
           title: localize('reloading.build.test.preset', 'Reloading build and test presets')
         },
         async () => {
-          const buildPreset = this._cmakeTools.buildPreset?.name;
-          const testPreset = this._cmakeTools.testPreset?.name;
+          const configurePreset = this._cmakeTools.configurePreset?.name;
+          const buildPreset = configurePreset ? this._cmakeTools.workspaceContext.state.getBuildPresetName(configurePreset) : undefined;
+          const testPreset = configurePreset ? this._cmakeTools.workspaceContext.state.getTestPresetName(configurePreset) : undefined;
           if (buildPreset) {
             await this.setBuildPreset(buildPreset, true/*needToCheckConfigurePreset*/, false/*checkChangingPreset*/);
           }
+          if (!buildPreset || !this._cmakeTools.buildPreset) {
+            await this.guessBuildPreset();
+          }
+
           if (testPreset) {
             await this.setTestPreset(testPreset, true/*needToCheckConfigurePreset*/, false/*checkChangingPreset*/);
+          } else {
+            await this.setTestPreset(null, false/*needToCheckConfigurePreset*/, false/*checkChangingPreset*/);
           }
         }
     );
 
     this._isChangingPresets = false;
+  }
+
+  private async guessBuildPreset(): Promise<void> {
+    const selectedConfigurePreset = this._cmakeTools.configurePreset?.name;
+    let currentBuildPreset: string | undefined;
+    if (selectedConfigurePreset) {
+      preset.expandConfigurePresetForPresets(this.folderFsPath, 'build');
+      const buildPresets = preset.allBuildPresets(this.folderFsPath);
+      for (const buildPreset of buildPresets) {
+        // Set active build preset as the first valid build preset matches the selected configure preset
+        if (buildPreset.configurePreset === selectedConfigurePreset) {
+          await this.setBuildPreset(buildPreset.name, false/*needToCheckConfigurePreset*/, false/*checkChangingPreset*/);
+          currentBuildPreset = this._cmakeTools.buildPreset?.name;
+        }
+        if (currentBuildPreset) {
+          break;
+        }
+      }
+    }
+
+    if (!currentBuildPreset) {
+      // No valid buid preset matches the selected configure preset
+      await this.setBuildPreset(preset.defaultBuildPreset.name, false/*needToCheckConfigurePreset*/, false/*checkChangingPreset*/);
+    }
   }
 
   private async checkConfigurePreset(): Promise<preset.ConfigurePreset | null> {
@@ -786,45 +817,55 @@ export class PresetsController {
     }
   }
 
-  async setTestPreset(presetName: string, needToCheckConfigurePreset: boolean = true, checkChangingPreset: boolean = true): Promise<void> {
-    if (checkChangingPreset) {
-      if (this._isChangingPresets) {
-        return;
-      }
-      this._isChangingPresets = true;
-    }
-
-    if (needToCheckConfigurePreset && presetName !== preset.defaultTestPreset.name) {
-      preset.expandConfigurePresetForPresets(this.folderFsPath, 'test');
-      const _preset = preset.getPresetByName(preset.allTestPresets(this.folderFsPath), presetName);
-      if (_preset?.configurePreset !== this._cmakeTools.configurePreset?.name) {
-        log.error(localize('test.preset.configure.preset.not.match', 'Test preset {0}: The configure preset does not match the selected configure preset', presetName));
-        await vscode.window.withProgress(
-            {
-              location: vscode.ProgressLocation.Notification,
-              title: localize('unloading.test.preset', 'Unloading test preset')
-            },
-            () => this._cmakeTools.setTestPreset(null)
-        );
-
-        if (checkChangingPreset) {
-          this._isChangingPresets = false;
+  async setTestPreset(presetName: string | null, needToCheckConfigurePreset: boolean = true, checkChangingPreset: boolean = true): Promise<void> {
+    if (presetName) {
+      if (checkChangingPreset) {
+        if (this._isChangingPresets) {
+          return;
         }
-
-        return;
+        this._isChangingPresets = true;
       }
-    }
-    // Load the test preset into the backend
-    await vscode.window.withProgress(
-        {
-          location: vscode.ProgressLocation.Notification,
-          title: localize('loading.test.preset', 'Loading test preset {0}', presetName)
-        },
-        () => this._cmakeTools.setTestPreset(presetName)
-    );
 
-    if (checkChangingPreset) {
-      this._isChangingPresets = false;
+      if (needToCheckConfigurePreset && presetName !== preset.defaultTestPreset.name) {
+        preset.expandConfigurePresetForPresets(this.folderFsPath, 'test');
+        const _preset = preset.getPresetByName(preset.allTestPresets(this.folderFsPath), presetName);
+        if (_preset?.configurePreset !== this._cmakeTools.configurePreset?.name) {
+          log.error(localize('test.preset.configure.preset.not.match', 'Test preset {0}: The configure preset does not match the selected configure preset', presetName));
+          await vscode.window.withProgress(
+              {
+                location: vscode.ProgressLocation.Notification,
+                title: localize('unloading.test.preset', 'Unloading test preset')
+              },
+              () => this._cmakeTools.setTestPreset(null)
+          );
+
+          if (checkChangingPreset) {
+            this._isChangingPresets = false;
+          }
+
+          return;
+        }
+      }
+      // Load the test preset into the backend
+      await vscode.window.withProgress(
+          {
+            location: vscode.ProgressLocation.Notification,
+            title: localize('loading.test.preset', 'Loading test preset {0}', presetName)
+          },
+          () => this._cmakeTools.setTestPreset(presetName)
+      );
+
+      if (checkChangingPreset) {
+        this._isChangingPresets = false;
+      }
+    } else {
+      await vscode.window.withProgress(
+          {
+            location: vscode.ProgressLocation.Notification,
+            title: localize('unloading.test.preset', 'Unloading test preset.')
+          },
+          () => this._cmakeTools.setTestPreset(null)
+      );
     }
   }
 


### PR DESCRIPTION
When selecting a configure preset:
1. If this is the first time this configure preset is selected
  a. When there are valid build presets with `configurePreset` field setting to this configure preset, auto select the first one.
  b. When there are no such valid build presets, auto select the default (empty) build preset.
  c. Don't do anything for test presets, since some projects cannot use ctest.
1. If this is not the first time this configure preset is selected
  a. Auto select the build preset used last time this configure preset was active.
  b. If this build preset is not valid anymore, follow (1) steps.
