### PR TITLE
Shorten the configuration title

### DIFF
--- a/package.json
+++ b/package.json
@@ -1011,7 +1011,7 @@
     },
     "configuration": {
       "type": "object",
-      "title": "CMake Tools configuration",
+      "title": "CMake Tools",
       "properties": {
         "cmake.autoSelectActiveFolder": {
           "type": "boolean",


### PR DESCRIPTION
The title is too big to fit in the narrow panel in the settings UI.  The word "configuration" isn't doing anything for us anyway.

![image](https://user-images.githubusercontent.com/12818240/136599174-2bba6f29-c915-4aed-b3a3-3a94fb00ea92.png)
