### PR TITLE
Don't add extra quotes to process args

### DIFF
--- a/src/preset.ts
+++ b/src/preset.ts
@@ -1370,10 +1370,10 @@ export function configureArgs(preset: ConfigurePreset): string[] {
   }
 
   if (preset.toolchainFile) {
-    result.push(`-DCMAKE_TOOLCHAIN_FILE="${preset.toolchainFile}"`);
+    result.push(`-DCMAKE_TOOLCHAIN_FILE=${preset.toolchainFile}`);
   }
   if (preset.installDir) {
-    result.push(`-DCMAKE_INSTALL_PREFIX="${preset.installDir}"`);
+    result.push(`-DCMAKE_INSTALL_PREFIX=${preset.installDir}`);
   }
 
   // Warnings


### PR DESCRIPTION
Addresses: #2179

Arguments are sent to `child_process.spawn` in an array so it is incorrect to account for potential spaces by adding quotes when not executing in the context of a shell (`doConfigure` does not pass the `shell` flag to `proc.execute`).