### PR TITLE
Assign names to status bar items

### DIFF
--- a/package.json
+++ b/package.json
@@ -1229,24 +1229,24 @@
               "description": "%cmake-tools.configuration.cmake.debugConfig.additionalSOLibSearchPath.description%"
             },
             "externalConsole": {
-                "type": "boolean",
-                "description": "%cmake-tools.configuration.cmake.debugConfig.externalConsole.description%"
+              "type": "boolean",
+              "description": "%cmake-tools.configuration.cmake.debugConfig.externalConsole.description%"
             },
             "console": {
-                "type": "string",
-                "enum": [
-                  "internalConsole",
-                  "integratedTerminal",
-                  "externalTerminal",
-                  "newExternalWindow"
-                ],
-                "enumDescriptions": [
-                  "%cmake-tools.configuration.cmake.debugConfig.console.internalConsole.description%",
-                  "%cmake-tools.configuration.cmake.debugConfig.console.integratedTerminal.description%",
-                  "%cmake-tools.configuration.cmake.debugConfig.console.externalTerminal.description%",
-                  "%cmake-tools.configuration.cmake.debugConfig.console.newExternalWindow.description%"
-                ],
-                "description": "%cmake-tools.configuration.cmake.debugConfig.console.description%"
+              "type": "string",
+              "enum": [
+                "internalConsole",
+                "integratedTerminal",
+                "externalTerminal",
+                "newExternalWindow"
+              ],
+              "enumDescriptions": [
+                "%cmake-tools.configuration.cmake.debugConfig.console.internalConsole.description%",
+                "%cmake-tools.configuration.cmake.debugConfig.console.integratedTerminal.description%",
+                "%cmake-tools.configuration.cmake.debugConfig.console.externalTerminal.description%",
+                "%cmake-tools.configuration.cmake.debugConfig.console.newExternalWindow.description%"
+              ],
+              "description": "%cmake-tools.configuration.cmake.debugConfig.console.description%"
             },
             "logging": {
               "type": "object",
@@ -2052,7 +2052,7 @@
     "@types/rimraf": "^3.0.0",
     "@types/sinon": "~9.0.10",
     "@types/tmp": "^0.2.0",
-    "@types/vscode": "1.56.0",
+    "@types/vscode": "1.63.0",
     "@types/which": "~2.0.0",
     "@types/xml2js": "^0.4.8",
     "@typescript-eslint/eslint-plugin": "^4.22.1",

--- a/src/status.ts
+++ b/src/status.ts
@@ -16,14 +16,23 @@ function hasCPPTools(): boolean {
 abstract class Button {
     readonly settingsName: string | null = null;
     protected readonly button: vscode.StatusBarItem;
+    private _name: string | null = null;
     private _forceHidden: boolean = false;
     private _hidden: boolean = false;
     private _text: string = '';
     private _tooltip: string | null = null;
     private _icon: string | null = null;
 
-    constructor(protected readonly config: ConfigurationReader, protected readonly priority: number) {
-        this.button = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, this.priority);
+    constructor(protected readonly id: string, protected readonly config: ConfigurationReader, protected readonly priority: number) {
+        this.button = vscode.window.createStatusBarItem(this.id, vscode.StatusBarAlignment.Left, this.priority);
+    }
+
+    get name(): string | null {
+        return this._name;
+    }
+    set name(v: string | null) {
+        this._name = v;
+        this.update();
     }
 
     /**
@@ -83,6 +92,7 @@ abstract class Button {
             this.button.hide();
             return;
         }
+        this.button.name = this.name || undefined;
         this.button.text = text;
         this.button.tooltip = this._getTooltip() || undefined;
         this.button.show();
@@ -187,7 +197,8 @@ class WorkspaceButton extends Button {
 
     settingsName = 'workspace';
     constructor(protected readonly config: ConfigurationReader, protected readonly priority: number) {
-        super(config, priority);
+        super('workspace', config, priority);
+        this.name = localize('cmake.active.folder', 'CMake: Active folder');
         this.command = 'cmake.selectActiveFolder';
         this.icon = 'folder-active';
         this.tooltip = localize('click.to.select.workspace.tooltip', 'Click to select the active folder');
@@ -223,7 +234,8 @@ class CMakeStatus extends Button {
 
     settingsName = 'status';
     constructor(protected readonly config: ConfigurationReader, protected readonly priority: number) {
-        super(config, priority);
+        super('status', config, priority);
+        this.name = localize('cmake.status', 'CMake: Status');
         this.hidden = true;
         this.command = 'cmake.setVariant';
         this.icon = 'info';
@@ -254,7 +266,8 @@ class KitSelection extends Button {
 
     settingsName = 'kit';
     constructor(protected readonly config: ConfigurationReader, protected readonly priority: number) {
-        super(config, priority);
+        super('kit', config, priority);
+        this.name = localize('cmake.active.kit', 'CMake: Active kit');
         this.hidden = true;
         this.command = 'cmake.selectKit';
         this.icon = 'tools';
@@ -298,7 +311,8 @@ class KitSelection extends Button {
 class BuildTargetSelectionButton extends Button {
     settingsName = 'buildTarget';
     constructor(protected readonly config: ConfigurationReader, protected readonly priority: number) {
-        super(config, priority);
+        super('buildTarget', config, priority);
+        this.name = localize('cmake.active.build.target', 'CMake: Active build target');
         this.hidden = false;
         this.command = 'cmake.setDefaultTarget';
         this.tooltip = localize('set.active.target.tooltip', 'Set the default build target');
@@ -311,7 +325,8 @@ class BuildTargetSelectionButton extends Button {
 class LaunchTargetSelectionButton extends Button {
     settingsName = 'launchTarget';
     constructor(protected readonly config: ConfigurationReader, protected readonly priority: number) {
-        super(config, priority);
+        super('launchTarget', config, priority);
+        this.name = localize('cmake.active.launch.target', 'CMake: Active launch target');
         this.command = 'cmake.selectLaunchTarget';
         this.tooltip = localize('select.target.tooltip', 'Select the target to launch');
     }
@@ -324,7 +339,8 @@ class LaunchTargetSelectionButton extends Button {
 class DebugButton extends Button {
     settingsName = 'debug';
     constructor(protected readonly config: ConfigurationReader, protected readonly priority: number) {
-        super(config, priority);
+        super('debug', config, priority);
+        this.name = localize('cmake.launch.debugger', 'CMake: Launch debugger');
         this.command = 'cmake.debugTarget';
         this.icon = 'bug';
         this.tooltip = localize('launch.debugger.tooltip', 'Launch the debugger for the selected target');
@@ -352,7 +368,8 @@ class DebugButton extends Button {
 class LaunchButton extends Button {
     settingsName = 'launch';
     constructor(protected readonly config: ConfigurationReader, protected readonly priority: number) {
-        super(config, priority);
+        super('launch', config, priority);
+        this.name = localize('cmake.launch.target', 'CMake: Launch target');
         this.command = 'cmake.launchTarget';
         this.icon = 'play';
         this.tooltip = localize('launch.tooltip', 'Launch the selected target in the terminal window');
@@ -376,7 +393,8 @@ class LaunchButton extends Button {
 class CTestButton extends Button {
     settingsName = 'ctest';
     constructor(protected readonly config: ConfigurationReader, protected readonly priority: number) {
-        super(config, priority);
+        super('ctest', config, priority);
+        this.name = localize('cmake.run.ctest', 'CMake: Run CTest');
         this.command = 'cmake.ctest';
         this.tooltip = localize('run.ctest.tests.tooltip', 'Run CTest tests');
     }
@@ -455,7 +473,8 @@ class BuildButton extends Button {
 
     settingsName = 'build';
     constructor(protected readonly config: ConfigurationReader, protected readonly priority: number) {
-        super(config, priority);
+        super('build', config, priority);
+        this.name = localize('cmake.build', 'CMake: Build');
         this.command = 'cmake.build';
         this.tooltip = localize('build.tooltip', 'Build the selected target');
     }
@@ -503,7 +522,8 @@ export class ConfigurePresetSelection extends Button {
 
     settingsName = 'configurePreset';
     constructor(protected readonly config: ConfigurationReader, protected readonly priority: number) {
-        super(config, priority);
+        super('configurePreset', config, priority);
+        this.name = localize('cmake.active.configure.preset', 'CMake: Active configure preset');
         this.hidden = false;
         this.command = 'cmake.selectConfigurePreset';
         this.icon = 'tools';
@@ -546,7 +566,8 @@ export class BuildPresetSelection extends Button {
 
     settingsName = 'buildPreset';
     constructor(protected readonly config: ConfigurationReader, protected readonly priority: number) {
-        super(config, priority);
+        super('buildPreset', config, priority);
+        this.name = localize('cmake.active.build.preset', 'CMake: Active build preset');
         this.hidden = false;
         this.command = 'cmake.selectBuildPreset';
         this.icon = 'tools';
@@ -589,7 +610,8 @@ export class TestPresetSelection extends Button {
 
     settingsName = 'testPreset';
     constructor(protected readonly config: ConfigurationReader, protected readonly priority: number) {
-        super(config, priority);
+        super('testPreset', config, priority);
+        this.name = localize('cmake.active.test.preset', 'CMake: Active test preset');
         this.hidden = false;
         this.command = 'cmake.selectTestPreset';
         this.icon = 'tools';

--- a/test/helpers/test/default-environment.ts
+++ b/test/helpers/test/default-environment.ts
@@ -50,7 +50,7 @@ export class DefaultEnvironment {
     readonly kitSelection = new SelectKitPickerHandle(this.defaultKitLabel, this.excludeKitLabel);
 
     private setupShowQuickPickerStub(selections: QuickPickerHandleStrategy[]) {
-        const fakeShowQuickPick = <T>(items: T[] | Thenable<T[]>, options?: vscode.QuickPickOptions, _token?: vscode.CancellationToken): Thenable<T | undefined> => {
+        const fakeShowQuickPick = <T>(items: readonly T[] | Thenable<readonly T[]>, options?: vscode.QuickPickOptions, _token?: vscode.CancellationToken): Thenable<T | undefined> => {
             if (options?.placeHolder === selections[0].identifier) {
                 return Promise.resolve(selections[0].handleQuickPick(items));
             }

--- a/test/helpers/vscodefake/memento.ts
+++ b/test/helpers/vscodefake/memento.ts
@@ -3,6 +3,9 @@ import * as vscode from 'vscode';
 export class TestMemento implements vscode.Memento {
     private readonly storage = new Map<string, any>();
 
+    public keys(): readonly string[] {
+        return Array.from(this.storage.keys());
+    }
     public get<T>(key: string): T | undefined;
     public get<T>(key: string, defaultValue: T): T;
     get<T>(key: string, defaultValue?: T): T | undefined {
@@ -27,6 +30,9 @@ export class TestMemento implements vscode.Memento {
 export class StateMemento implements vscode.Memento {
     private storage: { [key: string]: any } = {};
 
+    public keys(): readonly string[] {
+        return Object.keys(this.storage);
+    }
     public get<T>(key: string): T | undefined;
     public get<T>(key: string, defaultValue: T): T;
     public get(key: any, defaultValue?: any) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -361,10 +361,10 @@
   resolved "https://registry.yarnpkg.com/@types/tmp/-/tmp-0.2.0.tgz#e3f52b4d7397eaa9193592ef3fdd44dc0af4298c"
   integrity sha512-flgpHJjntpBAdJD43ShRosQvNC0ME97DCfGvZEDlAThQmnerRXrLbX6YgzRBQCZTthET9eAWFAMaYP0m0Y4HzQ==
 
-"@types/vscode@1.56.0":
-  version "1.56.0"
-  resolved "https://registry.yarnpkg.com/@types/vscode/-/vscode-1.56.0.tgz#2a75ee6d66e529295648b0b6ee43824564ed9c1a"
-  integrity sha512-Q5VmQxOx+L1Y6lIJiGcJzwcyV3pQo/eiW8P+7sNLhFI16tJCwtua2DLjHRcpjbCLNVYpQM73kzfFo1Z0HyP9eQ==
+"@types/vscode@1.63.0":
+  version "1.63.0"
+  resolved "https://registry.yarnpkg.com/@types/vscode/-/vscode-1.63.0.tgz#3bddb5b79a93e8fcdd420bb00f7066658c79c70c"
+  integrity sha512-iePu1axOi5WSThV6l2TYcciBIpAlMarjBC8H0y8L8ocsZLxh7MttzwFU3pjoItF5fRVGxHS0Hsvje9jO3yJsfw==
 
 "@types/which@~2.0.0":
   version "2.0.0"


### PR DESCRIPTION
## This change addresses item #1933

This assigns a name to each button on the status bar which allows users to individually show/hide buttons. Before this change, users can only show/hide all buttons at once.

Users have reported in https://github.com/microsoft/vscode-cmake-tools/issues/1945 that the status bar buttons take up a lot of space. Allowing users to hide individual buttons that they might not need (e.g. tests) could help.

In order to use the newer `createStatusBarItem` overload, I had to update `@types/vscode` to a newer version. I picked `1.63.0` which matches the minimum VS Code version specified in `package.json`:
```json
"engines": {
    "vscode": "^1.63.0"
  },
```
As part of this update, I had to make some minor changes to the mocking and tests code.

The names assigned to the buttons are shown in the context menu of the status bar:

<img width="257" alt="image" src="https://user-images.githubusercontent.com/15180557/168452700-71f3cb09-bd42-4de0-b644-01918bb41f17.png">

They would need to be localized.