### PR TITLE
add partial activation telemetry

### DIFF
--- a/src/cmakeTools.ts
+++ b/src/cmakeTools.ts
@@ -623,7 +623,7 @@ export class CMakeTools implements api.CMakeToolsAPI {
 
                         let selectedFile: string | undefined;
                         if (!selection) {
-                            telemetryProperties["missingCMakeListsUserAction"] = "cancle";
+                            telemetryProperties["missingCMakeListsUserAction"] = "cancel";
                             break; // User canceled it.
                         } else if (selection.label === browse) {
                             const openOpts: vscode.OpenDialogOptions = {

--- a/src/cmakeTools.ts
+++ b/src/cmakeTools.ts
@@ -623,6 +623,7 @@ export class CMakeTools implements api.CMakeToolsAPI {
 
                         let selectedFile: string | undefined;
                         if (!selection) {
+                            telemetryProperties["missingCMakeListsUserAction"] = "cancle";
                             break; // User canceled it.
                         } else if (selection.label === browse) {
                             const openOpts: vscode.OpenDialogOptions = {
@@ -646,6 +647,7 @@ export class CMakeTools implements api.CMakeToolsAPI {
                                 // doesn't need to fire the settings change event (which would trigger unnecessarily
                                 // another immediate configure, which will be blocked anyway).
                                 config.updatePartial({ sourceDirectory: relPath }, false);
+                                telemetryProperties["missingCMakeListsUserAction"] = "updateSourceDirectory";
 
                                 // Since the source directory is set via a file open dialog tuned to CMakeLists.txt,
                                 // we know that it exists and we don't need any other additional checks on its value,

--- a/src/cmakeTools.ts
+++ b/src/cmakeTools.ts
@@ -642,12 +642,12 @@ export class CMakeTools implements api.CMakeToolsAPI {
                         if (selectedFile) {
                             const relPath = util.getRelativePath(selectedFile, this.folder.uri.fsPath);
                             void vscode.workspace.getConfiguration('cmake', this.folder.uri).update("sourceDirectory", relPath);
+                            telemetryProperties["missingCMakeListsUserAction"] = "updateSourceDirectory";
                             if (config) {
                                 // Updating sourceDirectory here, at the beginning of the configure process,
                                 // doesn't need to fire the settings change event (which would trigger unnecessarily
                                 // another immediate configure, which will be blocked anyway).
                                 config.updatePartial({ sourceDirectory: relPath }, false);
-                                telemetryProperties["missingCMakeListsUserAction"] = "updateSourceDirectory";
 
                                 // Since the source directory is set via a file open dialog tuned to CMakeLists.txt,
                                 // we know that it exists and we don't need any other additional checks on its value,
@@ -659,6 +659,8 @@ export class CMakeTools implements api.CMakeToolsAPI {
                                     return vscode.commands.executeCommand('cmake.configure');
                                 }
                             }
+                        } else {
+                            telemetryProperties["missingCMakeListsUserAction"] = "invalidSourceDirectoryPath";
                         }
                     } else if (result === ignoreCMakeListsMissing) {
                         // The user ignores the missing CMakeLists.txt file --> limit the CMake Tools extension functionality


### PR DESCRIPTION
indicate if a new CMakeLists.txt is being selected or if the menu is being canceled.
bug fix #2511 

[sinemakinci1](https://github.com/sinemakinci1) `cancel`, `updateSourceDirectory`, `invalidSourceDirectoryPath` will add up to 100%.