### PR TITLE
launch.json 'externalConsole' is deprecated.

### DIFF
--- a/docs/debug-launch.md
+++ b/docs/debug-launch.md
@@ -66,7 +66,7 @@ Here is a minimal example of a `launch.json` file that uses `cmake.launchTargetP
                     "value": "Something something"
                 }
             ],
-            "externalConsole": true,
+            "console": "externalTerminal",
             "MIMode": "gdb",
             "setupCommands": [
                 {


### PR DESCRIPTION
Just update https://github.com/microsoft/vscode-cmake-tools/tree/main/docs/debug-launch.md
