### PR TITLE
Enable backendTests in CI

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -185,6 +185,8 @@
                 "--colors",
                 "-r",
                 "ts-node/register",
+                "-r",
+                "tsconfig-paths/register",
                 "${workspaceFolder}/test/backend-unit-tests/**/*.test.ts"
             ],
             "internalConsoleOptions": "openOnSessionStart"

--- a/package.json
+++ b/package.json
@@ -532,7 +532,9 @@
           },
           "command": {
             "type": "string",
-            "enum": [ "build" ],
+            "enum": [
+              "build"
+            ],
             "description": "CMake build command"
           },
           "options": {
@@ -1984,6 +1986,7 @@
     "extensionTestsSuccessfulBuild": "yarn run pretest && node ./out/test/extension-tests/successful-build/runTest.js",
     "extensionTestsSingleRoot": "yarn run pretest && node ./out/test/extension-tests/single-root-UI/runTest.js",
     "extensionTestsMultioot": "yarn run pretest && node ./out/test/extension-tests/multi-root-UI/runTest.js",
+    "backendTests": "node ./node_modules/mocha/bin/_mocha -u tdd --timeout 999999 --colors -r ts-node/register -r tsconfig-paths/register ./test/backend-unit-tests/**/*.test.ts",
     "docs": "node ./node_modules/typedoc/bin/typedoc --excludeExternals --out build/docs/dev --readme none src/ types/"
   },
   "husky": {
@@ -2035,6 +2038,7 @@
     "sinon": "~9.2.4",
     "ts-loader": "^8.0.17",
     "ts-node": "^9.1.1",
+    "tsconfig-paths": "^3.11.0",
     "tslint": "^5.20.1",
     "typedoc": "^0.20.36",
     "typescript": "^4.1.5",
@@ -2057,8 +2061,8 @@
     "tmp": "^0.2.1",
     "vscode-cpptools": "^5.0.0",
     "vscode-extension-telemetry": "^0.1.7",
-    "vscode-tas-client": "^0.1.22",
     "vscode-nls": "^5.0.0",
+    "vscode-tas-client": "^0.1.22",
     "which": "~2.0.2",
     "xml2js": "^0.4.23"
   },

--- a/scripts/ci.ps1
+++ b/scripts/ci.ps1
@@ -102,6 +102,7 @@ Invoke-ChronicCommand "yarn lint" $yarn run lint
 # Run tests
 Invoke-TestPreparation -CMakePath $cmake_binary
 
+Invoke-ChronicCommand "yarn backendTests" $yarn run backendTests
 Invoke-ChronicCommand "yarn pretest" $yarn run pretest
 Invoke-ChronicCommand "yarn smokeTests" $yarn run smokeTests
 Invoke-ChronicCommand "yarn unitTests" $yarn run unitTests

--- a/test/backend-unit-tests/cmake/strand.test.ts
+++ b/test/backend-unit-tests/cmake/strand.test.ts
@@ -1,6 +1,3 @@
-// eslint-disable-next-line import/no-unassigned-import
-import 'module-alias/register';
-
 import * as chai from 'chai';
 import { expect } from 'chai';
 import * as chaiAsPromised from 'chai-as-promised';

--- a/yarn.lock
+++ b/yarn.lock
@@ -5713,6 +5713,16 @@ ts-node@^9.1.1:
     source-map-support "^0.5.17"
     yn "3.1.1"
 
+tsconfig-paths@^3.11.0:
+  version "3.11.0"
+  resolved "https://registry.yarnpkg.com/tsconfig-paths/-/tsconfig-paths-3.11.0.tgz#954c1fe973da6339c78e06b03ce2e48810b65f36"
+  integrity sha512-7ecdYDnIdmv639mmDwslG6KQg1Z9STTz1j7Gcz0xa+nshh/gKDAHcPxRbWOsA3SPp0tXP2leTcY9Kw+NAkfZzA==
+  dependencies:
+    "@types/json5" "^0.0.29"
+    json5 "^1.0.1"
+    minimist "^1.2.0"
+    strip-bom "^3.0.0"
+
 tsconfig-paths@^3.9.0:
   version "3.9.0"
   resolved "https://registry.yarnpkg.com/tsconfig-paths/-/tsconfig-paths-3.9.0.tgz#098547a6c4448807e8fcb8eae081064ee9a3c90b"


### PR DESCRIPTION
Launching backendTests without the need of compiling typescript for better developing experience.

Signed-off-by: Yonggang Luo <luoyonggang@gmail.com>
