### PR TITLE
Fix the Build VSIX workflow

### DIFF
--- a/.github/workflows/build-vsix.yml
+++ b/.github/workflows/build-vsix.yml
@@ -31,6 +31,7 @@ jobs:
           find: "\"version\": \"(\\d+\\.\\d+\\.\\d+)\""
           replace: "\"version\": \"$1-${{ steps.get-short-sha.outputs.sha }}\""
           include: "package.json"
+          exclude: ".git"
 
       - name: Build the VSIX
         run:  |


### PR DESCRIPTION
A recent change to a default value for `exclude` with one of our Actions causes the Build VSIX workflow to fail.  https://github.com/jacobtomlinson/gha-find-replace/issues/30.

Explicitly setting the value to the old default restores the functionality