### PR TITLE
Fix a bug where the browse configuration was not updated after a codemodel change

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -762,6 +762,7 @@ class ExtensionManager implements vscode.Disposable {
                         this._configProvider.markAsReady();
                     }
                 } else {
+                    cpptools.didChangeCustomBrowseConfiguration(this._configProvider);
                     cpptools.didChangeCustomConfiguration(this._configProvider);
                     this._configProvider.markAsReady();
                 }


### PR DESCRIPTION
Fix a particularly nasty issue where the code model never updates the browse configuration for a project.