### PR TITLE
Add "cmake.ignoreCMakeListsMissing" (#2532)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Improvements:
 - Add c++23 support. [#2475](https://github.com/microsoft/vscode-cmake-tools/issues/2475) [@sweemer](https://github.com/sweemer)
 - Add support for multiple targets in the CMake task provider. [#2122](https://github.com/microsoft/vscode-cmake-tools/issues/2122)
 - Add setting `cmake.showSystemKits`. [PR #2520](https://github.com/microsoft/vscode-cmake-tools/pull/2520) [@bharatvaj](https://github.com/bharatvaj)
+- Add setting `cmake.ignoreCMakeListsMissing`. [PR #2537](https://github.com/microsoft/vscode-cmake-tools/pull/2537) [@ilg-ul](https://github.com/ilg-ul)
 
 Bug Fixes:
 - `Clean All Projects` menu item builds rather than cleans. [#2460](https://github.com/microsoft/vscode-cmake-tools/issues/2460)

--- a/package.json
+++ b/package.json
@@ -1939,6 +1939,12 @@
           ],
           "description": "%cmake-tools.configuration.cmake.launchBehavior.description%",
           "default": "reuseTerminal"
+        },
+        "cmake.ignoreCMakeListsMissing": {
+          "type": "boolean",
+          "default": false,
+          "description": "%cmake-tools.configuration.cmake.ignoreCMakeListsMissing.description%",
+          "scope": "resource"
         }
       }
     },

--- a/package.nls.json
+++ b/package.nls.json
@@ -142,6 +142,7 @@
     "cmake-tools.configuration.cmake.exportCompileCommandsFile.description": "Enables exporting compile_commands.json.",
     "cmake-tools.configuration.cmake.useCMakePresets.description": "Use CMakePresets.json to configure drive CMake configure, build, and test. When using CMakePresets.json, kits, variants, and some settings in settings.json will be ignored.",
     "cmake-tools.configuration.cmake.allowCommentsInPresetsFile.description": "Allow the use of JSON extensions such as comments in CMakePresets.json. Please note that your CMakePresets.json file may be considered invalid by other IDEs or on the command line if you use non-standard JSON.",
+    "cmake-tools.configuration.cmake.ignoreCMakeListsMissing.description": "Do not ask the user what to do if the CMakeLists.txt is not found in the root folder of the project, simply ignore it.",
     "cmake-tools.configuration.cmake.launchBehavior.description": "Controls what happens with the launch terminal when you launch a target.",
     "cmake-tools.configuration.cmake.launchBehavior.reuseTerminal.description": "The launch terminal instance is reused and the target will launch as soon as the terminal is idle.",
     "cmake-tools.configuration.cmake.launchBehavior.breakAndReuseTerminal.description": "The launch terminal instance is reused and a break command is sent to terminate any active foreground process before launching the target.",

--- a/package.nls.json
+++ b/package.nls.json
@@ -142,7 +142,7 @@
     "cmake-tools.configuration.cmake.exportCompileCommandsFile.description": "Enables exporting compile_commands.json.",
     "cmake-tools.configuration.cmake.useCMakePresets.description": "Use CMakePresets.json to configure drive CMake configure, build, and test. When using CMakePresets.json, kits, variants, and some settings in settings.json will be ignored.",
     "cmake-tools.configuration.cmake.allowCommentsInPresetsFile.description": "Allow the use of JSON extensions such as comments in CMakePresets.json. Please note that your CMakePresets.json file may be considered invalid by other IDEs or on the command line if you use non-standard JSON.",
-    "cmake-tools.configuration.cmake.ignoreCMakeListsMissing.description": "Do not ask the user what to do if the CMakeLists.txt is not found in the root folder of the project, simply ignore it.",
+    "cmake-tools.configuration.cmake.ignoreCMakeListsMissing.description": "If true, the extension will not ask the user to select a CMakeLists.txt file for configuration when one is found in the workspace but not in the root folder.",
     "cmake-tools.configuration.cmake.launchBehavior.description": "Controls what happens with the launch terminal when you launch a target.",
     "cmake-tools.configuration.cmake.launchBehavior.reuseTerminal.description": "The launch terminal instance is reused and the target will launch as soon as the terminal is idle.",
     "cmake-tools.configuration.cmake.launchBehavior.breakAndReuseTerminal.description": "The launch terminal instance is reused and a break command is sent to terminate any active foreground process before launching the target.",

--- a/src/cmakeTools.ts
+++ b/src/cmakeTools.ts
@@ -569,8 +569,7 @@ export class CMakeTools implements api.CMakeToolsAPI {
             case CMakePreconditionProblems.MissingCMakeListsFile:
                 telemetryEvent = "partialActivation";
 
-                const ignoreCMakeListsMissing: boolean = this.workspaceContext.state.ignoreCMakeListsMissing ||
-                  this.workspaceContext.config.ignoreCMakeListsMissing;
+                const ignoreCMakeListsMissing: boolean = this.workspaceContext.state.ignoreCMakeListsMissing || this.workspaceContext.config.ignoreCMakeListsMissing;
                 telemetryProperties["ignoreCMakeListsMissing"] = ignoreCMakeListsMissing.toString();
 
                 if (!ignoreCMakeListsMissing) {

--- a/src/cmakeTools.ts
+++ b/src/cmakeTools.ts
@@ -570,7 +570,7 @@ export class CMakeTools implements api.CMakeToolsAPI {
                 telemetryEvent = "partialActivation";
 
                 const ignoreCMakeListsMissing: boolean = this.workspaceContext.state.ignoreCMakeListsMissing ||
-                  !this.workspaceContext.config.ignoreCMakeListsMissing;
+                  this.workspaceContext.config.ignoreCMakeListsMissing;
                 telemetryProperties["ignoreCMakeListsMissing"] = ignoreCMakeListsMissing.toString();
 
                 if (!ignoreCMakeListsMissing) {

--- a/src/cmakeTools.ts
+++ b/src/cmakeTools.ts
@@ -570,7 +570,8 @@ export class CMakeTools implements api.CMakeToolsAPI {
                 telemetryEvent = "partialActivation";
                 telemetryProperties["ignoreCMakeListsMissing"] = this.workspaceContext.state.ignoreCMakeListsMissing.toString();
 
-                if (!this.workspaceContext.state.ignoreCMakeListsMissing) {
+                if (!this.workspaceContext.state.ignoreCMakeListsMissing &&
+                    !this.workspaceContext.config.ignoreCMakeListsMissing) {
                     const quickStart = localize('quickstart.cmake.project', "Create");
                     const changeSourceDirectory = localize('edit.setting', "Locate");
                     const ignoreCMakeListsMissing = localize('ignore.activation', "Don't show again");

--- a/src/cmakeTools.ts
+++ b/src/cmakeTools.ts
@@ -576,7 +576,7 @@ export class CMakeTools implements api.CMakeToolsAPI {
                 if (!ignoreCMakeListsMissing) {
                     const quickStart = localize('quickstart.cmake.project', "Create");
                     const changeSourceDirectory = localize('edit.setting', "Locate");
-                    const ignoreCMakeListsMissing = localize('ignore.activation', "Don't show again");
+                    const ignoreActivation = localize('ignore.activation', "Don't show again");
 
                     let showCMakeLists: boolean = await showCMakeListsExperiment();
                     const existingCmakeListsFiles: string[] | undefined = await util.getAllCMakeListsPaths(this.folder.uri);
@@ -593,7 +593,7 @@ export class CMakeTools implements api.CMakeToolsAPI {
 
                     const result = showCMakeLists ? changeSourceDirectory : await vscode.window.showErrorMessage(
                         localize('missing.cmakelists', 'CMakeLists.txt was not found in the root of the folder {0}. How would you like to proceed?', `"${this.folderName}"`),
-                        quickStart, changeSourceDirectory, ignoreCMakeListsMissing);
+                        quickStart, changeSourceDirectory, ignoreActivation);
 
                     if (result === quickStart) {
                         // Return here, since the updateFolderFullFeature set below (after the "switch")
@@ -664,7 +664,7 @@ export class CMakeTools implements api.CMakeToolsAPI {
                         } else {
                             telemetryProperties["missingCMakeListsUserAction"] = showCMakeLists ? "cancel-browse-exp" : "cancel-browse-ctl";
                         }
-                    } else if (result === ignoreCMakeListsMissing) {
+                    } else if (result === ignoreActivation) {
                         // The user ignores the missing CMakeLists.txt file --> limit the CMake Tools extension functionality
                         // (hide commands and status bar) and record this choice so that this popup doesn't trigger next time.
                         // The switch back to full functionality can be done later by changes to the cmake.sourceDirectory setting

--- a/src/cmakeTools.ts
+++ b/src/cmakeTools.ts
@@ -568,10 +568,12 @@ export class CMakeTools implements api.CMakeToolsAPI {
                 break;
             case CMakePreconditionProblems.MissingCMakeListsFile:
                 telemetryEvent = "partialActivation";
-                telemetryProperties["ignoreCMakeListsMissing"] = this.workspaceContext.state.ignoreCMakeListsMissing.toString();
 
-                if (!this.workspaceContext.state.ignoreCMakeListsMissing &&
-                    !this.workspaceContext.config.ignoreCMakeListsMissing) {
+                const ignoreCMakeListsMissing: boolean = this.workspaceContext.state.ignoreCMakeListsMissing ||
+                  !this.workspaceContext.config.ignoreCMakeListsMissing;
+                telemetryProperties["ignoreCMakeListsMissing"] = ignoreCMakeListsMissing.toString();
+
+                if (!ignoreCMakeListsMissing) {
                     const quickStart = localize('quickstart.cmake.project', "Create");
                     const changeSourceDirectory = localize('edit.setting', "Locate");
                     const ignoreCMakeListsMissing = localize('ignore.activation', "Don't show again");

--- a/src/config.ts
+++ b/src/config.ts
@@ -140,6 +140,7 @@ export interface ExtensionConfigurationSettings {
     useCMakePresets: UseCMakePresets;
     allowCommentsInPresetsFile: boolean;
     launchBehavior: string;
+    ignoreCMakeListsMissing: boolean;
 }
 
 type EmittersOf<T> = {
@@ -353,6 +354,10 @@ export class ConfigurationReader implements vscode.Disposable {
         return this.configData.allowCommentsInPresetsFile;
     }
 
+    get ignoreCMakeListsMissing(): boolean {
+        return this.configData.ignoreCMakeListsMissing;
+    }
+
     get cmakeCommunicationMode(): CMakeCommunicationMode {
         let communicationMode = this.configData.cmakeCommunicationMode;
         if (communicationMode === "automatic" && this.useCMakeServer) {
@@ -480,6 +485,7 @@ export class ConfigurationReader implements vscode.Disposable {
         statusbar: new vscode.EventEmitter<StatusBarConfig>(),
         useCMakePresets: new vscode.EventEmitter<UseCMakePresets>(),
         allowCommentsInPresetsFile: new vscode.EventEmitter<boolean>(),
+        ignoreCMakeListsMissing: new vscode.EventEmitter<boolean>(),
         launchBehavior: new vscode.EventEmitter<string>()
     };
 

--- a/test/unit-tests/config.test.ts
+++ b/test/unit-tests/config.test.ts
@@ -60,7 +60,8 @@ function createConfig(conf: Partial<ExtensionConfigurationSettings>): Configurat
         },
         useCMakePresets: 'never',
         allowCommentsInPresetsFile: false,
-        launchBehavior: 'reuseTerminal'
+        launchBehavior: 'reuseTerminal',
+        ignoreCMakeListsMissing: false
     });
     ret.updatePartial(conf);
     return ret;


### PR DESCRIPTION
## This change addresses item #2532

### This changes visible behaviour

The following changes are proposed:

- add the boolean `cmake.ignoreCMakeListsMissing` option at the end of the list
- add the boolean `ignoreCMakeListsMissing` member to the `ExtensionConfigurationSettings` interface
- if this option is set, skip asking the user what to do if `CMakeLists.txt` is not found in the project root

## Other Notes/Information

- the option is defined in the `resource` scope, but it is only checked in the `this.workspaceContext.config`
- the option has an even emitter, but for now it is not used
- there are no i18n messages


