### PR TITLE
Make sure we don't delete the cache for projects configured from outside VSCode

### DIFF
--- a/src/drivers/cmfileapi-driver.ts
+++ b/src/drivers/cmfileapi-driver.ts
@@ -119,7 +119,12 @@ export class CMakeFileApiDriver extends CMakeDriver {
         await this.doConfigure([], undefined);
       }
     } else {
-      if (cacheExists) {
+      // Do not delete the cache if configureOnOpen is false, which signals a project that may be
+      // expected to be configured from outside VSCode and deleting the cache breaks that scenario.
+      // Since this setting will prevent configure anyway (until a configure command is invoked
+      // or build/test will trigger automatic configuring), there is no need to delete the cache now
+      // even if this is not a project configured from outside VSCode.
+      if (cacheExists && this.config.configureOnOpen !== false) {
         // No need to remove the other CMake files for the generator change to work properly
         log.info(localize('removing', 'Removing {0}', this.cachePath));
         await fs.unlink(this.cachePath);


### PR DESCRIPTION
Fix for https://github.com/microsoft/vscode-cmake-tools/issues/2140.
Don't delete cache when generator extension default differs from cache value and configure is disabled.
