### PR TITLE
Introduce FS access limiter for cmake api helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # What's New?
 
+## 1.11
+Improvements:
+- Fix build Error: EMFILE: too many open files. [#2288](https://github.com/microsoft/vscode-cmake-tools/issues/2288) [@FrogTheFrog](https://github.com/FrogTheFrog)
+
 ## 1.10.5
 Bug Fixes:
 - fix "CMake: compile active file" command. [#2438](https://github.com/microsoft/vscode-cmake-tools/issues/2438)

--- a/package.json
+++ b/package.json
@@ -1897,9 +1897,9 @@
         "cmake.launchBehavior": {
           "type": "string",
           "enum": [
-              "reuseTerminal",
-              "breakAndReuseTerminal",
-              "newTerminal"
+            "reuseTerminal",
+            "breakAndReuseTerminal",
+            "newTerminal"
           ],
           "enumDescriptions": [
             "%cmake-tools.configuration.cmake.launchBehavior.reuseTerminal.description%",
@@ -2072,6 +2072,7 @@
     "json5": "^2.2.0",
     "minimist": "^1.2.5",
     "open": "^7.4.1",
+    "p-limit": "^3.1.0",
     "rimraf": "^3.0.2",
     "tmp": "^0.2.1",
     "vscode-cpptools": "^5.0.0",

--- a/src/drivers/cmakefileapi/api_helpers.ts
+++ b/src/drivers/cmakefileapi/api_helpers.ts
@@ -14,23 +14,19 @@ import { fs } from '@cmt/pr';
 import * as path from 'path';
 import * as nls from 'vscode-nls';
 import rollbar from '@cmt/rollbar';
-import * as pLimit from 'p-limit';
 
 nls.config({ messageFormat: nls.MessageFormat.bundle, bundleFormat: nls.BundleFormat.standalone })();
 const localize: nls.LocalizeFunc = nls.loadMessageBundle();
 
 const log = logging.createLogger('cmakefileapi-parser');
 
-// Limits the concurrent async access to the file system to avoid errors such as "EMFILE: too many open files".
-const fsAccessLimiter = pLimit(50);
-
 export async function createQueryFileForApi(api_path: string): Promise<string> {
     const query_path = path.join(api_path, 'query', 'client-vscode');
     const query_file_path = path.join(query_path, 'query.json');
     const requests = { requests: [{ kind: 'cache', version: 2 }, { kind: 'codemodel', version: 2 }, { kind: 'toolchains', version: 1 }] };
     try {
-        await fsAccessLimiter(() => fs.mkdir_p(query_path));
-        await fsAccessLimiter(() => fs.writeFile(query_file_path, JSON.stringify(requests)));
+        await fs.mkdir_p(query_path);
+        await fs.writeFile(query_file_path, JSON.stringify(requests));
     } catch (e) {
         rollbar.exception(localize('failed.writing.to.file', 'Failed writing to file {0}', query_file_path), e);
         throw e;
@@ -40,11 +36,11 @@ export async function createQueryFileForApi(api_path: string): Promise<string> {
 
 export async function loadIndexFile(reply_path: string): Promise<index_api.Index.IndexFile | null> {
     log.debug(`Read reply folder: ${reply_path}`);
-    if (!await fsAccessLimiter(() => fs.exists(reply_path))) {
+    if (!await fs.exists(reply_path)) {
         return null;
     }
 
-    const files = await fsAccessLimiter(() => fs.readdir(reply_path));
+    const files = await fs.readdir(reply_path);
     log.debug(`Found index files: ${JSON.stringify(files)}`);
 
     const index_files = files.filter(filename => filename.startsWith('index-')).sort();
@@ -52,13 +48,13 @@ export async function loadIndexFile(reply_path: string): Promise<index_api.Index
         throw Error('No index file found.');
     }
     const index_file_path = path.join(reply_path, index_files[index_files.length - 1]);
-    const file_content = await fsAccessLimiter(() => fs.readFile(index_file_path));
+    const file_content = await fs.readFile(index_file_path);
 
     return JSON.parse(file_content.toString()) as index_api.Index.IndexFile;
 }
 
 export async function loadCacheContent(filename: string): Promise<Map<string, api.CacheEntry>> {
-    const file_content = await fsAccessLimiter(() => fs.readFile(filename));
+    const file_content = await fs.readFile(filename);
     const cache_from_cmake = JSON.parse(file_content.toString()) as index_api.Cache.CacheContent;
 
     const expected_version = { major: 2, minor: 0 };
@@ -105,7 +101,7 @@ function convertFileApiCacheToExtensionCache(cache_from_cmake: index_api.Cache.C
 }
 
 export async function loadCodeModelContent(filename: string): Promise<index_api.CodeModelKind.Content> {
-    const file_content = await fsAccessLimiter(() => fs.readFile(filename));
+    const file_content = await fs.readFile(filename);
     const codemodel = JSON.parse(file_content.toString()) as index_api.CodeModelKind.Content;
     const expected_version = { major: 2, minor: 0 };
     const detected_version = codemodel.version;
@@ -124,7 +120,7 @@ export async function loadCodeModelContent(filename: string): Promise<index_api.
 }
 
 export async function loadTargetObject(filename: string): Promise<index_api.CodeModelKind.TargetObject> {
-    const file_content = await fsAccessLimiter(() => fs.readFile(filename));
+    const file_content = await fs.readFile(filename);
     return JSON.parse(file_content.toString()) as index_api.CodeModelKind.TargetObject;
 }
 
@@ -277,7 +273,7 @@ export async function loadExtCodeModelContent(reply_path: string, codeModel_file
 }
 
 export async function loadToolchains(filename: string): Promise<Map<string, CodeModelToolchain>> {
-    const file_content = await fsAccessLimiter(() => fs.readFile(filename));
+    const file_content = await fs.readFile(filename);
     const toolchains = JSON.parse(file_content.toString()) as index_api.Toolchains.Content;
 
     const expected_version = { major: 1, minor: 0 };

--- a/src/pr.ts
+++ b/src/pr.ts
@@ -63,17 +63,17 @@ export namespace fs {
 
     export const writeFile = limitify(promisify(fs_.writeFile));
 
-    export const readdir = limitify(promisify(fs_.readdir));
+    export const readdir = promisify(fs_.readdir);
 
-    export const mkdir = limitify(promisify(fs_.mkdir));
+    export const mkdir = promisify(fs_.mkdir);
 
-    export const mkdtemp = limitify(promisify(fs_.mkdtemp));
+    export const mkdtemp = promisify(fs_.mkdtemp);
 
-    export const rename = limitify(promisify(fs_.rename));
+    export const rename = promisify(fs_.rename);
 
-    export const stat = limitify(promisify(fs_.stat));
+    export const stat = promisify(fs_.stat);
 
-    export const walk = limitify(promisify(walk_));
+    export const walk = promisify(walk_);
 
     /**
      * Try and stat() a file/folder. If stat() fails for *any reason*, returns `null`.
@@ -89,9 +89,9 @@ export namespace fs {
         }
     }
 
-    export const readlink = limitify(promisify(fs_.readlink));
+    export const readlink = promisify(fs_.readlink);
 
-    export const unlink = limitify(promisify(fs_.unlink));
+    export const unlink = promisify(fs_.unlink);
 
     export const appendFile = limitify(promisify(fs_.appendFile));
 
@@ -142,7 +142,7 @@ export namespace fs {
      * @param outPath The new path to the hard link
      */
     export function hardLinkFile(inPath: string, outPath: string): Promise<void> {
-        return fsAccessLimiter(() => new Promise<void>((resolve, reject) => {
+        return new Promise<void>((resolve, reject) => {
             fs_.link(inPath, outPath, err => {
                 if (err) {
                     reject(err);
@@ -150,7 +150,7 @@ export namespace fs {
                     resolve();
                 }
             });
-        }));
+        });
     }
 
     /**
@@ -158,7 +158,7 @@ export namespace fs {
      * @param dirpath Directory to remove
      */
     export function rmdir(dirpath: string): Promise<void> {
-        return fsAccessLimiter(() => new Promise<void>((resolve, reject) => {
+        return new Promise<void>((resolve, reject) => {
             rimraf(dirpath, err => {
                 if (err) {
                     reject(err);
@@ -166,6 +166,6 @@ export namespace fs {
                     resolve();
                 }
             });
-        }));
+        });
     }
 }


### PR DESCRIPTION
<!-- Delete the following heading if there is no corresponding issue -->
## This change addresses item #2288

### This changes how the cmake api driver helpers use the async fs functions

The following changes are proposed:

- Add a limiter-like function to reduce the concurrent interaction with the file system.
- Set the said limit to maximum **50** concurrent read/writes or other access.

## Other Notes/Information

Might have went overboard with the function usage as it is required in place at the moment. However, for completeness sake added the it everywhere.

The project I'm working has ~5500 api files. I chose the value to be a third of the default initial per-configured limit on my system (which was around ~150 if I remember correctly).
