### PR TITLE
Turn preset to use mergeEnvironmentWithExpand

### DIFF
--- a/src/cmake-tools.ts
+++ b/src/cmake-tools.ts
@@ -765,7 +765,7 @@ export class CMakeTools implements vscode.Disposable, api.CMakeToolsAPI {
   async executeCMakeCommand(args: string[], options?: ExecutionOptions): Promise<ExecutionResult> {
     const drv = await this.getCMakeDriverInstance();
     if (drv) {
-      return drv.executeCommand(drv.cmake.path, args, undefined, options).result;
+      return (await drv.executeCommand(drv.cmake.path, args, undefined, options)).result;
     } else {
       throw new Error(localize('unable.to.execute.cmake.command', 'Unable to execute cmake command, there is no valid cmake driver instance.'));
     }
@@ -774,7 +774,7 @@ export class CMakeTools implements vscode.Disposable, api.CMakeToolsAPI {
   async execute(program: string, args: string[], options?: ExecutionOptions): Promise<ExecutionResult> {
     const drv = await this.getCMakeDriverInstance();
     if (drv) {
-      return drv.executeCommand(program, args, undefined, options).result;
+      return (await drv.executeCommand(program, args, undefined, options)).result;
     } else {
       throw new Error(localize('unable.to.execute.program', 'Unable to execute program, there is no valid cmake driver instance.'));
     }

--- a/src/ctest.ts
+++ b/src/ctest.ts
@@ -367,7 +367,7 @@ export class CTestDriver implements vscode.Disposable {
         this.ws.config.ctestDefaultArgs, this.ws.config.ctestArgs);
     }
 
-    const child = driver.executeCommand(
+    const child = await driver.executeCommand(
         ctestpath,
         ctestArgs,
         new CTestOutputLogger(),
@@ -410,10 +410,17 @@ export class CTestDriver implements vscode.Disposable {
     } else {
       buildConfigArgs.push('-C', driver.currentBuildType);
     }
-    const result
-        = await driver
-              .executeCommand(ctestpath, ['-N', ...buildConfigArgs], undefined, {cwd: driver.binaryDir, silent: true})
-              .result;
+    const child = await driver.executeCommand(
+      ctestpath,
+      ["-N", ...buildConfigArgs],
+      undefined,
+      {
+        cwd: driver.binaryDir,
+        silent: true,
+        environment: await driver.getCTestCommandEnvironment()
+      }
+    );
+    const result = await child.result;
     if (result.retc !== 0) {
       // There was an error running CTest. Odd...
       log.error(localize('ctest.error', 'There was an error running ctest to determine available test executables'));

--- a/src/drivers/cmfileapi-driver.ts
+++ b/src/drivers/cmfileapi-driver.ts
@@ -251,7 +251,7 @@ export class CMakeFileApiDriver extends CMakeDriver {
       log.debug(`Configuring using ${this.useCMakePresets ? 'preset' : 'kit'}`);
       log.debug('Invoking CMake', cmake, 'with arguments', JSON.stringify(args));
       const env = await this.getConfigureEnvironment();
-      const res = await this.executeCommand(cmake, args, outputConsumer, {environment: env}).result;
+      const res = await (await this.executeCommand(cmake, args, outputConsumer, {environment: env})).result;
       log.trace(res.stderr);
       log.trace(res.stdout);
       if (res.retc === 0) {

--- a/src/drivers/driver.ts
+++ b/src/drivers/driver.ts
@@ -16,7 +16,7 @@ import {CMakeOutputConsumer} from '@cmt/diagnostics/cmake';
 import {RawDiagnosticParser} from '@cmt/diagnostics/util';
 import {ProgressMessage} from '@cmt/drivers/cms-client';
 import * as expand from '@cmt/expand';
-import {CMakeGenerator, effectiveKitEnvironment, Kit, kitChangeNeedsClean, KitDetect, getKitDetect, getKitEnvironmentVariablesObject} from '@cmt/kit';
+import {CMakeGenerator, effectiveKitEnvironment, Kit, kitChangeNeedsClean, KitDetect, getKitDetect} from '@cmt/kit';
 import * as logging from '@cmt/logging';
 import paths from '@cmt/paths';
 import {fs} from '@cmt/pr';
@@ -170,69 +170,56 @@ export abstract class CMakeDriver implements vscode.Disposable {
 
   /**
    * The environment variables required by the current kit
+   * The ${dollar} are not expanded and missing environment variable subs are not expanded for this variables
    */
-  private _kitEnvironmentVariables = new Map<string, string>();
-
-  /**
-   * Compute the environment variables that apply with substitutions by expansionOptions
-   */
-  async computeExpandedEnvironment(in_env: proc.EnvironmentVariables, expanded_env: proc.EnvironmentVariables): Promise<proc.EnvironmentVariables> {
-    const env = {} as {[key: string]: string};
-    const opts = this.expansionOptions;
-
-    await Promise.resolve(
-      util.objectPairs(in_env)
-      .forEach(async ([key, value]) => env[key] = await expand.expandString(value, {...opts, envOverride: expanded_env}))
-    );
-    return env;
-  }
+  private _kitEnvironmentVariables: proc.EnvironmentVariables = {};
 
   /**
    * Get the environment variables that should be set at CMake-configure time.
    */
   async getConfigureEnvironment(): Promise<proc.EnvironmentVariables> {
+    const envs_to_merge: (proc.EnvironmentVariables | undefined)[] = [];
     if (this.useCMakePresets) {
-      return this._configurePreset?.environment as proc.EnvironmentVariables;
+      envs_to_merge.push(this._configurePreset?.environment as proc.EnvironmentVariables);
     } else {
-      let envs = getKitEnvironmentVariablesObject(this._kitEnvironmentVariables);
-      /* NOTE: By mergeEnvironment one by one to enable expanding self containd variable such as PATH properly */
-      /* If configureEnvironment and environment both configured different PATH, doing this will preserve them all */
-      envs = util.mergeEnvironment(envs, await this.computeExpandedEnvironment(this.config.environment, envs));
-      envs = util.mergeEnvironment(envs, await this.computeExpandedEnvironment(this.config.configureEnvironment, envs));
-      envs = util.mergeEnvironment(envs, await this.computeExpandedEnvironment(this._variantEnv, envs));
-      return envs;
+      envs_to_merge.push(this._kitEnvironmentVariables);
     }
+    envs_to_merge.push(this.config.environment);
+    envs_to_merge.push(this.config.configureEnvironment);
+    envs_to_merge.push(this._variantEnv);
+    return expand.mergeEnvironmentWithExpand(false, envs_to_merge, this.expansionOptions);
   }
 
   /**
    * Get the environment variables that should be set at CMake-build time.
    */
   async getCMakeBuildCommandEnvironment(in_env: proc.EnvironmentVariables): Promise<proc.EnvironmentVariables> {
-    let envs: proc.EnvironmentVariables;
+    const envs_to_merge: (proc.EnvironmentVariables | undefined)[] = [in_env];
     if (this.useCMakePresets) {
-      envs =  util.mergeEnvironment(in_env, this._buildPreset?.environment as proc.EnvironmentVariables);
+      envs_to_merge.push(this._buildPreset?.environment as proc.EnvironmentVariables);
     } else {
-      envs = util.mergeEnvironment(in_env, getKitEnvironmentVariablesObject(this._kitEnvironmentVariables));
+      envs_to_merge.push(this._kitEnvironmentVariables);
     }
-    envs = util.mergeEnvironment(envs, await this.computeExpandedEnvironment(this.config.environment, envs));
-    envs = util.mergeEnvironment(envs, await this.computeExpandedEnvironment(this.config.buildEnvironment, envs));
-    envs = util.mergeEnvironment(envs, await this.computeExpandedEnvironment(this._variantEnv, envs));
-    return envs;
+    envs_to_merge.push(this.config.environment);
+    envs_to_merge.push(this.config.buildEnvironment);
+    envs_to_merge.push(this._variantEnv);
+    return expand.mergeEnvironmentWithExpand(false, envs_to_merge, this.expansionOptions);
   }
 
   /**
    * Get the environment variables that should be set at CTest and running program time.
    */
   async getCTestCommandEnvironment(): Promise<proc.EnvironmentVariables> {
+    const envs_to_merge: (proc.EnvironmentVariables | undefined)[] = [];
     if (this.useCMakePresets) {
-      return (this._testPreset?.environment ? this._testPreset?.environment : {}) as proc.EnvironmentVariables;
+      envs_to_merge.push(this._testPreset?.environment as proc.EnvironmentVariables);
     } else {
-      let envs = getKitEnvironmentVariablesObject(this._kitEnvironmentVariables);
-      envs = util.mergeEnvironment(envs, await this.computeExpandedEnvironment(this.config.environment, envs));
-      envs = util.mergeEnvironment(envs, await this.computeExpandedEnvironment(this.config.testEnvironment, envs));
-      envs = util.mergeEnvironment(envs, await this.computeExpandedEnvironment(this._variantEnv, envs));
-      return envs;
+      envs_to_merge.push(this._kitEnvironmentVariables);
     }
+    envs_to_merge.push(this.config.environment);
+    envs_to_merge.push(this.config.testEnvironment);
+    envs_to_merge.push(this._variantEnv);
+    return expand.mergeEnvironmentWithExpand(false, envs_to_merge, this.expansionOptions);
   }
 
   get onProgress(): vscode.Event<ProgressMessage> {
@@ -336,15 +323,29 @@ export abstract class CMakeDriver implements vscode.Disposable {
     return { vars };
   }
 
-  getEffectiveSubprocessEnvironment(opts?: proc.ExecutionOptions): proc.EnvironmentVariables {
-    const cur_env = process.env as proc.EnvironmentVariables;
-    const kit_env = (this.config.ignoreKitEnv) ? {} : getKitEnvironmentVariablesObject(this._kitEnvironmentVariables);
-    return util.mergeEnvironment(cur_env, kit_env, (opts && opts.environment) ? opts.environment : {});
+  async getEffectiveSubprocessEnvironment(opts?: proc.ExecutionOptions): Promise<proc.EnvironmentVariables> {
+    let envs_to_merge: (proc.EnvironmentVariables | undefined)[] =  [];
+    if (this.config.ignoreKitEnv) {
+      envs_to_merge = [
+        process.env as proc.EnvironmentVariables,
+        this.config.environment,
+        this._variantEnv,
+        opts?.environment
+      ];
+    } else {
+      envs_to_merge = [
+        this._kitEnvironmentVariables,
+        this.config.environment,
+        this._variantEnv,
+        opts?.environment
+      ];
+    }
+    return expand.mergeEnvironmentWithExpand(false, envs_to_merge, this.expansionOptions);
   }
 
-  executeCommand(command: string, args?: string[], consumer?: proc.OutputConsumer, options?: proc.ExecutionOptions):
-      proc.Subprocess {
-    const environment = this.getEffectiveSubprocessEnvironment(options);
+  async executeCommand(command: string, args?: string[], consumer?: proc.OutputConsumer, options?: proc.ExecutionOptions):
+      Promise<proc.Subprocess> {
+    const environment = await this.getEffectiveSubprocessEnvironment(options);
     const exec_options = {...options, environment};
     return proc.execute(command, args, consumer, exec_options);
   }
@@ -365,13 +366,13 @@ export abstract class CMakeDriver implements vscode.Disposable {
    * Launch the given compilation command in an embedded terminal.
    * @param cmd The compilation command from a compilation database to run
    */
-  runCompileCommand(cmd: ArgsCompileCommand): vscode.Terminal {
+  async runCompileCommand(cmd: ArgsCompileCommand): Promise<vscode.Terminal> {
     let env: proc.EnvironmentVariables;
     if (this.useCMakePresets) {
       // buildpreset.environment at least has process.env after expansion
       env = this._buildPreset!.environment as proc.EnvironmentVariables;
     } else {
-      env = this.getEffectiveSubprocessEnvironment();
+      env = await this.getCMakeBuildCommandEnvironment({});
     }
     const key = `${cmd.directory}${JSON.stringify(env)}`;
     let existing = this._compileTerms.get(key);
@@ -774,7 +775,7 @@ export abstract class CMakeDriver implements vscode.Disposable {
   }
 
   public async testHaveCommand(program: string, args: string[] = ['--version']): Promise<boolean> {
-    const child = this.executeCommand(program, args, undefined, {silent: true});
+    const child = await this.executeCommand(program, args, undefined, {silent: true});
     try {
       const result = await child.result;
       log.debug(localize('command.version.test.return.code', 'Command version test return code {0}', nullableValueToString(result.retc)));
@@ -870,7 +871,7 @@ export abstract class CMakeDriver implements vscode.Disposable {
     if (arg) {
       args.push(arg);
     }
-    const child = this.executeCommand(program, args, undefined, {silent: true, cwd});
+    const child = await this.executeCommand(program, args, undefined, {silent: true, cwd});
     try {
       const result = await child.result;
       console.log(localize('command.version.test.return.code', 'Command version test return code {0}', nullableValueToString(result.retc)));
@@ -1616,7 +1617,7 @@ export abstract class CMakeDriver implements vscode.Disposable {
       }
       const exeOpt: proc.ExecutionOptions
           = {environment: buildcmd.build_env, outputEncoding: outputEnc, useTask: this.config.buildTask};
-      const child = this.executeCommand(buildcmd.command, buildcmd.args, consumer, exeOpt);
+      const child = await this.executeCommand(buildcmd.command, buildcmd.args, consumer, exeOpt);
       this._currentBuildProcess = child;
       await child.result;
       this._currentBuildProcess = null;

--- a/src/drivers/legacy-driver.ts
+++ b/src/drivers/legacy-driver.ts
@@ -97,7 +97,7 @@ export class LegacyCMakeDriver extends CMakeDriver {
     } else {
       log.debug(localize('invoking.cmake.with.arguments', 'Invoking CMake {0} with arguments {1}', cmake, JSON.stringify(args)));
       const env = await this.getConfigureEnvironment();
-      const res = await this.executeCommand(cmake, args, outputConsumer, {environment: env}).result;
+      const res = await (await this.executeCommand(cmake, args, outputConsumer, {environment: env})).result;
       log.trace(res.stderr);
       log.trace(res.stdout);
       if (res.retc === 0) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -728,17 +728,8 @@ class ExtensionManager implements vscode.Disposable {
           return;
         }
         const drv: CMakeDriver | null = await cmt.getCMakeDriverInstance();
-        const env: Map<string, string> = new Map<string, string>();
         const configureEnv = await drv?.getConfigureEnvironment();
-        if (configureEnv) {
-          for (const key in configureEnv) {
-            const value = configureEnv[key];
-            if (util.isString(value)) {
-              env.set(key, value);
-            }
-          }
-        }
-
+        const env = configureEnv ?? process.env;
         const isMultiConfig = !!cache.get('CMAKE_CONFIGURATION_TYPES');
         if (drv) {
           drv.isMultiConfig = isMultiConfig;

--- a/src/kit.ts
+++ b/src/kit.ts
@@ -20,8 +20,9 @@ import {fs} from './pr';
 import * as proc from './proc';
 import {loadSchema} from './schema';
 import { TargetTriple, findTargetTriple, parseTargetTriple, computeTargetTriple } from './triple';
-import {compare, dropNulls, objectPairs, Ordering, versionLess} from './util';
+import {compare, dropNulls, Ordering, versionLess} from './util';
 import * as nls from 'vscode-nls';
+import { GeneralEnvironmentType } from './proc';
 
 nls.config({ messageFormat: nls.MessageFormat.bundle, bundleFormat: nls.BundleFormat.standalone })();
 const localize: nls.LocalizeFunc = nls.loadMessageBundle();
@@ -728,16 +729,15 @@ async function collectDevBatVars(hostArch: string, devbat: string, args: string[
     minor: 0,
     patch: 0
   };
-  const WindowsSDKVersion = vars.get('WindowsSDKVersion') ?? '0.0.0';
+  const WindowsSDKVersion = util.envGetValue(vars, 'WindowsSDKVersion') ?? '0.0.0';
   try {
     WindowsSDKVersionParsed = util.parseVersion(WindowsSDKVersion);
   } catch (err) {
     log.error(`Parse '${WindowsSDKVersion}' failed`);
   }
   if (util.compareVersion(WindowsSDKVersionParsed, {major: 10, minor: 0, patch: 14393}) >= 0) {
-    const WindowsSdkDir = vars.get('WindowsSdkDir') ?? '';
-    const pathKey = vars.has('Path') ? 'Path' : 'PATH';
-    const existPath = vars.get(pathKey) ?? '';
+    const WindowsSdkDir = util.envGetValue(vars, 'WindowsSdkDir') ?? '';
+    const existPath = util.envGetValue(vars, 'PATH') ?? '';
     const oldWinSdkBinPath = path.join(WindowsSdkDir, 'bin', hostArch);
     const newWinSdkBinPath = path.join(WindowsSdkDir, 'bin', WindowsSDKVersion, hostArch);
     const newWinSdkBinPathExist = await fs.exists(newWinSdkBinPath);
@@ -746,7 +746,7 @@ async function collectDevBatVars(hostArch: string, devbat: string, args: string[
         existPath.toLowerCase().indexOf(newWinSdkBinPath.toLowerCase()) < 0) {
       log.info(localize('windows.sdk.path.patch', 'Patch Windows SDK bin path from {0} to {1} for {2}',
         oldWinSdkBinPath, newWinSdkBinPath, devbat));
-      vars.set(pathKey, `${newWinSdkBinPath};${existPath}`);
+      util.envSet(vars, 'PATH', `${newWinSdkBinPath};${existPath}`);
     }
   }
   log.debug(localize('ok.running', 'OK running {0} {1}, env vars: {2}', devbat, args.join(' '), JSON.stringify([...vars])));
@@ -755,10 +755,9 @@ async function collectDevBatVars(hostArch: string, devbat: string, args: string[
 
 /**
  * Gets the environment variables set by a shell script.
- * @param kit The kit to get the environment variables for
+ * @param environmentSetupScript The environmentSetupScript to get the environment variables for the kit
  */
-export async function getShellScriptEnvironment(kit: Kit, opts?: expand.ExpansionOptions): Promise<Map<string, string>|undefined> {
-  console.assert(kit.environmentSetupScript);
+export async function getShellScriptEnvironment(environmentSetupScript: string, base_env: proc.EnvironmentVariables, opts: expand.ExpansionOptions): Promise<proc.EnvironmentVariables|undefined> {
   const filename = Math.random().toString() + (process.platform === 'win32' ? '.bat' : '.sh');
   const script_filename = `vs-cmt-${filename}`;
   const environment_filename = script_filename + '.env';
@@ -784,10 +783,7 @@ export async function getShellScriptEnvironment(kit: Kit, opts?: expand.Expansio
   let script = '';
   let run_command = '';
 
-  let environmentSetupScript = kit.environmentSetupScript;
-  if (opts) {
-    environmentSetupScript = await expand.expandString(environmentSetupScript!, opts);
-  }
+  environmentSetupScript = await expand.expandString(environmentSetupScript!, {...opts, envOverride: base_env});
 
   if (process.platform === 'win32') { // windows
     script += `call "${environmentSetupScript}"\r\n`; // call the user batch script
@@ -804,7 +800,7 @@ export async function getShellScriptEnvironment(kit: Kit, opts?: expand.Expansio
   } catch (error) {}
   await fs.writeFile(script_path, script); // write batch file
 
-  const res = await proc.execute(run_command, [], null, {shell: true, silent: true}).result; // run script
+  const res = await proc.execute(run_command, [], null, {shell: true, silent: true, environment: base_env}).result; // run script
   await fs.unlink(script_path); // delete script file
   const output = (res.stdout) ? res.stdout + (res.stderr || '') : res.stderr;
 
@@ -815,22 +811,22 @@ export async function getShellScriptEnvironment(kit: Kit, opts?: expand.Expansio
     await fs.unlink(environment_path);
   } catch (error) { log.error(error); }
   if (!env || env === '') {
-    console.log(`Error running ${kit.environmentSetupScript} with:`, output);
+    console.log(`Error running ${environmentSetupScript} with:`, output);
     return;
   }
 
   // split and trim env vars
   const vars
-      = env.split('\n').map(l => l.trim()).filter(l => l.length !== 0).reduce<Map<string, string>>((acc, line) => {
+      = env.split('\n').map(l => l.trim()).filter(l => l.length !== 0).reduce<proc.EnvironmentVariables>((acc, line) => {
           const match = /(\w+)=?(.*)/.exec(line);
           if (match) {
-            acc.set(match[1], match[2]);
+            util.envSet(acc, match[1], match[2]);
           } else {
             log.error(localize('error.parsing.environment', 'Error parsing environment variable: {0}', line));
           }
           return acc;
-        }, new Map());
-  log.debug(localize('ok.running', 'OK running {0}, env vars: {1}', kit.environmentSetupScript, JSON.stringify([...vars])));
+        }, {});
+  log.debug(localize('ok.running', 'OK running {0}, env vars: {1}', environmentSetupScript, JSON.stringify(Object.entries(vars))));
   return vars;
 }
 
@@ -905,25 +901,25 @@ async function varsForVSInstallation(inst: VSInstallation, hostArch: string, tar
     // this issue, but this here seems to work. It basically just sets
     // the VS{vs_version_number}COMNTOOLS environment variable to contain
     // the path to the Common7 directory.
-    const vs_version = variables.get('VISUALSTUDIOVERSION');
-    if (vs_version) {variables.set(`VS${vs_version.replace('.', '')}COMNTOOLS`, common_dir); }
+    const vs_version = util.envGetValue(variables, 'VISUALSTUDIOVERSION');
+    if (vs_version) { util.envSet(variables, `VS${vs_version.replace('.', '')}COMNTOOLS`, common_dir); }
 
     // For Ninja and Makefile generators, CMake searches for some compilers
     // before it checks for cl.exe. We can force CMake to check cl.exe first by
     // setting the CC and CXX environment variables when we want to do a
     // configure.
-    variables.set('CC', 'cl.exe');
-    variables.set('CXX', 'cl.exe');
+    util.envSet(variables, 'CC', 'cl.exe');
+    util.envSet(variables, 'CXX', 'cl.exe');
 
     if (paths.ninjaPath) {
-      let envPATH = variables.get('PATH');
+      let envPATH = util.envGetValue(variables, 'PATH');
       if (undefined !== envPATH) {
         const env_paths = envPATH.split(';');
         const ninja_path = path.dirname(paths.ninjaPath!);
         const ninja_base_path = env_paths.find(path_el => path_el === ninja_path);
         if (undefined === ninja_base_path) {
           envPATH = envPATH.concat(';' + ninja_path);
-          variables.set('PATH', envPATH);
+          util.envSet(variables, 'PATH', envPATH);
         }
       }
     }
@@ -1103,32 +1099,30 @@ export async function getVSKitEnvironment(kit: Kit): Promise<Map<string, string>
   return varsForVSInstallation(requested, kit.visualStudioArchitecture!, kit.preferredGenerator?.platform);
 }
 
-export async function effectiveKitEnvironment(kit: Kit, opts?: expand.ExpansionOptions): Promise<Map<string, string>> {
-  let host_env;
-  const kit_env = objectPairs(kit.environmentVariables || {});
-  if (opts) {
-    for (const env_var of kit_env) {
-      env_var[1] = await expand.expandString(env_var[1], opts);
-    }
-  }
-  if (kit.environmentSetupScript) {
-    const shell_vars = await getShellScriptEnvironment(kit, opts);
+export async function baseKitEnvironment(
+  environmentVariables?: proc.EnvironmentVariables,
+  environmentSetupScript?: string,
+  opts?: expand.ExpansionOptions
+): Promise<proc.EnvironmentVariables> {
+  const expandOpts = opts ?? expand.emptyExpansionOptions();
+  let base_env = await expand.mergeEnvironmentWithExpand(true, [process.env as proc.EnvironmentVariables, environmentVariables], opts);
+  if (environmentSetupScript) {
+    const shell_vars = await getShellScriptEnvironment(environmentSetupScript, base_env, expandOpts);
     if (shell_vars) {
-      host_env = util.map(shell_vars, ([k, v]): [string, string] => [k.toLocaleUpperCase(), v]) as [string, string][];
+      base_env = shell_vars;
     }
   }
-  if (host_env === undefined) {
-    // get host_env from process if it was not set by shell script before
-    host_env = objectPairs(process.env) as [string, string][];
-  }
+  return base_env;
+}
+
+export async function effectiveKitEnvironment(kit: Kit, opts?: expand.ExpansionOptions): Promise<proc.EnvironmentVariables> {
+  const env = await baseKitEnvironment(kit.environmentVariables, kit.environmentSetupScript, opts);
   if (kit.visualStudio && kit.visualStudioArchitecture) {
     const vs_vars = await getVSKitEnvironment(kit);
     if (vs_vars) {
-      return new Map(
-          util.map(util.chain(host_env, kit_env, vs_vars), ([k, v]): [string, string] => [k.toLocaleUpperCase(), v]));
+      return util.mergeEnvironment(env, getKitEnvironmentVariablesObject(vs_vars));
     }
   }
-  const env = new Map(util.chain(host_env, kit_env));
   const isWin32 = process.platform === 'win32';
   if (isWin32) {
     const path_list: string[] = [];
@@ -1137,35 +1131,28 @@ export async function effectiveKitEnvironment(kit: Kit, opts?: expand.ExpansionO
     if (cCompiler) {
       path_list.push(path.dirname(cCompiler));
     }
-    const cmt_mingw_path = env.get("CMT_MINGW_PATH");
+    const cmt_mingw_path = util.envGetValue(env, "CMT_MINGW_PATH");
     if (cmt_mingw_path) {
       path_list.push(cmt_mingw_path);
     }
-    let path_key: string | undefined;
-    if (env.has("PATH")) {
-      path_key = "PATH";
-    } else if (env.has("Path")) {
-      path_key = "Path";
+    const env_path = util.envGetValue(env, 'PATH');
+    if (env_path) {
+      path_list.unshift(env_path);
     }
-    if (path_key) {
-      path_list.unshift(env.get(path_key) ?? '');
-      env.set(path_key, path_list.join(';'));
-    }
+    util.envSet(env, 'PATH', path_list.join(';'));
   }
   return env;
 }
 
-export async function findCLCompilerPath(env: Map<string, string>): Promise<string|null> {
-  const path_var = util.find(env.entries(), ([key, _val]) => key.toLocaleLowerCase() === 'path');
-  if (!path_var) {
+export async function findCLCompilerPath(env: GeneralEnvironmentType): Promise<string|null> {
+  const path_val = util.envGetValue(env, 'PATH');
+  if (!path_val) {
     return null;
   }
-  const path_ext_var = util.find(env.entries(), ([key, _val]) => key.toLocaleLowerCase() === 'pathext');
-  if (!path_ext_var) {
+  const path_ext = util.envGetValue(env, 'PATHEXT');
+  if (!path_ext) {
     return null;
   }
-  const path_val = path_var[1];
-  const path_ext = path_ext_var[1];
   for (const dir of path_val.split(';')) {
     for (const ext of path_ext.split(';')) {
       const fname = `cl${ext}`;
@@ -1205,9 +1192,10 @@ export async function scanForKits(cmakeTools: CMakeTools | undefined, opt?: KitS
     const scan_paths = new Set<string>();
 
     // Search directories on `PATH` for compiler binaries
-    if (process.env.hasOwnProperty('PATH')) {
+    const env_path = util.envGetValue(process.env, 'PATH');
+    if (env_path) {
       const sep = isWin32 ? ';' : ':';
-      for (const dir of (process.env.PATH as string).split(sep)) {
+      for (const dir of env_path.split(sep)) {
         scan_paths.add(dir);
       }
     }
@@ -1231,8 +1219,9 @@ export async function scanForKits(cmakeTools: CMakeTools | undefined, opt?: KitS
       const clang_paths = new Set<string>();
 
       // LLVM_ROOT environment variable location
-      if (process.env.hasOwnProperty('LLVM_ROOT')) {
-        const llvm_root = path.normalize(process.env.LLVM_ROOT as string + "\\bin");
+      const env_llvm_root = util.envGetValue(process.env, 'LLVM_ROOT');
+      if (env_llvm_root) {
+        const llvm_root = path.normalize(env_llvm_root + "\\bin");
         clang_paths.add(llvm_root);
       }
 

--- a/src/preset.ts
+++ b/src/preset.ts
@@ -5,9 +5,9 @@ import * as path from 'path';
 import * as util from '@cmt/util';
 import * as logging from '@cmt/logging';
 import { EnvironmentVariables, execute } from '@cmt/proc';
-import { expandString, ExpansionOptions } from '@cmt/expand';
+import { expandString, ExpansionOptions, mergeEnvironmentWithExpand } from '@cmt/expand';
 import paths from '@cmt/paths';
-import { effectiveKitEnvironment, getKitEnvironmentVariablesObject, Kit, targetArchFromGeneratorPlatform } from '@cmt/kit';
+import { effectiveKitEnvironment, Kit, targetArchFromGeneratorPlatform } from '@cmt/kit';
 import { compareVersions, vsInstallations } from '@cmt/installs/visual-studio';
 
 nls.config({ messageFormat: nls.MessageFormat.bundle, bundleFormat: nls.BundleFormat.standalone })();
@@ -31,12 +31,14 @@ export interface Preset {
   description?: string;
   hidden?: boolean;
   inherits?: string | string[];
-  environment?: { [key: string]: null | string };
+  environment?: EnvironmentVariables;
   vendor?: VendorType;
   condition?: Condition | boolean | null;
 
   __expanded?: boolean; // Private field to indicate if we have already expanded this preset.
   __inheritedPresetCondition?: boolean; // Private field to indicate the fully evaluated inherited preset condition.
+  __environmentList?: EnvironmentVariables[]; // Private filed to record environment list from ancestor to current preset
+  __clEnvironment?: EnvironmentVariables; // cl environment should setup at the very beginning, so place it independently
 }
 
 export interface ValueStrategy {
@@ -529,7 +531,9 @@ function getVendorForConfigurePresetHelper(folder: string, preset: ConfigurePres
 async function getExpansionOptions(folder: string,
                                    workspaceFolder: string,
                                    sourceDir: string,
-                                   preset: ConfigurePreset | BuildPreset | TestPreset) {
+                                   preset: ConfigurePreset | BuildPreset | TestPreset,
+                                   envOverride?: EnvironmentVariables
+): ExpansionOptions {
   const generator = 'generator' in preset
     ? preset.generator
     : ('__generator' in preset ? preset.__generator : undefined);
@@ -548,7 +552,7 @@ async function getExpansionOptions(folder: string,
       sourceDirName: path.basename(sourceDir),
       presetName: preset.name
     },
-    envOverride: preset.environment as EnvironmentVariables,
+    envOverride: envOverride,
     recursive: true,
     // Don't support commands since expansion might be called on activation. If there is
     // an extension depending on us, and there is a command in this extension is invoked,
@@ -855,9 +859,11 @@ async function expandConfigurePresetHelper(folder: string,
   if (!preset.cacheVariables) {
     preset.cacheVariables = {};
   }
+  if (!preset.__environmentList) {
+    preset.__environmentList = [];
+  }
 
   // Expand inherits
-  let inheritedEnv = {};
   if (preset.inherits) {
     if (util.isString(preset.inherits)) {
       preset.inherits = [preset.inherits];
@@ -866,7 +872,7 @@ async function expandConfigurePresetHelper(folder: string,
       const parent = await expandConfigurePresetImpl(folder, parentName, workspaceFolder, sourceDir, allowUserPreset);
       if (parent) {
         // Inherit environment
-        inheritedEnv = util.mergeEnvironment(parent.environment! as EnvironmentVariables, inheritedEnv as EnvironmentVariables);
+        preset.__environmentList.push(...parent.__environmentList!);
         // Inherit cache vars
         for (const name in parent.cacheVariables) {
           if (preset.cacheVariables[name] === undefined) {
@@ -885,11 +891,9 @@ async function expandConfigurePresetHelper(folder: string,
     }
   }
 
-  inheritedEnv = util.mergeEnvironment(process.env as EnvironmentVariables, inheritedEnv as EnvironmentVariables);
-
-  let compilerEnv: EnvironmentVariables = {};
-
-  // [Windows Only] If CMAKE_CXX_COMPILER or CMAKE_C_COMPILER is set as cl, clang, clang-cl, clang-cpp and clang++,
+  preset.__environmentList.push(preset.environment);
+  // [Windows Only] If CMAKE_CXX_COMPILER or CMAKE_C_COMPILER is set as 'cl' or 'cl.exe', but they are not on PATH,
+  // then set the env automatically
   // but they are not on PATH, then set the env automatically.
   if (process.platform === 'win32') {
     const getStringValueFromCacheVar = (variable?: CacheVarType) => {
@@ -946,9 +950,10 @@ async function expandConfigurePresetHelper(folder: string,
                           "Configure preset {0}: Compiler '{1}' with toolset '{2}' and architecture '{3}' was not found, you may need to run 'CMake: Scan for Compilers' if it exists on your computer.",
                           preset.name, `${compilerName}.exe`, toolset.version ? `${toolset.version},${toolset.host}` : toolset.host, arch));
           } else {
-            compilerEnv = getKitEnvironmentVariablesObject(await effectiveKitEnvironment(kits[latestVsIndex]));
+            preset.__clEnvironment = await effectiveKitEnvironment(kits[latestVsIndex]);
+            const ninjaEnvironment = await expandPresetEnvironmentList(preset, workspaceFolder, sourceDir);
             // if ninja isn't on path, try to look for it in a VS install
-            const ninjaLoc = await execute('where.exe', ['ninja'], null, { environment: preset.environment as EnvironmentVariables,
+            const ninjaLoc = await execute('where.exe', ['ninja'], null, { environment: ninjaEnvironment,
                                                                            silent: true,
                                                                            encoding: 'utf8',
                                                                            shell: true }).result;
@@ -956,7 +961,7 @@ async function expandConfigurePresetHelper(folder: string,
               const vsCMakePaths = await paths.vsCMakePaths(kits[latestVsIndex].visualStudio);
               if (vsCMakePaths.ninja) {
                 log.warning(localize('ninja.not.set', 'Ninja is not set on PATH, trying to use {0}', vsCMakePaths.ninja));
-                compilerEnv['PATH'] = `${path.dirname(vsCMakePaths.ninja)};${compilerEnv['PATH']}`;
+                util.envSet(preset.__clEnvironment, 'PATH', `${path.dirname(vsCMakePaths.ninja)};${util.envGetValue(preset.__clEnvironment, 'PATH')}`);
               }
             }
           }
@@ -964,9 +969,6 @@ async function expandConfigurePresetHelper(folder: string,
       }
     }
   }
-
-  compilerEnv = util.mergeEnvironment(inheritedEnv as EnvironmentVariables, compilerEnv as EnvironmentVariables);
-  preset.environment = util.mergeEnvironment(compilerEnv as EnvironmentVariables, preset.environment as EnvironmentVariables);
 
   preset.__expanded = true;
   return preset;
@@ -1106,23 +1108,10 @@ export async function expandBuildPreset(folder: string,
   if (!preset) {
     return null;
   }
+  preset.environment = await expandPresetEnvironmentList(preset, workspaceFolder, sourceDir);
+  const expansionOpts = createPresetExpansionOption(preset, workspaceFolder, sourceDir, preset.environment);
 
-  // Expand strings under the context of current preset
   const expandedPreset: BuildPreset = { name };
-  const expansionOpts: ExpansionOptions = await getExpansionOptions(folder, workspaceFolder, sourceDir, preset);
-
-  // Expand environment vars first since other fields may refer to them
-  if (preset.environment) {
-    expandedPreset.environment = { };
-    for (const key in preset.environment) {
-      if (preset.environment[key]) {
-        expandedPreset.environment[key] = await expandString(preset.environment[key]!, expansionOpts);
-      }
-    }
-  }
-
-  expansionOpts.envOverride = expandedPreset.environment as EnvironmentVariables;
-
   // Expand other fields
   if (preset.targets) {
     if (util.isString(preset.targets)) {
@@ -1207,7 +1196,9 @@ async function expandBuildPresetHelper(folder: string,
   if (!preset.environment) {
     preset.environment = {};
   }
-  let inheritedEnv = {};
+  if (!preset.__environmentList) {
+    preset.__environmentList = [];
+  }
 
   // Expand inherits
   if (preset.inherits) {
@@ -1218,7 +1209,7 @@ async function expandBuildPresetHelper(folder: string,
       const parent = await expandBuildPresetImpl(folder, parentName, workspaceFolder, sourceDir, preferredGeneratorName, allowUserPreset);
       if (parent) {
         // Inherit environment
-        inheritedEnv = util.mergeEnvironment(parent.environment! as EnvironmentVariables, inheritedEnv);
+        preset.__environmentList.push(...parent.__environmentList!);
         // Inherit other fields
         let key: keyof BuildPreset;
         for (key in parent) {
@@ -1239,14 +1230,14 @@ async function expandBuildPresetHelper(folder: string,
       preset.__generator = configurePreset.generator;
 
       if (preset.inheritConfigureEnvironment !== false) { // Check false explicitly since defaults to true
-        inheritedEnv = util.mergeEnvironment(inheritedEnv, configurePreset.environment! as EnvironmentVariables);
+        preset.__environmentList.push(...configurePreset.__environmentList!);
       }
     } else {
       return null;
     }
   }
 
-  preset.environment = util.mergeEnvironment(process.env as EnvironmentVariables, inheritedEnv, preset.environment as EnvironmentVariables);
+  preset.__environmentList.push(preset.environment);
 
   preset.__expanded = true;
   return preset;
@@ -1273,22 +1264,10 @@ export async function expandTestPreset(folder: string,
   if (!preset) {
     return null;
   }
+  preset.environment = await expandPresetEnvironmentList(preset, workspaceFolder, sourceDir);
+  const expansionOpts = createPresetExpansionOption(preset, workspaceFolder, sourceDir, preset.environment);
 
   const expandedPreset: TestPreset = { name };
-  const expansionOpts: ExpansionOptions = await getExpansionOptions(folder, workspaceFolder, sourceDir, preset);
-
-  // Expand environment vars first since other fields may refer to them
-  if (preset.environment) {
-    expandedPreset.environment = { };
-    for (const key in preset.environment) {
-      if (preset.environment[key]) {
-        expandedPreset.environment[key] = await expandString(preset.environment[key]!, expansionOpts);
-      }
-    }
-  }
-
-  expansionOpts.envOverride = expandedPreset.environment as EnvironmentVariables;
-
   // Expand other fields
   if (preset.overwriteConfigurationFile) {
     expandedPreset.overwriteConfigurationFile = [];
@@ -1405,7 +1384,9 @@ async function expandTestPresetHelper(folder: string,
   if (!preset.environment) {
     preset.environment = {};
   }
-  let inheritedEnv = {};
+  if (!preset.__environmentList) {
+    preset.__environmentList = [];
+  }
 
   // Expand inherits
   if (preset.inherits) {
@@ -1416,7 +1397,7 @@ async function expandTestPresetHelper(folder: string,
       const parent = await expandTestPresetImpl(folder, parentName, workspaceFolder, sourceDir, preferredGeneratorName, allowUserPreset);
       if (parent) {
         // Inherit environment
-        inheritedEnv = util.mergeEnvironment(parent.environment! as EnvironmentVariables, inheritedEnv);
+        preset.__environmentList.push(...parent.__environmentList!);
         // Inherit other fields
         let key: keyof TestPreset;
         for (key in parent) {
@@ -1437,14 +1418,14 @@ async function expandTestPresetHelper(folder: string,
       preset.__generator = configurePreset.generator;
 
       if (preset.inheritConfigureEnvironment !== false) { // Check false explicitly since defaults to true
-        inheritedEnv = util.mergeEnvironment(inheritedEnv, configurePreset.environment! as EnvironmentVariables);
+        preset.__environmentList.push(...configurePreset.__environmentList!);
       }
     } else {
       return null;
     }
   }
 
-  preset.environment = util.mergeEnvironment(process.env as EnvironmentVariables, inheritedEnv, preset.environment as EnvironmentVariables);
+  preset.__environmentList.push(preset.environment);
 
   preset.__expanded = true;
   return preset;

--- a/src/proc.ts
+++ b/src/proc.ts
@@ -77,6 +77,8 @@ export interface BuildCommand {
 export interface EnvironmentVariables { [key: string]: string }
 export interface DebuggerEnvironmentVariable { name: string; value: string }
 
+export type GeneralEnvironmentType = EnvironmentVariables | Map<string, string> | NodeJS.ProcessEnv;
+
 export interface ExecutionOptions {
   environment?: EnvironmentVariables;
   shell?: boolean;


### PR DESCRIPTION
Using consistence function for environment set and get to fix the
gap between windows and unix.

Directly use configureEnv, as now getConfigureEnvironment would not return environment with undefined/null value

Also expand with environment variable when get effectiveKitEnvironment

Fixes https://github.com/microsoft/vscode-cmake-tools/issues/1592

preset using the same environment variable merge strategy like kits does

Using GeneralEnvironmentType

Signed-off-by: Yonggang Luo <luoyonggang@gmail.com>

Convert collectDevBatVars to use util.envGetValue

<!-- Thanks for your contribution! To make things easier, please fill out the template below. -->

<!-- Please delete any unused sections. -->

<!-- Delete the following heading if there is no corresponding issue -->
## This change addresses item #[[put issue number here to generate a link]]

### This changes [[visible behavior/performance/documentation/etc.]]

The following changes are proposed:

- <!-- Put something here -->
- <!-- And maybe here -->
- <!-- Add or remove bullets as you need -->

## The purpose of this change

<!-- If not linked to an issue, describe the purpose of this change. Otherwise,
delete this section. -->

## Other Notes/Information

<!-- Write whatever you feel is relevant -->
