### PR TITLE
Split vscode out of diagnostics parsing utils.

### DIFF
--- a/src/basic/util.ts
+++ b/src/basic/util.ts
@@ -1,0 +1,78 @@
+/**
+ * Generate an array of key-value pairs from an object using
+ * `getOwnPropertyNames`
+ * @param obj The object to iterate
+ */
+export function objectPairs<V>(obj: { [key: string]: V }): [string, V][] {
+    return Object.getOwnPropertyNames(obj).map(key => ([key, obj[key]] as [string, V]));
+}
+
+/**
+ * Map an iterable by some projection function
+ * @param iter An iterable to map
+ * @param proj The projection function
+ */
+export function* map<In, Out>(iter: Iterable<In>, proj: (arg: In) => Out): Iterable<Out> {
+    for (const item of iter) {
+        yield proj(item);
+    }
+}
+
+export function* chain<T>(...iter: Iterable<T>[]): Iterable<T> {
+    for (const sub of iter) {
+        for (const item of sub) {
+            yield item;
+        }
+    }
+}
+
+export function reduce<In, Out>(iter: Iterable<In>, init: Out, mapper: (acc: Out, el: In) => Out): Out {
+    for (const item of iter) {
+        init = mapper(init, item);
+    }
+    return init;
+}
+
+export function find<T>(iter: Iterable<T>, predicate: (value: T) => boolean): T | undefined {
+    for (const value of iter) {
+        if (predicate(value)) {
+            return value;
+        }
+    }
+    // Nothing found
+    return undefined;
+}
+
+/**
+ * Generate a random integral value.
+ * @param min Minimum value
+ * @param max Maximum value
+ */
+export function randint(min: number, max: number): number {
+    return Math.floor(Math.random() * (max - min) + min);
+}
+
+export function product<T>(arrays: T[][]): T[][] {
+    return arrays.reduce(
+        (acc, curr) =>
+            // Append each element of the current array to each list already accumulated
+            acc.map(prev => curr.map(item => prev.concat(item)))
+                // Join all the lists
+                .reduce((a, b) => a.concat(b), []),
+        [[]] as T[][]);
+}
+
+/**
+ * Get one less than the given number of number-string.
+ *
+ * If the number is greater than zero, returns that number minus one. If
+ * the number is less than one, returns zero.
+ * @param num A number or string representing a number
+ */
+export function oneLess(num: number | string): number {
+    if (typeof num === 'string') {
+        return oneLess(parseInt(num));
+    } else {
+        return Math.max(0, num - 1);
+    }
+}

--- a/src/diagnostics/cmake.ts
+++ b/src/diagnostics/cmake.ts
@@ -5,9 +5,10 @@
 import { Logger } from '@cmt/logging';
 import { OutputConsumer } from '@cmt/proc';
 import * as util from '@cmt/util';
+import { oneLess } from '@cmt/basic/util';
 import * as vscode from 'vscode';
 
-import { FileDiagnostic, oneLess } from './util';
+import { FileDiagnostic } from './util';
 
 /**
  * Class which consumes output from CMake.

--- a/src/diagnostics/compilers.ts
+++ b/src/diagnostics/compilers.ts
@@ -1,0 +1,19 @@
+import * as gcc from './gcc';
+import * as ghs from './ghs';
+import * as diab from './diab';
+import * as gnu_ld from './gnu-ld';
+import * as mvsc from './msvc';
+import * as iar from './iar';
+
+import { RawDiagnosticParser } from './rawDiagnosticParser';
+
+export class Compilers {
+    [compiler: string]: RawDiagnosticParser;
+
+    gcc = new gcc.Parser();
+    ghs = new ghs.Parser();
+    diab = new diab.Parser();
+    gnuLD = new gnu_ld.Parser();
+    msvc = new mvsc.Parser();
+    iar = new iar.Parser();
+}

--- a/src/diagnostics/diab.ts
+++ b/src/diagnostics/diab.ts
@@ -1,10 +1,9 @@
 /**
  * Module for parsing Wind River Diab diagnostics
- */ /** */
+ */
 
-import * as vscode from 'vscode';
-
-import { oneLess, RawDiagnosticParser, FeedLineResult } from './util';
+import { oneLess } from '@cmt/basic/util';
+import { FeedLineResult, RawDiagnosticParser } from './rawDiagnosticParser';
 
 export const REGEX = /^\"(.*)\",\s+(?:line\s+(\d+):\s+)?(info|warning|(?:|fatal |catastrophic )error)\s+\((.*)\):\s+(.*)$/;
 
