### PR TITLE
Add Ninja Multi-Config to findBestGenerator

### DIFF
--- a/src/drivers/driver.ts
+++ b/src/drivers/driver.ts
@@ -785,7 +785,7 @@ export abstract class CMakeDriver implements vscode.Disposable {
         for (const gen of preferredGenerators) {
             const gen_name = gen.name;
             const generator_present = await (async (): Promise<boolean> => {
-                if (gen_name === 'Ninja') {
+                if (gen_name === 'Ninja' || gen_name === 'Ninja Multi-Config') {
                     return await this.testHaveCommand('ninja') || this.testHaveCommand('ninja-build');
                 }
                 if (gen_name === 'MinGW Makefiles') {


### PR DESCRIPTION
<!-- Thanks for your contribution! To make things easier, please fill out the template below. -->

<!-- Please delete any unused sections. -->

<!-- Delete the following heading if there is no corresponding issue -->
## This change addresses item #1423 

This fixes an issue where Ninja Multi-Config was not considered when listed in cmake.preferredGenerator
