### PR TITLE
Update to latest XLoc package for OneLocBuild

### DIFF
--- a/jobs/loc/TranslationsImportExport.yml
+++ b/jobs/loc/TranslationsImportExport.yml
@@ -43,7 +43,6 @@ steps:
     LclSource: lclFilesfromPackage
     LclPackageId: 'LCL-JUNO-PROD-VCMAKE'
     isUseLfLineEndingsSelected: true
-    lsBuildXLocPackageVersion: '7.0.30510'
 
 - task: CmdLine@2
   inputs:


### PR DESCRIPTION
We had been pinned to an older version, due to a bug that was corrupting our newlines. That has since been fixed. This change removes the pinned version requirement.