### PR TITLE
Fixes for 2180 and 2181

### DIFF
--- a/src/drivers/driver.ts
+++ b/src/drivers/driver.ts
@@ -1573,9 +1573,9 @@ export abstract class CMakeDriver implements vscode.Disposable {
         }
       } else {
         if (gen) {
-          if (/(Unix|MinGW) Makefiles|Ninja/.test(gen) && targets.indexOf('clean') > 0) {
+          if (/(Unix|MinGW) Makefiles|Ninja/.test(gen) && targets !== ['clean']) {
             buildToolArgs.push('-j', this.config.numJobs.toString());
-          } else if (/Visual Studio/.test(gen) &&  targets.indexOf('clean') > 0) {
+          } else if (/Visual Studio/.test(gen) &&  targets !== ['clean']) {
             buildToolArgs.push('/maxcpucount:' + this.config.numJobs.toString());
           }
         }


### PR DESCRIPTION
Fix for https://github.com/microsoft/vscode-cmake-tools/issues/2181: update "if" logic when comparing the targets array with "clean".

Fix for https://github.com/microsoft/vscode-cmake-tools/issues/2180: before the PR https://github.com/microsoft/vscode-cmake-tools/pull/2029, the extension would still set the compilation database internally, regardless of the setting "cmake.copyCompileCommands". Make sure that if compile_commands.json exists, we point to it even if "cmake.mergedCompileCommands" nor "cmake.copyCompileCommands" are not set, so that "Compile active file" works.