### PR TITLE
Add OneLocBuild to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ test/unit-tests/driver/workspace/test_project/bin/
 vscode-extensions-localization-export/
 vscode-translations-import/
 jobs/loc/LCL
+OneLocBuild
 .ci-build
 .DS_Store
 debug.log


### PR DESCRIPTION
Fixes an issue causing our internal localization pipeline to fail. It looks like some change was made resulting in this directory lingering in our repo after we run the OneLocBuild task. It then caused a problem for our import script (which intentionally fails when it sees uncommitted changes).