### PR TITLE
Remove debugger statement in RollbarController

### DIFF
--- a/src/rollbar.ts
+++ b/src/rollbar.ts
@@ -73,7 +73,6 @@ class RollbarController {
         const message = cleanString(exception.message);
         logEvent('exception2', { message, callstack });
         console.error(exception);
-        debugger;
     }
 
     /**


### PR DESCRIPTION
I develop other VS Code extensions but have the CMake Tools extension installed. This `debugger;` statement tends to fire whenever I exit my VS Code instance under test, which steals focus back to the VS Code instance running the debugger even though it's not my code.