### PR TITLE
Reduce direct access to process.env for tests

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -529,7 +529,7 @@ class ExtensionManager implements vscode.Disposable {
             await scanForKitsIfNeeded(cmt);
 
         let should_configure = cmt.workspaceContext.config.configureOnOpen;
-        if (should_configure === null && process.env['CMT_TESTING'] !== '1') {
+        if (should_configure === null && !util.isTestMode()) {
             interface Choice1 {
                 title: string;
                 doConfigure: boolean;
@@ -943,7 +943,7 @@ class ExtensionManager implements vscode.Disposable {
      * Show UI to allow the user to select an active kit
      */
     async selectKit(folder?: vscode.WorkspaceFolder): Promise<boolean> {
-        if (process.env['CMT_TESTING'] === '1') {
+        if (util.isTestMode()) {
             log.trace(localize('selecting.kit.in.test.mode', 'Running CMakeTools in test mode. selectKit is disabled.'));
             return false;
         }
@@ -1473,7 +1473,7 @@ class ExtensionManager implements vscode.Disposable {
      * Show UI to allow the user to add an active configure preset
      */
     async addConfigurePreset(folder: vscode.WorkspaceFolder): Promise<boolean> {
-        if (process.env['CMT_TESTING'] === '1') {
+        if (util.isTestMode()) {
             log.trace(localize('add.config.preset.in.test.mode', 'Running CMakeTools in test mode. addConfigurePreset is disabled.'));
             return false;
         }
@@ -1490,7 +1490,7 @@ class ExtensionManager implements vscode.Disposable {
      * Show UI to allow the user to add an active build preset
      */
     async addBuildPreset(folder: vscode.WorkspaceFolder): Promise<boolean> {
-        if (process.env['CMT_TESTING'] === '1') {
+        if (util.isTestMode()) {
             log.trace(localize('add.build.preset.in.test.mode', 'Running CMakeTools in test mode. addBuildPreset is disabled.'));
             return false;
         }
@@ -1507,7 +1507,7 @@ class ExtensionManager implements vscode.Disposable {
      * Show UI to allow the user to add an active test preset
      */
     async addTestPreset(folder: vscode.WorkspaceFolder): Promise<boolean> {
-        if (process.env['CMT_TESTING'] === '1') {
+        if (util.isTestMode()) {
             log.trace(localize('add.test.preset.in.test.mode', 'Running CMakeTools in test mode. addTestPreset is disabled.'));
             return false;
         }
@@ -1525,7 +1525,7 @@ class ExtensionManager implements vscode.Disposable {
      * Show UI to allow the user to select an active configure preset
      */
     async selectConfigurePreset(folder?: vscode.WorkspaceFolder): Promise<boolean> {
-        if (process.env['CMT_TESTING'] === '1') {
+        if (util.isTestMode()) {
             log.trace(localize('selecting.config.preset.in.test.mode', 'Running CMakeTools in test mode. selectConfigurePreset is disabled.'));
             return false;
         }
@@ -1553,7 +1553,7 @@ class ExtensionManager implements vscode.Disposable {
      * Show UI to allow the user to select an active build preset
      */
     async selectBuildPreset(folder?: vscode.WorkspaceFolder): Promise<boolean> {
-        if (process.env['CMT_TESTING'] === '1') {
+        if (util.isTestMode()) {
             log.trace(localize('selecting.build.preset.in.test.mode', 'Running CMakeTools in test mode. selectBuildPreset is disabled.'));
             return false;
         }
@@ -1575,7 +1575,7 @@ class ExtensionManager implements vscode.Disposable {
      * Show UI to allow the user to select an active test preset
      */
     async selectTestPreset(folder?: vscode.WorkspaceFolder): Promise<boolean> {
-        if (process.env['CMT_TESTING'] === '1') {
+        if (util.isTestMode()) {
             log.trace(localize('selecting.test.preset.in.test.mode', 'Running CMakeTools in test mode. selectTestPreset is disabled.'));
             return false;
         }

--- a/src/kit.ts
+++ b/src/kit.ts
@@ -374,7 +374,7 @@ export async function kitIfCompiler(bin: string, pr?: ProgressReporter): Promise
 }
 
 async function scanDirectory<Ret>(dir: string, mapper: (filePath: string) => Promise<Ret | null>): Promise<Ret[]> {
-    if (process.env['CMT_TESTING'] === '1' && process.platform === 'win32' && dir.indexOf('AppData') > 0 && dir.indexOf('Local') > 0) {
+    if (util.isTestMode() && process.platform === 'win32' && dir.indexOf('AppData') > 0 && dir.indexOf('Local') > 0) {
         // This folder causes problems with tests on Windows.
         log.debug(localize('skipping.scan.of.appdata', 'Skipping scan of %LocalAppData% folder'));
         return [];
@@ -1294,8 +1294,7 @@ export async function scanForKitsIfNeeded(cmt: CMakeTools): Promise<boolean> {
     const kitsVersionCurrent = 2;
 
     // Scan also when there is no kits version saved in the state.
-    if ((!kitsVersionSaved || kitsVersionSaved !== kitsVersionCurrent) &&
-        process.env['CMT_TESTING'] !== '1' && !kitsController.KitsController.isScanningForKits()) {
+    if ((!kitsVersionSaved || kitsVersionSaved !== kitsVersionCurrent) && !util.isTestMode() && !kitsController.KitsController.isScanningForKits()) {
         log.info(localize('silent.kits.rescan', 'Detected kits definition version change from {0} to {1}. Silently scanning for kits.', kitsVersionSaved, kitsVersionCurrent));
         await kitsController.KitsController.scanForKits(cmt);
         await cmt.extensionContext.globalState.update('kitsVersionSaved', kitsVersionCurrent);

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -19,14 +19,14 @@ interface VSCMakePaths {
 
 class WindowsEnvironment {
     get AppData(): string | undefined {
-        if (process.env['CMT_TESTING'] === '1') {
+        if (util.isTestMode()) {
             return path.join(vscode.workspace.workspaceFolders![0].uri.fsPath, '.vscode');
         }
         return process.env['APPDATA'];
     }
 
     get LocalAppData(): string | undefined {
-        if (process.env['CMT_TESTING'] === '1') {
+        if (util.isTestMode()) {
             return path.join(vscode.workspace.workspaceFolders![0].uri.fsPath, '.vscode');
         }
         return process.env['LOCALAPPDATA'];

--- a/src/proc.ts
+++ b/src/proc.ts
@@ -187,7 +187,7 @@ export function execute(command: string,
                             line_acc += lines[0];
                             if (outputConsumer) {
                                 outputConsumer.output(line_acc);
-                            } else if (process.env['CMT_TESTING']) {
+                            } else if (util.isTestMode()) {
                                 log.info(line_acc);
                             }
                             line_acc = '';
@@ -207,7 +207,7 @@ export function execute(command: string,
                             stderr_line_acc += lines[0];
                             if (outputConsumer) {
                                 outputConsumer.error(stderr_line_acc);
-                            } else if (process.env['CMT_TESTING'] && stderr_line_acc) {
+                            } else if (util.isTestMode() && stderr_line_acc) {
                                 log.info(stderr_line_acc);
                             }
                             stderr_line_acc = '';

--- a/src/util.ts
+++ b/src/util.ts
@@ -678,6 +678,13 @@ export function isCodespaces(): boolean {
     return !!process.env["CODESPACES"];
 }
 
+/**
+ * Returns true if the extension is currently running tests.
+ */
+export function isTestMode(): boolean {
+    return process.env['CMT_TESTING'] === '1';
+}
+
 export async function getAllCMakeListsPaths(dir: vscode.Uri): Promise<string[] | undefined> {
     const regex: RegExp = new RegExp(/(\/|\\)CMakeLists\.txt$/);
     return recGetAllFilePaths(dir.fsPath, regex, await readDir(dir.fsPath), []);

--- a/src/variant.ts
+++ b/src/variant.ts
@@ -381,7 +381,7 @@ export class VariantManager implements vscode.Disposable {
                 }
             }
             return false;
-        } else if (process.env['CMT_TESTING'] === '1') {
+        } else if (util.isTestMode()) {
             await this.publishActiveKeywordSettings(this.activeKeywordSetting ?? items[0].keywordSettings);
             return true;
         } else {


### PR DESCRIPTION
Reducing the number of places that directly access `process.env`. This variable is checked often enough that it deserves its own function.