### PR TITLE
Support for ++2b cpp standard

### DIFF
--- a/src/cpptools.ts
+++ b/src/cpptools.ts
@@ -58,7 +58,7 @@ interface TargetDefaults {
 
 function parseCppStandard(std: string, can_use_gnu: boolean): StandardVersion {
   const is_gnu = can_use_gnu && std.startsWith('gnu');
-  if (std.endsWith('++2a') || std.endsWith('++20') || std.endsWith('++latest')) {
+  if (std.endsWith('++2a') || std.endsWith('++2b') || std.endsWith('++20') || std.endsWith('++latest')) {
     return is_gnu ? 'gnu++20' : 'c++20';
   } else if (std.endsWith('++17') || std.endsWith('++1z')) {
     return is_gnu ? 'gnu++17' : 'c++17';


### PR DESCRIPTION
Fix for https://github.com/microsoft/vscode-cmake-tools/issues/2150.

Reroute -std=gnu++2b passed to cmake towards gnu++20 or c++20, sinceCppTools didn't implement 2b yet.
Same as what was done for ++2a.
