### PR TITLE
Upgrade @types/vscode to version 1.56 to used improved TerminalOptions

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "native"
   ],
   "engines": {
-    "vscode": "^1.53.0"
+    "vscode": "^1.56.0"
   },
   "categories": [
     "Other"
@@ -2004,7 +2004,7 @@
     "@types/rimraf": "^3.0.0",
     "@types/sinon": "~9.0.10",
     "@types/tmp": "^0.2.0",
-    "@types/vscode": "1.53.0",
+    "@types/vscode": "1.56.0",
     "@types/which": "~2.0.0",
     "@types/xml2js": "^0.4.8",
     "@typescript-eslint/eslint-plugin": "^4.22.1",

--- a/test/helpers/vscodefake/extensioncontext.ts
+++ b/test/helpers/vscodefake/extensioncontext.ts
@@ -38,8 +38,11 @@ export class DefaultExtensionContext implements vscode.ExtensionContext {
     get extensionMode(): vscode.ExtensionMode {
         throw new Error(notImplementedErr);
     }
+    extension: vscode.Extension<any>;
 
-    constructor() {}
+    constructor() {
+        this.extension = vscode.extensions.getExtension("ms-vscode.cmake-tools")!;
+    }
     public clean() {
         (this.workspaceState as TestMemento).clear();
         (this.globalState as StateMemento).clear();
@@ -83,8 +86,11 @@ export class SmokeTestExtensionContext implements vscode.ExtensionContext {
     get extensionMode(): vscode.ExtensionMode {
         throw new Error(notImplementedErr);
     }
+    extension: vscode.Extension<any>;
 
-    constructor(public readonly extensionPath: string) {}
+    constructor(public readonly extensionPath: string) {
+        this.extension = vscode.extensions.getExtension("ms-vscode.cmake-tools")!;
+    }
     public clean() {
         (this.workspaceState as TestMemento).clear();
         (this.globalState as StateMemento).clear();

--- a/yarn.lock
+++ b/yarn.lock
@@ -361,10 +361,10 @@
   resolved "https://registry.yarnpkg.com/@types/tmp/-/tmp-0.2.0.tgz#e3f52b4d7397eaa9193592ef3fdd44dc0af4298c"
   integrity sha512-flgpHJjntpBAdJD43ShRosQvNC0ME97DCfGvZEDlAThQmnerRXrLbX6YgzRBQCZTthET9eAWFAMaYP0m0Y4HzQ==
 
-"@types/vscode@1.53.0":
-  version "1.53.0"
-  resolved "https://registry.yarnpkg.com/@types/vscode/-/vscode-1.53.0.tgz#47b53717af6562f2ad05171bc9c8500824a3905c"
-  integrity sha512-XjFWbSPOM0EKIT2XhhYm3D3cx3nn3lshMUcWNy1eqefk+oqRuBq8unVb6BYIZqXy9lQZyeUl7eaBCOZWv+LcXQ==
+"@types/vscode@1.56.0":
+  version "1.56.0"
+  resolved "https://registry.yarnpkg.com/@types/vscode/-/vscode-1.56.0.tgz#2a75ee6d66e529295648b0b6ee43824564ed9c1a"
+  integrity sha512-Q5VmQxOx+L1Y6lIJiGcJzwcyV3pQo/eiW8P+7sNLhFI16tJCwtua2DLjHRcpjbCLNVYpQM73kzfFo1Z0HyP9eQ==
 
 "@types/which@~2.0.0":
   version "2.0.0"


### PR DESCRIPTION
Upgrade @types/vscode to version 1.56 to used improved TerminalOptions

The TerminalOptions.env upgrade from
```
        env?: { [key: string]: string | null };
```
to
```
        env?: { [key: string]: string | null | undefined };
```
The TerminalOptions.env upgrade from
```
        env?: { [key: string]: string | null };
```
to
```
        env?: { [key: string]: string | null | undefined };
```

So that TerminalOptions.env can accept
`{ [key: string]: string | null | undefined }`,
`{ [key: string]: string | undefined }` that is NodeJS.ProcessEnv,
`{ [key: string]: string}` and
`{ [key: string]: string | null}`

Signed-off-by: Yonggang Luo <luoyonggang@gmail.com>
