### PR TITLE
Fix missing MSVC telemetry

### DIFF
--- a/src/drivers/driver.ts
+++ b/src/drivers/driver.ts
@@ -16,7 +16,7 @@ import {CMakeOutputConsumer} from '@cmt/diagnostics/cmake';
 import {RawDiagnosticParser} from '@cmt/diagnostics/util';
 import {ProgressMessage} from '@cmt/drivers/cms-client';
 import * as expand from '@cmt/expand';
-import {CMakeGenerator, effectiveKitEnvironment, Kit, kitChangeNeedsClean, KitDetect, getKitDetect, getKitEnvironmentVariablesObject} from '@cmt/kit';
+import {CMakeGenerator, effectiveKitEnvironment, Kit, kitChangeNeedsClean, KitDetect, getKitDetect, getKitEnvironmentVariablesObject, getVSKitEnvironment} from '@cmt/kit';
 import * as logging from '@cmt/logging';
 import paths from '@cmt/paths';
 import {fs} from '@cmt/pr';
@@ -1272,6 +1272,26 @@ export abstract class CMakeDriver implements vscode.Disposable {
           telemetryProperties.CppCompilerName = cppCompilerVersion.name;
           telemetryProperties.CppCompilerVersion = cppCompilerVersion.version;
         }
+      } else if (this._kit?.visualStudio && this._kit.visualStudioArchitecture) {
+        const env = await getVSKitEnvironment(this._kit);
+        const dirs = env?.get('Path')?.split(';') ?? [];
+        let compilerPath = '';
+        for (const dir of dirs) {
+          if (dir.indexOf('MSVC') > 0) {
+            compilerPath = path.join(dir, 'cl.exe');
+            break;
+          }
+        }
+        if (compilerPath) {
+          const compiler = await this.getCompilerVersion(compilerPath);
+          telemetryProperties.CCompilerVersion = compiler.version;
+          telemetryProperties.CppCompilerVersion = compiler.version;
+        } else {
+          telemetryProperties.CCompilerVersion = 'unknown';
+          telemetryProperties.CppCompilerVersion = 'unknown';
+        }
+        telemetryProperties.CCompilerName = 'cl';
+        telemetryProperties.CppCompilerName = 'cl';
       }
 
       if (this._kit?.visualStudioArchitecture) {


### PR DESCRIPTION
I discovered that `cl` was not being reported in the configure telemetry as I was working on a view for this data. There's not a super clean way to get the compiler path from the Kit because CMake Tools doesn't ever need it. I discovered I could find the path in the %PATH% variable from the developer environment. We don't add `VCToolsInstallDir` to that environment because it causes problems with downlevel toolsets so I couldn't use that.