### PR TITLE
Fixes ci.ps1 warning

### DIFF
--- a/scripts/ci.ps1
+++ b/scripts/ci.ps1
@@ -28,14 +28,8 @@ if ($PSVersionTable.PSVersion.Major -lt 6) {
 # The root directory of our repository:
 $REPO_DIR = Split-Path $PSScriptRoot -Parent
 
-$Package = Get-Content (Join-Path $REPO_DIR "package.json") | ConvertFrom-Json
-
-$CMakeToolsVersion = $Package.version
-
 # Import the utility modules
 Import-Module (Join-Path $PSScriptRoot "cmt.psm1")
-
-$DOC_BUILD_DIR = Join-Path $REPO_DIR "build/docs"
 
 # Sanity check for yarn
 $yarn = Find-Program yarn


### PR DESCRIPTION
[{
	"resource": "/e:/CI-Cor-Ready/study/vscode-cmake-tools/scripts/ci.ps1",
	"owner": "_generated_diagnostic_collection_name_#3",
	"code": "PSUseDeclaredVarsMoreThanAssignments",
	"severity": 4,
	"message": "The variable 'CMakeToolsVersion' is assigned but never used.",
	"source": "PSScriptAnalyzer",
	"startLineNumber": 33,
	"startColumn": 1,
	"endLineNumber": 33,
	"endColumn": 19
},{
	"resource": "/e:/CI-Cor-Ready/study/vscode-cmake-tools/scripts/ci.ps1",
	"owner": "_generated_diagnostic_collection_name_#3",
	"code": "PSUseDeclaredVarsMoreThanAssignments",
	"severity": 4,
	"message": "The variable 'DOC_BUILD_DIR' is assigned but never used.",
	"source": "PSScriptAnalyzer",
	"startLineNumber": 38,
	"startColumn": 1,
	"endLineNumber": 38,
	"endColumn": 15
}]
