### PR TITLE
Add "cmake.skipSelectKit"

### DIFF
--- a/package.json
+++ b/package.json
@@ -1945,6 +1945,12 @@
           "default": false,
           "description": "%cmake-tools.configuration.cmake.ignoreCMakeListsMissing.description%",
           "scope": "resource"
+        },
+        "cmake.skipSelectKit": {
+          "type": "boolean",
+          "default": false,
+          "description": "%cmake-tools.configuration.cmake.skipSelectKit.description%",
+          "scope": "resource"
         }
       }
     },

--- a/package.nls.json
+++ b/package.nls.json
@@ -143,6 +143,7 @@
     "cmake-tools.configuration.cmake.useCMakePresets.description": "Use CMakePresets.json to configure drive CMake configure, build, and test. When using CMakePresets.json, kits, variants, and some settings in settings.json will be ignored.",
     "cmake-tools.configuration.cmake.allowCommentsInPresetsFile.description": "Allow the use of JSON extensions such as comments in CMakePresets.json. Please note that your CMakePresets.json file may be considered invalid by other IDEs or on the command line if you use non-standard JSON.",
     "cmake-tools.configuration.cmake.ignoreCMakeListsMissing.description": "If true, the extension will not ask the user to select a CMakeLists.txt file for configuration when one is found in the workspace but not in the root folder.",
+    "cmake-tools.configuration.cmake.skipSelectKit.description": "If true, the extension will not ask the user to select a kit.",
     "cmake-tools.configuration.cmake.launchBehavior.description": "Controls what happens with the launch terminal when you launch a target.",
     "cmake-tools.configuration.cmake.launchBehavior.reuseTerminal.description": "The launch terminal instance is reused and the target will launch as soon as the terminal is idle.",
     "cmake-tools.configuration.cmake.launchBehavior.breakAndReuseTerminal.description": "The launch terminal instance is reused and a break command is sent to terminate any active foreground process before launching the target.",

--- a/src/config.ts
+++ b/src/config.ts
@@ -141,6 +141,7 @@ export interface ExtensionConfigurationSettings {
     allowCommentsInPresetsFile: boolean;
     launchBehavior: string;
     ignoreCMakeListsMissing: boolean;
+    skipSelectKit: boolean;
 }
 
 type EmittersOf<T> = {
@@ -357,6 +358,9 @@ export class ConfigurationReader implements vscode.Disposable {
     get ignoreCMakeListsMissing(): boolean {
         return this.configData.ignoreCMakeListsMissing;
     }
+    get skipSelectKit(): boolean {
+        return this.configData.skipSelectKit;
+    }
 
     get cmakeCommunicationMode(): CMakeCommunicationMode {
         let communicationMode = this.configData.cmakeCommunicationMode;
@@ -486,6 +490,7 @@ export class ConfigurationReader implements vscode.Disposable {
         useCMakePresets: new vscode.EventEmitter<UseCMakePresets>(),
         allowCommentsInPresetsFile: new vscode.EventEmitter<boolean>(),
         ignoreCMakeListsMissing: new vscode.EventEmitter<boolean>(),
+        skipSelectKit: new vscode.EventEmitter<boolean>(),
         launchBehavior: new vscode.EventEmitter<string>()
     };
 

--- a/src/kitsController.ts
+++ b/src/kitsController.ts
@@ -274,6 +274,11 @@ export class KitsController {
             return false;
         }
 
+        if (this.cmakeTools.workspaceContext.config.skipSelectKit) {
+            log.debug(localize('skip.select.kit', 'Skip selection of a kit'));
+            return false;
+        }
+
         const avail = this.availableKits;
         log.debug(localize('start.selection.of.kits', 'Start selection of kits. Found {0} kits.', avail.length));
 

--- a/test/unit-tests/config.test.ts
+++ b/test/unit-tests/config.test.ts
@@ -61,7 +61,8 @@ function createConfig(conf: Partial<ExtensionConfigurationSettings>): Configurat
         useCMakePresets: 'never',
         allowCommentsInPresetsFile: false,
         launchBehavior: 'reuseTerminal',
-        ignoreCMakeListsMissing: false
+        ignoreCMakeListsMissing: false,
+        skipSelectKit: false
     });
     ret.updatePartial(conf);
     return ret;


### PR DESCRIPTION
## This change addresses item #2538

### This changes visible behaviour

The following changes are proposed:

- add the boolean `cmake.skipSelectKit` option at the end of the list
- add the boolean `skipSelectKit` member to the `ExtensionConfigurationSettings` interface
- if this option is set, skip asking the user to select a kit ; the result is similar to the user selecting the _Undefined_ choice

## Other Notes/Information

- the option is defined in the `resource` scope, but it is only checked in the `workspaceContext.config`
- the option has an even emitter, but for now it is not used
- there are no i18n messages
