### PR TITLE
Don't update cpptools if IntelliSense is disabled

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -710,6 +710,10 @@ class ExtensionManager implements vscode.Disposable {
       }
     );
     rollbar.invokeAsync(localize('update.code.model.for.cpptools', 'Update code model for cpptools'), {}, async () => {
+      if (vscode.workspace.getConfiguration('C_Cpp').get<string>('intelliSenseEngine')?.toLocaleLowerCase() === 'disabled') {
+        log.debug(localize('update.intellisense.disabled', 'Not updating the configuration provider because C_Cpp.intelliSenseEngine is set to \'Disabled\''));
+        return;
+      }
       if (!this._cppToolsAPI) {
         this._cppToolsAPI = await cpt.getCppToolsApi(cpt.Version.v5);
       }


### PR DESCRIPTION
Addresses: #2188
Works around: https://github.com/microsoft/vscode-cpptools/issues/8279

This will ensure cpptools does not error when IntelliSense is Disabled and CMake Tools wants to send IntelliSense configurations.