@@ -22,7 +21,12 @@ export class Parser extends RawDiagnosticParser {
             return {
                 full,
                 file,
-                location: new vscode.Range(oneLess(lineno), oneLess(column), oneLess(lineno), 999),
+                location: {
+                    startLine: oneLess(lineno),
+                    startCharacter: oneLess(column),
+                    endLine: oneLess(lineno),
+                    endCharacter: 999
+                },
                 severity,
                 code,
                 message,

--- a/src/diagnostics/gcc.ts
+++ b/src/diagnostics/gcc.ts
@@ -1,10 +1,9 @@
 /**
  * Module for handling GCC diagnostics
- */ /** */
+ */
 
-import * as vscode from 'vscode';
-
-import { oneLess, RawDiagnostic, RawDiagnosticParser, RawRelated, FeedLineResult } from './util';
+import { oneLess } from '@cmt/basic/util';
+import { FeedLineResult, RawDiagnostic, RawDiagnosticParser, RawRelated } from './rawDiagnosticParser';
 
 export const REGEX = /^(.*):(\d+):(\d+):\s+(?:fatal )?(\w*)(?:\sfatale)?\s?:\s+(.*)/;
 
@@ -36,7 +35,12 @@ export class Parser extends RawDiagnosticParser {
                 const lineNo = oneLess(linestr);
                 this._pendingTemplateError.requiredFrom.push({
                     file,
-                    location: new vscode.Range(lineNo, parseInt(column), lineNo, 999),
+                    location: {
+                        startLine: lineNo,
+                        startCharacter: parseInt(column),
+                        endLine: lineNo,
+                        endCharacter: 999
+                    },
                     message
                 });
                 return FeedLineResult.Ok;
@@ -68,13 +72,23 @@ export class Parser extends RawDiagnosticParser {
                 if (severity === 'note' && this._prevDiag) {
                     this._prevDiag.related.push({
                         file,
-                        location: new vscode.Range(lineno, column, lineno, 999),
+                        location: {
+                            startLine: lineno,
+                            startCharacter: column,
+                            endLine: lineno,
+                            endCharacter: 999
+                        },
                         message
                     });
                     return FeedLineResult.Ok;
                 } else {
                     const related: RawRelated[] = [];
-                    const location = new vscode.Range(lineno, column, lineno, 999);
+                    const location = {
+                        startLine: lineno,
+                        startCharacter: column,
+                        endLine: lineno,
+                        endCharacter: 999
+                    };
                     if (this._pendingTemplateError) {
                         related.push({
                             location,

--- a/src/diagnostics/ghs.ts
+++ b/src/diagnostics/ghs.ts
@@ -1,10 +1,9 @@
 /**
  * Module for parsing GHS diagnostics
- */ /** */
+ */
 
-import * as vscode from 'vscode';
-
-import { oneLess, RawDiagnosticParser, FeedLineResult } from './util';
+import { oneLess } from '@cmt/basic/util';
+import { FeedLineResult, RawDiagnosticParser } from './rawDiagnosticParser';
 
 export const REGEX = /^\"(.*)\",\s+(?:(?:line\s+(\d+)\s+\(col\.\s+(\d+)\))|(?:At end of source)):\s+(?:fatal )?(remark|warning|error)\s+(.*)/;
 
@@ -21,7 +20,12 @@ export class Parser extends RawDiagnosticParser {
             return {
                 full,
                 file,
-                location: new vscode.Range(oneLess(lineno), oneLess(column), oneLess(lineno), 999),
+                location: {
+                    startLine: oneLess(lineno),
+                    startCharacter: oneLess(column),
+                    endLine: oneLess(lineno),
+                    endCharacter: 999
+                },
                 severity,
                 message,
                 related: []

--- a/src/diagnostics/gnu-ld.ts
+++ b/src/diagnostics/gnu-ld.ts
@@ -1,10 +1,9 @@
 /**
  * Module for handling GNU linker diagnostics
- */ /** */
+ */
 
-import * as vscode from 'vscode';
-
-import { FeedLineResult, oneLess, RawDiagnosticParser } from './util';
+import { oneLess } from '@cmt/basic/util';
+import { FeedLineResult, RawDiagnosticParser } from './rawDiagnosticParser';
 
 export const REGEX = /^(.*):(\d+)\s?:\s+(.*[^\]])$/;
 
@@ -25,7 +24,12 @@ export class Parser extends RawDiagnosticParser {
             return {
                 full,
                 file,
-                location: new vscode.Range(lineno, 0, lineno, 999),
+                location: {
+                    startLine: lineno,
+                    startCharacter: 0,
+                    endLine: lineno,
+                    endCharacter: 999
+                },
                 severity: 'error',
                 message,
                 related: []

--- a/src/diagnostics/iar.ts
+++ b/src/diagnostics/iar.ts
@@ -1,10 +1,9 @@
 /**
  * Module for parsing IAR diagnostics
- */ /** */
+ */
 
-import * as vscode from 'vscode';
-
-import { oneLess, RawDiagnosticParser, FeedLineResult, RawDiagnostic } from './util';
+import { oneLess } from '@cmt/basic/util';
+import { FeedLineResult, RawDiagnostic, RawDiagnosticParser } from './rawDiagnosticParser';
 
 const CODE_REGEX = /^\"(?<file>.*)\",(?<line>\d+)\s+(?<severity>[A-Za-z ]+)\[(?<code>[A-Za-z]+[0-9]+)\]:(?<message_start>.*)$/;
 
@@ -63,7 +62,12 @@ export class Parser extends RawDiagnosticParser {
                     this.pending_diagnostic = {
                         full: full,
                         file: file,
-                        location: new vscode.Range(oneLess(lineno), this.pending_column ?? 0, oneLess(lineno), 999),
+                        location: {
+                            startLine: oneLess(lineno),
+                            startCharacter: this.pending_column ?? 0,
+                            endLine: oneLess(lineno),
+                            endCharacter: 999
+                        },
                         severity: this.translateSeverity(severity),
                         message: message_start ? message_start + ' ' : '', // Add space ready for the next line of the message. It'll be trimmed if there isn't an additional part to the message.
                         code: code,

--- a/src/diagnostics/msvc.ts
+++ b/src/diagnostics/msvc.ts
@@ -1,10 +1,9 @@
 /**
  * Module for handling MSVC diagnostics
- */ /** */
+ */
 
-import * as vscode from 'vscode';
-
-import { oneLess, RawDiagnosticParser, FeedLineResult } from './util';
+import { oneLess } from '@cmt/basic/util';
+import { FeedLineResult, RawDiagnosticParser } from './rawDiagnosticParser';
 
 export const REGEX = /^\s*(\d+>)?\s*([^\s>].*)\((\d+|\d+,\d+|\d+,\d+,\d+,\d+)\)\s*:\s+((?:fatal )?error|warning|info)\s*(\w{1,2}\d+)?\s*:\s*(.*)$/;
 
@@ -19,17 +18,17 @@ export class Parser extends RawDiagnosticParser {
             const parts = location.split(',');
             const n0 = oneLess(parts[0]);
             if (parts.length === 1) {
-                return new vscode.Range(n0, 0, n0, 999);
+                return {startLine: n0, startCharacter: 0, endLine: n0, endCharacter: 999};
             }
             if (parts.length === 2) {
                 const n1 = oneLess(parts[1]);
-                return new vscode.Range(n0, n1, n0, n1);
+                return {startLine: n0, startCharacter: n1, endLine: n0, endCharacter: n1};
             }
             if (parts.length === 4) {
                 const n1 = oneLess(parts[1]);
                 const n2 = oneLess(parts[2]);
                 const n3 = oneLess(parts[3]);
-                return new vscode.Range(n0, n1, n2, n3);
+                return {startLine: n0, startCharacter: n1, endLine: n2, endCharacter: n3};
             }
             throw new Error('Unable to determine location of MSVC diagnostic');
         })();

--- a/src/diagnostics/rawDiagnosticParser.ts
+++ b/src/diagnostics/rawDiagnosticParser.ts
@@ -1,0 +1,67 @@
+/**
+ * Base class for handling diagnostics
+ */
+
+export enum FeedLineResult {
+    Ok,
+    NotMine,
+}
+
+export interface RawDiagnosticLocation {
+    startLine: number;
+    startCharacter: number;
+    endLine: number;
+    endCharacter: number;
+}
+
+export interface RawRelated {
+    file: string;
+    location: RawDiagnosticLocation;
+    message: string;
+}
+
+export interface RawDiagnostic {
+    full: string;
+    file: string;
+    location: RawDiagnosticLocation;
+    severity: string;
+    message: string;
+    code?: string;
+    related: RawRelated[];
+}
+
+/**
+ * Base class for parsing raw diagnostic information on a line-by-line basis
+ */
+export abstract class RawDiagnosticParser {
+    /**
+     * Get the diagnostics which have been parsed by this object
+     */
+    get diagnostics(): readonly RawDiagnostic[] {
+        return this._diagnostics;
+    }
+    private readonly _diagnostics: RawDiagnostic[] = [];
+
+    /**
+     * Push another line into the parser
+     * @param line Another line to parse
+     */
+    handleLine(line: string): boolean {
+        const result = this.doHandleLine(line);
+        if (result === FeedLineResult.Ok) {
+            return true;
+        } else if (result === FeedLineResult.NotMine) {
+            return false;
+        } else {
+            this._diagnostics.push(result);
+            return true;
+        }
+    }
+
+    /**
+     * Implement in derived classes to parse a line. Returns a new diagnostic, or
+     * `undefined` if the give line does not complete a diagnostic
+     * @param line The line to process
+     */
+    protected abstract doHandleLine(line: string): RawDiagnostic | FeedLineResult;
+}

--- a/src/diagnostics/util.ts
+++ b/src/diagnostics/util.ts
@@ -2,7 +2,7 @@
  * Types and utilities for diagnostic parsing and handling
  */
 
-import { reduce } from '@cmt/util';
+import { reduce } from '@cmt/basic/util';
 import * as vscode from 'vscode';
 
 /**
@@ -20,42 +20,6 @@ export interface FileDiagnostic {
      * The actual diagnostic itself
      */
     diag: vscode.Diagnostic;
-}
-
-export enum FeedLineResult {
-    Ok,
-    NotMine,
-}
-
-export interface RawRelated {
-    file: string;
-    location: vscode.Range;
-    message: string;
-}
-
-export interface RawDiagnostic {
-    full: string;
-    file: string;
-    location: vscode.Range;
-    severity: string;
-    message: string;
-    code?: string;
-    related: RawRelated[];
-}
-
-/**
- * Get one less than the given number of number-string.
- *
- * If the number is greater than zero, returns that number minus one. If
- * the number is less than one, returns zero.
- * @param num A number or string representing a number
- */
-export function oneLess(num: number | string): number {
-    if (typeof num === 'string') {
-        return oneLess(parseInt(num));
-    } else {
-        return Math.max(0, num - 1);
-    }
 }
 
 /**
@@ -80,40 +44,4 @@ export function populateCollection(coll: vscode.DiagnosticCollection, fdiags: It
     diags_by_file.forEach((diags, filepath) => {
         coll.set(vscode.Uri.file(filepath), diags);
     });
-}
-
-/**
- * Base class for parsing raw diagnostic information on a line-by-line basis
- */
-export abstract class RawDiagnosticParser {
-    /**
-     * Get the diagnostics which have been parsed by this object
-     */
-    get diagnostics(): readonly RawDiagnostic[] {
-        return this._diagnostics;
-    }
-    private readonly _diagnostics: RawDiagnostic[] = [];
-
-    /**
-     * Push another line into the parser
-     * @param line Another line to parse
-     */
-    handleLine(line: string): boolean {
-        const result = this.doHandleLine(line);
-        if (result === FeedLineResult.Ok) {
-            return true;
-        } else if (result === FeedLineResult.NotMine) {
-            return false;
-        } else {
-            this._diagnostics.push(result);
-            return true;
-        }
-    }
-
-    /**
-     * Implement in derived classes to parse a line. Returns a new diagnostic, or
-     * `undefined` if the give line does not complete a diagnostic
-     * @param line The line to process
-     */
-    protected abstract doHandleLine(line: string): RawDiagnostic | FeedLineResult;
 }

--- a/src/drivers/driver.ts
+++ b/src/drivers/driver.ts
@@ -13,7 +13,7 @@ import { ArgsCompileCommand } from '@cmt/compdb';
 import { ConfigurationReader, defaultNumJobs } from '@cmt/config';
 import { CMakeBuildConsumer, CompileOutputConsumer } from '@cmt/diagnostics/build';
 import { CMakeOutputConsumer } from '@cmt/diagnostics/cmake';
-import { RawDiagnosticParser } from '@cmt/diagnostics/util';
+import { RawDiagnosticParser } from '@cmt/diagnostics/rawDiagnosticParser';
 import { ProgressMessage } from '@cmt/drivers/cms-client';
 import * as expand from '@cmt/expand';
 import { CMakeGenerator, effectiveKitEnvironment, Kit, kitChangeNeedsClean, KitDetect, getKitDetect, getVSKitEnvironment } from '@cmt/kit';

--- a/src/util.ts
+++ b/src/util.ts
@@ -10,6 +10,8 @@ import { DebuggerEnvironmentVariable, execute } from '@cmt/proc';
 import rollbar from '@cmt/rollbar';
 import { Environment, EnvironmentUtils } from './environmentVariables';
 
+export * from "@cmt/basic/util";
+
 nls.config({ messageFormat: nls.MessageFormat.bundle, bundleFormat: nls.BundleFormat.standalone })();
 const localize: nls.LocalizeFunc = nls.loadMessageBundle();
 
@@ -171,70 +173,6 @@ export function isTruthy(value: (boolean | string | null | undefined | number)) 
     }
     // Numbers/bools/etc. follow common C-style truthiness
     return !!value;
-}
-
-/**
- * Generate an array of key-value pairs from an object using
- * `getOwnPropertyNames`
- * @param obj The object to iterate
- */
-export function objectPairs<V>(obj: { [key: string]: V }): [string, V][] {
-    return Object.getOwnPropertyNames(obj).map(key => ([key, obj[key]] as [string, V]));
-}
-
-/**
- * Map an iterable by some projection function
- * @param iter An iterable to map
- * @param proj The projection function
- */
-export function* map<In, Out>(iter: Iterable<In>, proj: (arg: In) => Out): Iterable<Out> {
-    for (const item of iter) {
-        yield proj(item);
-    }
-}
-
-export function* chain<T>(...iter: Iterable<T>[]): Iterable<T> {
-    for (const sub of iter) {
-        for (const item of sub) {
-            yield item;
-        }
-    }
-}
-
-export function reduce<In, Out>(iter: Iterable<In>, init: Out, mapper: (acc: Out, el: In) => Out): Out {
-    for (const item of iter) {
-        init = mapper(init, item);
-    }
-    return init;
-}
-
-export function find<T>(iter: Iterable<T>, predicate: (value: T) => boolean): T | undefined {
-    for (const value of iter) {
-        if (predicate(value)) {
-            return value;
-        }
-    }
-    // Nothing found
-    return undefined;
-}
-
-/**
- * Generate a random integral value.
- * @param min Minimum value
- * @param max Maximum value
- */
-export function randint(min: number, max: number): number {
-    return Math.floor(Math.random() * (max - min) + min);
-}
-
-export function product<T>(arrays: T[][]): T[][] {
-    return arrays.reduce(
-        (acc, curr) =>
-            // Append each element of the current array to each list already accumulated
-            acc.map(prev => curr.map(item => prev.concat(item)))
-                // Join all the lists
-                .reduce((a, b) => a.concat(b), []),
-        [[]] as T[][]);
 }
 
 export interface CMakeValue {

--- a/test/unit-tests/diagnostics.test.ts
+++ b/test/unit-tests/diagnostics.test.ts
@@ -151,9 +151,9 @@ suite('Diagnostics', async () => {
         feedLines(build_consumer, [], lines);
         expect(build_consumer.compilers.gcc.diagnostics).to.have.length(1);
         const diag = build_consumer.compilers.gcc.diagnostics[0];
-        expect(diag.location.start.line).to.eq(84);
+        expect(diag.location.startLine).to.eq(84);
         expect(diag.message).to.eq('comparison of unsigned expression >= 0 is always true [-Wtautological-compare]');
-        expect(diag.location.start.character).to.eq(14);
+        expect(diag.location.startCharacter).to.eq(14);
         const expected = '/Users/ruslan.sorokin/Projects/Other/dpi/core/dpi_histogram.h';
         expect(platformPathEquivalent(diag.file, expected), `${diag.file} !== ${expected}`).to.be.true;
         expect(diag.severity).to.eq('warning');
@@ -168,8 +168,8 @@ suite('Diagnostics', async () => {
         const diag = build_consumer.compilers.gcc.diagnostics[0];
         const expected = '/Users/Tobias/Code/QUIT/Source/qidespot1.cpp';
         expect(platformPathEquivalent(diag.file, expected), `${diag.file} !== ${expected}`).to.be.true;
-        expect(diag.location.start.line).to.eq(302);
-        expect(diag.location.start.character).to.eq(48);
+        expect(diag.location.startLine).to.eq(302);
+        expect(diag.location.startCharacter).to.eq(48);
         expect(diag.message).to.eq(`expected ';' after expression`);
         expect(diag.severity).to.eq('error');
     });
@@ -179,10 +179,10 @@ suite('Diagnostics', async () => {
         feedLines(build_consumer, [], lines);
         expect(build_consumer.compilers.gcc.diagnostics).to.have.length(1);
         const diag = build_consumer.compilers.gcc.diagnostics[0];
-        expect(diag.location.start.line).to.eq(3);
+        expect(diag.location.startLine).to.eq(3);
         expect(diag.message).to.eq('some_header.h: No such file or directory');
-        expect(diag.location.start.line).to.eq(3);
-        expect(diag.location.start.character).to.eq(25);
+        expect(diag.location.startLine).to.eq(3);
+        expect(diag.location.startCharacter).to.eq(25);
         expect(diag.file).to.eq('/some/path/here');
         expect(diag.severity).to.eq('error');
         expect(path.posix.normalize(diag.file)).to.eq(diag.file);
@@ -195,9 +195,9 @@ suite('Diagnostics', async () => {
         expect(build_consumer.compilers.gcc.diagnostics).to.have.length(1);
         const diag = build_consumer.compilers.gcc.diagnostics[0];
 
-        expect(diag.location.start.line).to.eq(1);
+        expect(diag.location.startLine).to.eq(1);
         expect(diag.message).to.eq('bonjour.h : Aucun fichier ou dossier de ce type');
-        expect(diag.location.start.character).to.eq(20);
+        expect(diag.location.startCharacter).to.eq(20);
         expect(diag.file).to.eq('/home/romain/TL/test/base.c');
         expect(diag.severity).to.eq('erreur');
         expect(path.posix.normalize(diag.file)).to.eq(diag.file);
@@ -209,9 +209,9 @@ suite('Diagnostics', async () => {
         expect(build_consumer.compilers.gcc.diagnostics).to.have.length(1);
         const diag = build_consumer.compilers.gcc.diagnostics[0];
 
-        expect(diag.location.start.line).to.eq(3);
+        expect(diag.location.startLine).to.eq(3);
         expect(diag.message).to.eq('unused parameter \'data\'');
-        expect(diag.location.start.character).to.eq(25);
+        expect(diag.location.startCharacter).to.eq(25);
         expect(diag.file).to.eq('/some/path/here');
         expect(diag.severity).to.eq('warning');
         expect(path.posix.normalize(diag.file)).to.eq(diag.file);
@@ -223,8 +223,8 @@ suite('Diagnostics', async () => {
         expect(build_consumer.compilers.gcc.diagnostics).to.have.length(1);
         const diag = build_consumer.compilers.gcc.diagnostics[0];
 
-        expect(diag.location.start.line).to.eq(20);
-        expect(diag.location.start.character).to.eq(13);
+        expect(diag.location.startLine).to.eq(20);
+        expect(diag.location.startCharacter).to.eq(13);
         expect(diag.file).to.eq('/test/main.cpp');
         expect(diag.message).to.eq(`unused parameter ‘v’ [-Wunused-parameter]`);
         expect(diag.severity).to.eq('warning');
@@ -235,9 +235,9 @@ suite('Diagnostics', async () => {
         expect(build_consumer.compilers.gcc.diagnostics).to.have.length(1);
         const diag = build_consumer.compilers.gcc.diagnostics[0];
 
-        expect(diag.location.start.line).to.eq(154);
+        expect(diag.location.startLine).to.eq(154);
         expect(diag.message).to.eq('déclaration implicite de la fonction ‘create’');
-        expect(diag.location.start.character).to.eq(1);
+        expect(diag.location.startCharacter).to.eq(1);
         expect(diag.file).to.eq('/home/romain/TL/test/base.c');
         expect(diag.severity).to.eq('attention');
         expect(path.posix.normalize(diag.file)).to.eq(diag.file);
@@ -256,7 +256,7 @@ suite('Diagnostics', async () => {
         expect(build_consumer.compilers.gnuLD.diagnostics).to.have.length(1);
         const diag = build_consumer.compilers.gnuLD.diagnostics[0];
 
-        expect(diag.location.start.line).to.eq(100);
+        expect(diag.location.startLine).to.eq(100);
         expect(diag.message).to.eq('undefined reference to `some_function\'');
         expect(diag.file).to.eq('/some/path/here');
         expect(diag.severity).to.eq('error');
@@ -269,7 +269,7 @@ suite('Diagnostics', async () => {
         expect(build_consumer.compilers.gnuLD.diagnostics).to.have.length(1);
         const diag = build_consumer.compilers.gnuLD.diagnostics[0];
 
-        expect(diag.location.start.line).to.eq(8);
+        expect(diag.location.startLine).to.eq(8);
         expect(diag.message).to.eq('référence indéfinie vers « create_automaton_product56 »');
         expect(diag.file).to.eq('/home/romain/TL/test/test_fa_tp4.c');
         expect(diag.severity).to.eq('error');
@@ -284,9 +284,9 @@ suite('Diagnostics', async () => {
         expect(build_consumer.compilers.ghs.diagnostics).to.have.length(1);
         const diag = build_consumer.compilers.ghs.diagnostics[0];
 
-        expect(diag.location.start.line).to.eq(630);
+        expect(diag.location.startLine).to.eq(630);
         expect(diag.message).to.eq('#68-D: integer conversion resulted in a change of sign');
-        expect(diag.location.start.character).to.eq(2);
+        expect(diag.location.startCharacter).to.eq(2);
         expect(diag.file).to.eq('C:\\path\\source\\debug\\debug.c');
         expect(diag.severity).to.eq('warning');
         expect(path.win32.normalize(diag.file)).to.eq(diag.file);
@@ -300,9 +300,9 @@ suite('Diagnostics', async () => {
         expect(build_consumer.compilers.ghs.diagnostics).to.have.length(1);
         const diag = build_consumer.compilers.ghs.diagnostics[0];
 
-        expect(diag.location.start.line).to.eq(0);
+        expect(diag.location.startLine).to.eq(0);
         expect(diag.message).to.eq('#96-D: a translation unit must contain at least one declaration');
-        expect(diag.location.start.character).to.eq(0);
+        expect(diag.location.startCharacter).to.eq(0);
         expect(diag.file).to.eq('C:\\path\\source\\debug\\debug.c');
         expect(diag.severity).to.eq('remark');
         expect(path.win32.normalize(diag.file)).to.eq(diag.file);
@@ -313,9 +313,9 @@ suite('Diagnostics', async () => {
         feedLines(build_consumer, [], lines);
         expect(build_consumer.compilers.ghs.diagnostics).to.have.length(1);
         const diag = build_consumer.compilers.ghs.diagnostics[0];
-        expect(diag.location.start.line).to.eq(630);
+        expect(diag.location.startLine).to.eq(630);
         expect(diag.message).to.eq('#68: some fatal error');
-        expect(diag.location.start.character).to.eq(2);
+        expect(diag.location.startCharacter).to.eq(2);
         expect(diag.file).to.eq('C:\\path\\source\\debug\\debug.c');
         expect(diag.severity).to.eq('error');
         expect(path.win32.normalize(diag.file)).to.eq(diag.file);
@@ -330,8 +330,8 @@ suite('Diagnostics', async () => {
         expect(build_consumer.compilers.diab.diagnostics).to.have.length(1);
         const diag = build_consumer.compilers.diab.diagnostics[0];
 
-        expect(diag.location.start.line).to.eq(630);
-        expect(diag.location.start.character).to.eq(0);
+        expect(diag.location.startLine).to.eq(630);
+        expect(diag.location.startCharacter).to.eq(0);
         expect(diag.message).to.eq('variable i is never used');
         expect(diag.file).to.eq('C:\\path\\source\\debug\\debug.c');
         expect(diag.code).to.eq('dcc:1518');
@@ -348,8 +348,8 @@ suite('Diagnostics', async () => {
         expect(build_consumer.compilers.diab.diagnostics).to.have.length(1);
         const diag = build_consumer.compilers.diab.diagnostics[0];
 
-        expect(diag.location.start.line).to.eq(630);
-        expect(diag.location.start.character).to.eq(0);
+        expect(diag.location.startLine).to.eq(630);
+        expect(diag.location.startCharacter).to.eq(0);
         expect(diag.message).to.eq('cannot open source file "../debug.h"');
         expect(diag.file).to.eq('C:\\path\\source\\debug\\debug.c');
         expect(diag.code).to.eq('etoa:5711');
@@ -366,8 +366,8 @@ suite('Diagnostics', async () => {
         expect(build_consumer.compilers.diab.diagnostics).to.have.length(1);
         const diag = build_consumer.compilers.diab.diagnostics[0];
 
-        expect(diag.location.start.line).to.eq(0);
-        expect(diag.location.start.character).to.eq(0);
+        expect(diag.location.startLine).to.eq(0);
+        expect(diag.location.startCharacter).to.eq(0);
         expect(diag.message).to.eq('License error: FLEXlm error: License server machine is down or not responding.');
         expect(diag.file).to.eq('C:\\path\\source\\debug\\debug.c');
         expect(diag.code).to.eq('etoa:1635');
@@ -391,8 +391,8 @@ suite('Diagnostics', async () => {
         feedLines(build_consumer, [], lines);
         expect(build_consumer.compilers.gcc.diagnostics).to.have.length(1);
         expect(build_consumer.compilers.gcc.diagnostics[0].file).to.eq('/foo.h');
-        expect(build_consumer.compilers.gcc.diagnostics[0].location.start.line).to.eq(65);
-        expect(build_consumer.compilers.gcc.diagnostics[0].location.start.character).to.eq(0);
+        expect(build_consumer.compilers.gcc.diagnostics[0].location.startLine).to.eq(65);
+        expect(build_consumer.compilers.gcc.diagnostics[0].location.startCharacter).to.eq(0);
     });
 
     test('Parse MSVC single proc error', () => {
@@ -400,8 +400,8 @@ suite('Diagnostics', async () => {
         feedLines(build_consumer, [], lines);
         expect(build_consumer.compilers.msvc.diagnostics).to.have.length(1);
         expect(build_consumer.compilers.msvc.diagnostics[0].file).to.eq('C:\\foo\\bar\\include\\bar.hpp');
-        expect(build_consumer.compilers.msvc.diagnostics[0].location.start.line).to.eq(66);
-        expect(build_consumer.compilers.msvc.diagnostics[0].location.start.character).to.eq(0);
+        expect(build_consumer.compilers.msvc.diagnostics[0].location.startLine).to.eq(66);
+        expect(build_consumer.compilers.msvc.diagnostics[0].location.startCharacter).to.eq(0);
     });
 
     test('Parse MSVC single proc error (older compiler)', () => {
@@ -409,8 +409,8 @@ suite('Diagnostics', async () => {
         feedLines(build_consumer, [], lines);
         expect(build_consumer.compilers.msvc.diagnostics).to.have.length(1);
         expect(build_consumer.compilers.msvc.diagnostics[0].file).to.eq('E:\\CI-Cor-Ready\\study\\reproc\\reproc\\src\\strv.c');
-        expect(build_consumer.compilers.msvc.diagnostics[0].location.start.line).to.eq(12);
-        expect(build_consumer.compilers.msvc.diagnostics[0].location.start.character).to.eq(0);
+        expect(build_consumer.compilers.msvc.diagnostics[0].location.startLine).to.eq(12);
+        expect(build_consumer.compilers.msvc.diagnostics[0].location.startCharacter).to.eq(0);
     });
 
     test('Parse MSVC multi proc error', () => {
@@ -418,8 +418,8 @@ suite('Diagnostics', async () => {
         feedLines(build_consumer, [], lines);
         expect(build_consumer.compilers.msvc.diagnostics).to.have.length(1);
         expect(build_consumer.compilers.msvc.diagnostics[0].file).to.eq('C:\\foo\\bar\\include\\bar.hpp');
-        expect(build_consumer.compilers.msvc.diagnostics[0].location.start.line).to.eq(66);
-        expect(build_consumer.compilers.msvc.diagnostics[0].location.start.character).to.eq(0);
+        expect(build_consumer.compilers.msvc.diagnostics[0].location.startLine).to.eq(66);
+        expect(build_consumer.compilers.msvc.diagnostics[0].location.startCharacter).to.eq(0);
     });
 
     test('Parse IAR error', () => {
@@ -435,8 +435,8 @@ suite('Diagnostics', async () => {
         const diagnostic = build_consumer.compilers.iar.diagnostics[0];
 
         expect(diagnostic.file).to.eq('C:\\foo\\bar\\bar.c');
-        expect(diagnostic.location.start.line).to.eq(146);
-        expect(diagnostic.location.start.character).to.eq(4);
+        expect(diagnostic.location.startLine).to.eq(146);
+        expect(diagnostic.location.startCharacter).to.eq(4);
         expect(diagnostic.code).to.eq('Pe020');
         expect(diagnostic.message).to.eq('identifier "kjfdlkj" is undefined');
         expect(diagnostic.severity).to.eq('error');
@@ -458,8 +458,8 @@ suite('Diagnostics', async () => {
         const diagnostic = build_consumer.compilers.iar.diagnostics[0];
 
         expect(diagnostic.file).to.eq('C:\\foo\\bar\\test.c');
-        expect(diagnostic.location.start.line).to.eq(0);
-        expect(diagnostic.location.start.character).to.eq(17);
+        expect(diagnostic.location.startLine).to.eq(0);
+        expect(diagnostic.location.startCharacter).to.eq(17);
         expect(diagnostic.code).to.eq('Pe1696');
         expect(diagnostic.message).to.eq('cannot open source file "kjlkjl"\nsearched: "C:\\Program Files (x86)\\IAR Systems\\Embedded Workbench\n8.0\\arm\\inc\\"\ncurrent directory: "C:\\Users\\user\\Documents"');
         expect(diagnostic.severity).to.eq('error');


### PR DESCRIPTION
Diagnostics parsing is just parsing the error line number and column number from the error string
There is no need depends on vscode to do that.
So remove the depends on vscode from these error message parsing functions,
So these functions can be tested without vscode(by nodejs directly).
After this, the tests can be running in a faster way and easier debugging.
