### PR TITLE
Increase timeout value for fixes tests timeout on win32

### DIFF
--- a/test/unit-tests/driver/driver-test.ts
+++ b/test/unit-tests/driver/driver-test.ts
@@ -93,7 +93,7 @@ export function makeDriverTestsuite(driverName: string, driver_generator: (cmake
             } else {
                 expect(allTargetName).to.eq('all');
             }
-        }).timeout(60000);
+        }).timeout(60000 * 2);
 
         test('Check binary dir', async () => {
             const config = ConfigurationReader.create();

--- a/test/unit-tests/kit-scan.test.ts
+++ b/test/unit-tests/kit-scan.test.ts
@@ -95,7 +95,7 @@ suite('Kits scan test', async () => {
 
         // Don't care about the result, just check that we don't throw during the test
         await kit.scanForKits(cmt, { ignorePath: process.platform === 'win32' });
-    }).timeout(120000); // Compiler detection can run a little slow
+    }).timeout(120000 * 2); // Compiler detection can run a little slow
 
     test('Detect a GCC compiler file', async () => {
         const compiler = path.join(fakebin, 'gcc-42.1');


### PR DESCRIPTION
The following error are copied from  https://github.com/microsoft/vscode-cmake-tools/runs/4933169033?check_suite_focus=true
```
2022-01-25T07:38:39.8034093Z [0m  1) CMake FileAPI driver tests
2022-01-25T07:38:39.8035702Z        All target for Visual Studio Community 2019 - amd64:
2022-01-25T07:38:39.8038322Z [0m[31m     Error: Timeout of 60000ms exceeded. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves. (d:\a\vscode-cmake-tools\vscode-cmake-tools\out\test\unit-tests\driver\cmfileapi-driver.test.js)[0m[90m
2022-01-25T07:38:39.8040365Z   	at listOnTimeout (internal/timers.js:554:17)
2022-01-25T07:38:39.8041995Z   	at processTimers (internal/timers.js:497:7)
2022-01-25T07:38:39.8043420Z [0m
2022-01-25T07:38:39.8044865Z [0m  2) Kits scan test
2022-01-25T07:38:39.8058046Z        Detect system kits never throws:
2022-01-25T07:38:39.8061281Z [0m[31m     Error: Timeout of 120000ms exceeded. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves. (d:\a\vscode-cmake-tools\vscode-cmake-tools\out\test\unit-tests\kit-scan.test.js)[0m[90m
2022-01-25T07:38:39.8063425Z   	at listOnTimeout (internal/timers.js:554:17)
2022-01-25T07:38:39.8065171Z   	at processTimers (internal/timers.js:497:7)
```

Signed-off-by: Yonggang Luo <luoyonggang@gmail.com>
