### PR TITLE
Fix IntelliSense usage of the short name (#2120)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.10.0
 Bug fixes:
 - Fix `Show Build Command` for folders that do not use CMake Presets. [#2211](https://github.com/microsoft/vscode-cmake-tools/issues/2211)
+- Fix IntelliSense usage of short name from variants file for buildType. [#2120](https://github.com/microsoft/vscode-cmake-tools/issues/2120)
 
 ## 1.9.1
 Bug fixes:

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -732,7 +732,7 @@ class ExtensionManager implements vscode.Disposable {
                 if (drv) {
                     drv.isMultiConfig = isMultiConfig;
                 }
-                const actualBuildType = (() => {
+                const actualBuildType = await (async () => {
                     if (cmt.useCMakePresets) {
                         if (isMultiConfig) {
                             return cmt.buildPreset?.configuration || null;
@@ -741,7 +741,7 @@ class ExtensionManager implements vscode.Disposable {
                             return buildType ? buildType.as<string>() : null; // Single config generators set the build type during config, not build.
                         }
                     } else {
-                        return cmt.activeVariant;
+                        return cmt.currentBuildType();
                     }
                 })();
 


### PR DESCRIPTION
IntelliSense now uses buidType from variants file instead of short name

<!-- Thanks for your contribution! To make things easier, please fill out the template below. -->

<!-- Please delete any unused sections. -->

<!-- Delete the following heading if there is no corresponding issue -->
## This change addresses item #2120

### This changes visible behavior

The following changes are proposed:

- IntelliSense will use current build type from variants files instead of short name

