### PR TITLE
Also add a build preset when adding a multi-config configure preset

### DIFF
--- a/src/preset.ts
+++ b/src/preset.ts
@@ -205,7 +205,7 @@ export function evaluatePresetCondition(preset: Preset, allPresets: Preset[], re
     return undefined;
 }
 
-type CacheVarType = null | boolean | string | { type: string; value: boolean | string };
+export type CacheVarType = null | boolean | string | { type: string; value: boolean | string };
 
 export type OsName = "Windows" | "Linux" | "macOS";
 


### PR DESCRIPTION
Improving the experience for adding configure presets.  For multi-config generators, we were adding `CMAKE_BUILD_TYPE` which is ineffective.  Multi-config generators need a build preset instead.

Also, explicitly add 'cl.exe' as the `CMAKE_[C|CXX]_COMPILER` when creating a config based off a Visual Studio kit.