### PR TITLE
Fix minimum CMake version logic used for presets

### DIFF
--- a/src/preset.ts
+++ b/src/preset.ts
@@ -406,7 +406,8 @@ export function minCMakeVersion(folder: string) {
     if (!min2) {
         return min1;
     }
-    return util.versionLess(min1, min2) ? min1 : min2;
+    // The combined minimum version is the higher version of the two
+    return util.versionLess(min1, min2) ? min2 : min1;
 }
 
 export function configurePresets(folder: string) {


### PR DESCRIPTION
This fixes the logic used to compute the minimum CMake version when both `CMakePresets.json` and `CMakeUserPresets.json` exist. Previously, it incorrectly picked the lower version of the two as the combined minimum.