### PR TITLE
Stop using `-H` to configure projects

### DIFF
--- a/src/drivers/cmfileapi-driver.ts
+++ b/src/drivers/cmfileapi-driver.ts
@@ -224,9 +224,11 @@ export class CMakeFileApiDriver extends CMakeDriver {
 
         // Dup args so we can modify them
         const args = Array.from(args_);
-        args.push(`-H${util.lightNormalizePath(this.sourceDir)}`);
-        const bindir = util.lightNormalizePath(this.binaryDir);
-        args.push(`-B${bindir}`);
+
+        // -S and -B were introduced in CMake 3.13 and this driver assumes CMake >= 3.15
+        args.push(`-S${util.lightNormalizePath(this.sourceDir)}`);
+        args.push(`-B${util.lightNormalizePath(this.binaryDir)}`);
+
         const gen = this.generator;
         let has_gen = false;
         for (const arg of args) {


### PR DESCRIPTION
The -H flag is an undocumented feature that was never supposed to be
used by the public. This commit makes the drivers use the appropriate
methods of configuring depending on the CMake version they handle:

Legacy: The binary directory has to be created first and CMake must be
invoked with that folder as its working directory. The source directory
is passed without any flags.

ServerAPI: The binary directory was already ensured to exist. No changes
necessary.

FileAPI: The driver for this assumes CMake >= 3.15, so the -S and -B
flags can be used. These flags were introduced in CMake 3.13.

Fixes: #2053

### This changes visible behavior