### PR TITLE
debugConfig settings should skip the linker check when set

### DIFF
--- a/src/debugger.ts
+++ b/src/debugger.ts
@@ -164,7 +164,7 @@ function searchForCompilerPathInCache(cache: CMakeCache): string | null {
 
 export async function getDebugConfigurationFromCache(cache: CMakeCache, target: ExecutableTarget, platform: string, modeOverride?: MIModes, debuggerPathOverride?: string): Promise<VSCodeDebugConfiguration | null> {
     const entry = cache.get('CMAKE_LINKER');
-    if (entry !== null) {
+    if (entry !== null && !modeOverride) {
         const linker = entry.value as string;
         const is_msvc_linker = linker.endsWith('link.exe') || linker.endsWith('ld.lld.exe');
         if (is_msvc_linker) {

--- a/src/debugger.ts
+++ b/src/debugger.ts
@@ -198,14 +198,14 @@ export async function getDebugConfigurationFromCache(cache: CMakeCache, target: 
     const clang_compiler_regex = /(clang[\+]{0,2})+(?!-cl)/gi;
     let mi_debugger_path = compiler_path.replace(clang_compiler_regex, 'lldb-mi');
     if (modeOverride !== MIModes.gdb) {
-        if (mi_debugger_path.search(new RegExp('lldb-mi')) !== -1) {
+        const lldbMIReplaced = mi_debugger_path.search(new RegExp('lldb-mi')) !== -1;
+        if (lldbMIReplaced) {
             // 1a. lldb-mi in the compiler path
             if (await checkDebugger(mi_debugger_path)) {
                 return createLLDBDebugConfiguration(mi_debugger_path, target);
             }
-            modeOverride = MIModes.lldb;
         }
-        if (modeOverride === MIModes.lldb) {
+        if (modeOverride === MIModes.lldb || lldbMIReplaced) {
             // 1b. lldb-mi installed by CppTools
             const cpptoolsExtension = vscode.extensions.getExtension('ms-vscode.cpptools');
             const cpptoolsDebuggerPath = cpptoolsExtension ? path.join(cpptoolsExtension.extensionPath, "debugAdapters", "lldb-mi", "bin", "lldb-mi") : undefined;


### PR DESCRIPTION
Addresses: #2509

This allows you to skip the linker check by using the following setting:
```
cmake.debugConfig: {
  "MIMode": "lldb"
}
```
Some additional logic was reworked to allow the mode override to force CMake Tools to pick cpptools' version of lldb-mi when the MIMode is explicitly set to "lldb" but the path heuristic fails.