### PR TITLE
Include `hostSystemName` in variable expansion when only using User presets

### DIFF
--- a/src/preset.ts
+++ b/src/preset.ts
@@ -576,7 +576,8 @@ async function getExpansionOptions(folder: string,
     };
 
     const presetsFile = getPresetsFile(folder);
-    if (presetsFile && presetsFile.version >= 3) {
+    const userPresetsFile = getUserPresetsFile(folder);
+    if (presetsFile && presetsFile.version >= 3 || userPresetsFile && userPresetsFile.version >= 3) {
         expansionOpts.vars['hostSystemName'] = await util.getHostSystemNameMemo();
     }
 

--- a/src/presetsController.ts
+++ b/src/presetsController.ts
@@ -181,10 +181,7 @@ export class PresetsController {
         preset.setOriginalUserPresetsFile(folder, presetsFile);
     };
 
-    private async resetPresetsFile(file: string,
-        setPresetsFile: SetPresetsFileFunc,
-        setOriginalPresetsFile: SetPresetsFileFunc,
-        fileExistCallback: (fileExists: boolean) => void) {
+    private async resetPresetsFile(file: string, setPresetsFile: SetPresetsFileFunc, setOriginalPresetsFile: SetPresetsFileFunc, fileExistCallback: (fileExists: boolean) => void) {
         const presetsFileBuffer = await this.readPresetsFile(file);
 
         // There might be a better location for this, but for now this is the best one...
@@ -205,14 +202,8 @@ export class PresetsController {
     // (need to clean or reload driver)
     async reapplyPresets() {
         // Reset all changes due to expansion since parents could change
-        await this.resetPresetsFile(this.presetsPath,
-            this._setPresetsFile,
-            this._setOriginalPresetsFile,
-            exists => this._presetsFileExists = exists);
-        await this.resetPresetsFile(this.userPresetsPath,
-            this._setUserPresetsFile,
-            this._setOriginalUserPresetsFile,
-            exists => this._userPresetsFileExists = exists);
+        await this.resetPresetsFile(this.presetsPath, this._setPresetsFile, this._setOriginalPresetsFile, exists => this._presetsFileExists = exists);
+        await this.resetPresetsFile(this.userPresetsPath, this._setUserPresetsFile, this._setOriginalUserPresetsFile, exists => this._userPresetsFileExists = exists);
 
         this._cmakeTools.minCMakeVersion = preset.minCMakeVersion(this.folderFsPath);
 


### PR DESCRIPTION
Addresses #2362 

CMakeUserPresets.json was not being included in the logic that determined whether `${hostSystemName}` was defined or not.