### PR TITLE
Add commands to get preset names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Improvements:
 - Allow editing Kits when presets are in use. [#1965](https://github.com/microsoft/vscode-cmake-tools/issues/1965)
 - Launch the target in the default terminal. [PR #2311](https://github.com/microsoft/vscode-cmake-tools/pull/2311) [@michallukowski](https://github.com/michallukowski)
 - Allow launching targets in parallel. [#2240](https://github.com/microsoft/vscode-cmake-tools/issues/2120) [@ColinDuquesnoy](https://github.com/ColinDuquesnoy)
+- Add commands to get preset names. [#2433](https://github.com/microsoft/vscode-cmake-tools/pull/2433)
 
 Bug Fixes:
 - CMakePrests.json toolset requires the VS version instead of the toolset version. [#1965](https://github.com/microsoft/vscode-cmake-tools/issues/1965)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.11
 Improvements:
 - Fix build Error: EMFILE: too many open files. [#2288](https://github.com/microsoft/vscode-cmake-tools/issues/2288) [@FrogTheFrog](https://github.com/FrogTheFrog)
+- Add commands to get preset names. [PR #2433](https://github.com/microsoft/vscode-cmake-tools/pull/2433)
 
 Bug Fixes:
 - `Clean All Projects` menu item builds rather than cleans. [#2460](https://github.com/microsoft/vscode-cmake-tools/issues/2460)
@@ -19,7 +20,6 @@ Improvements:
 - Allow editing Kits when presets are in use. [#1965](https://github.com/microsoft/vscode-cmake-tools/issues/1965)
 - Launch the target in the default terminal. [PR #2311](https://github.com/microsoft/vscode-cmake-tools/pull/2311) [@michallukowski](https://github.com/michallukowski)
 - Allow launching targets in parallel. [#2240](https://github.com/microsoft/vscode-cmake-tools/issues/2120) [@ColinDuquesnoy](https://github.com/ColinDuquesnoy)
-- Add commands to get preset names. [#2433](https://github.com/microsoft/vscode-cmake-tools/pull/2433)
 
 Bug Fixes:
 - CMakePrests.json toolset requires the VS version instead of the toolset version. [#1965](https://github.com/microsoft/vscode-cmake-tools/issues/1965)

--- a/docs/cmake-settings.md
+++ b/docs/cmake-settings.md
@@ -89,6 +89,9 @@ Supported commands for substitution:
 |`cmake.tasksBuildCommand`|The CMake command used to build your project based on the currently selected Kit + Variant + Target. Suitable for use within `tasks.json`.|
 |`cmake.activeFolderName`|The name of the active folder (e.g. in a multi-root workspace)|
 |`cmake.activeFolderPath`|The asolute path of the active folder (e.g. in a multi-root workspace)|
+|`cmake.activeConfigurePresetName`|The name of the selected configure preset.|
+|`cmake.activeBuildPresetName`|The name of the selected build preset.|
+|`cmake.activeTestPresetName`|The name of the selected test preset.|
 
 ## Next steps
 

--- a/docs/cmake-settings.md
+++ b/docs/cmake-settings.md
@@ -89,9 +89,9 @@ Supported commands for substitution:
 |`cmake.tasksBuildCommand`|The CMake command used to build your project based on the currently selected Kit + Variant + Target. Suitable for use within `tasks.json`.|
 |`cmake.activeFolderName`|The name of the active folder (e.g. in a multi-root workspace)|
 |`cmake.activeFolderPath`|The asolute path of the active folder (e.g. in a multi-root workspace)|
-|`cmake.activeConfigurePresetName`|The name of the selected configure preset.|
-|`cmake.activeBuildPresetName`|The name of the selected build preset.|
-|`cmake.activeTestPresetName`|The name of the selected test preset.|
+|`cmake.activeConfigurePresetName`|The name of the active configure preset.|
+|`cmake.activeBuildPresetName`|The name of the active build preset.|
+|`cmake.activeTestPresetName`|The name of the active test preset.|
 
 ## Next steps
 

--- a/package.json
+++ b/package.json
@@ -34,6 +34,9 @@
   "activationEvents": [
     "onCommand:cmake.activeFolderName",
     "onCommand:cmake.activeFolderPath",
+    "onCommand:cmake.activeConfigurePresetName",
+    "onCommand:cmake.activeBuildPresetName",
+    "onCommand:cmake.activeTestPresetName",
     "onCommand:cmake.build",
     "onCommand:cmake.buildAll",
     "onCommand:cmake.buildWithTarget",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1459,17 +1459,17 @@ class ExtensionManager implements vscode.Disposable {
 
     activeConfigurePresetName(): string {
         telemetry.logEvent("substitution", { command: "activeConfigurePresetName" });
-        return this._folders.activeFolder?.cmakeTools.configurePreset?.name || '';
+        return this.folders.activeFolder?.cmakeTools.configurePreset?.name || '';
     }
 
     activeBuildPresetName(): string {
         telemetry.logEvent("substitution", { command: "activeBuildPresetName" });
-        return this._folders.activeFolder?.cmakeTools.buildPreset?.name || '';
+        return this.folders.activeFolder?.cmakeTools.buildPreset?.name || '';
     }
 
     activeTestPresetName(): string {
         telemetry.logEvent("substitution", { command: "activeTestPresetName" });
-        return this._folders.activeFolder?.cmakeTools.testPreset?.name || '';
+        return this.folders.activeFolder?.cmakeTools.testPreset?.name || '';
     }
 
     /**

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1454,6 +1454,21 @@ class ExtensionManager implements vscode.Disposable {
         return false;
     }
 
+    activeConfigurePresetName(): string {
+        telemetry.logEvent("substitution", { command: "activeConfigurePresetName" });
+        return this._folders.activeFolder?.cmakeTools.configurePreset?.name || '';
+    }
+
+    activeBuildPresetName(): string {
+        telemetry.logEvent("substitution", { command: "activeBuildPresetName" });
+        return this._folders.activeFolder?.cmakeTools.buildPreset?.name || '';
+    }
+
+    activeTestPresetName(): string {
+        telemetry.logEvent("substitution", { command: "activeTestPresetName" });
+        return this._folders.activeFolder?.cmakeTools.testPreset?.name || '';
+    }
+
     /**
      * Opens CMakePresets.json at the root of the project. Creates one if it does not exist.
      */
@@ -1626,6 +1641,9 @@ async function setup(context: vscode.ExtensionContext, progress?: ProgressHandle
     const funs: (keyof ExtensionManager)[] = [
         'activeFolderName',
         'activeFolderPath',
+        'activeConfigurePresetName',
+        'activeBuildPresetName',
+        'activeTestPresetName',
         "useCMakePresets",
         "openCMakePresets",
         'addConfigurePreset',


### PR DESCRIPTION
### This changes commands for command substitution and associated documentation.

The following changes are proposed:

3 new commands: `cmake.activeConfigurePresetName`, `cmake.activeBuildPresetName`, `cmake.activeTestPresetName`. Each returns a string with the name of the corresponding preset, or an empty string if the preset is not available.

## The purpose of this change

These commands are designed to be used with the command substitution syntax in `launch.json` or `tasks.json`. They help to write generic launch configurations or tasks in the presence of CMake projects with multiple presets that may use the `${presetName}` macro to select the `binaryDir`. While the existing `cmake.launchTargetPath` can often also be used in this situation, it can't handle constructing the path to files that aren't the target (e.g. associated debug information or, for embedded applications, hex or bin files).

FYI @aleun @gcampbell-msft 