### PR TITLE
Use CMake driver to detect changes in CMake files

### DIFF
--- a/src/cmakeTools.ts
+++ b/src/cmakeTools.ts
@@ -896,14 +896,23 @@ export class CMakeTools implements api.CMakeToolsAPI {
             }
 
             const sourceDirectory = (this.sourceDir).toLowerCase();
-            let isCmakeListsFile: boolean = false;
+            
+            let isCmakeFile: boolean;
+            if (drv && drv.cmakeFiles.length > 0) {
+                // If CMake file information is available from the driver, use it
+                isCmakeFile = drv.cmakeFiles.some(f => lightNormalizePath(str) === lightNormalizePath(path.resolve(this.sourceDir, f).toLowerCase()));
+            } else {
+                // Otherwise, fallback to a simple check (does not cover CMake include files)
+                isCmakeFile = false;
             if (str.endsWith("cmakelists.txt")) {
                 const allcmakelists: string[] | undefined = await util.getAllCMakeListsPaths(this.folder.uri);
                 // Look for the CMakeLists.txt files that are in the workspace or the sourceDirectory root.
-                isCmakeListsFile = (str === path.join(sourceDirectory, "cmakelists.txt")) ||
+                    isCmakeFile = (str === path.join(sourceDirectory, "cmakelists.txt")) ||
                     (allcmakelists?.find(file => str === file.toLocaleLowerCase()) !== undefined);
             }
-            if (isCmakeListsFile) {
+            }
+
+            if (isCmakeFile) {
                 // CMakeLists.txt change event: its creation or deletion are relevant,
                 // so update full/partial feature set view for this folder.
                 await updateFullFeatureSetForFolder(this.folder);

--- a/src/drivers/cmakeDriver.ts
+++ b/src/drivers/cmakeDriver.ts
@@ -125,6 +125,12 @@ export abstract class CMakeDriver implements vscode.Disposable {
     abstract get uniqueTargets(): api.Target[];
 
     /**
+     * List of all files (CMakeLists.txt and included .cmake files) used by CMake
+     * during configuration
+     */
+    abstract get cmakeFiles(): string[];
+
+    /**
      * Do any necessary disposal for the driver. For the CMake Server driver,
      * this entails shutting down the server process and closing the open pipes.
      *

--- a/src/drivers/cmakeFileApi.ts
+++ b/src/drivers/cmakeFileApi.ts
@@ -180,6 +180,26 @@ export namespace Toolchains {
     }
 }
 
+export namespace CMakeFiles {
+    export interface Content {
+        version: ApiVersion;
+        paths: PathInfo[];
+        inputs: InputFileInfo[];
+    }
+
+    export interface PathInfo {
+        build: string;
+        source: string;
+    }
+
+    export interface InputFileInfo {
+        path: string;
+        isGenerated?: boolean;
+        isExternal?: boolean;
+        isCMake?: boolean;
+    }
+}
+
 nls.config({ messageFormat: nls.MessageFormat.bundle, bundleFormat: nls.BundleFormat.standalone })();
 const localize: nls.LocalizeFunc = nls.loadMessageBundle();
 
@@ -201,7 +221,14 @@ async function tryReadFile(file: string): Promise<string | undefined> {
 export async function createQueryFileForApi(apiPath: string): Promise<string> {
     const queryPath = path.join(apiPath, 'query', 'client-vscode');
     const queryFilePath = path.join(queryPath, 'query.json');
-    const requests = { requests: [{ kind: 'cache', version: 2 }, { kind: 'codemodel', version: 2 }, { kind: 'toolchains', version: 1 }] };
+    const requests = {
+        requests: [
+            { kind: 'cache', version: 2 },
+            { kind: 'codemodel', version: 2 },
+            { kind: 'toolchains', version: 1 },
+            { kind: 'cmakeFiles', version: 1 }
+        ]
+    };
     try {
         await fs.mkdir_p(queryPath);
         await fs.writeFile(queryFilePath, JSON.stringify(requests));
@@ -253,6 +280,29 @@ export async function loadCacheContent(filename: string): Promise<Map<string, ap
     }
 
     return convertFileApiCacheToExtensionCache(cmakeCacheContent);
+}
+
+export async function loadCMakeFiles(filename: string): Promise<string[]> {
+    const fileContent = await tryReadFile(filename);
+    if (!fileContent) {
+        return [];
+    }
+    const cmakeFilesContent = JSON.parse(fileContent.toString()) as CMakeFiles.Content;
+
+    const expectedVersion = { major: 1, minor: 0 };
+    const detectedVersion = cmakeFilesContent.version;
+    if (detectedVersion.major !== expectedVersion.major || detectedVersion.minor < expectedVersion.minor) {
+        log.warning(localize(
+            'cmake.files.object.version',
+            'CMake Files object version ({0}.{1}) of cmake-file-api is unexpected. Expecting ({2}.{3}).',
+            detectedVersion.major,
+            detectedVersion.minor,
+            expectedVersion.major,
+            expectedVersion.minor));
+        return [];
+    }
+
+    return cmakeFilesContent.inputs.map(input => input.path);
 }
 
 function findPropertyValue(cacheElement: Cache.CMakeCacheEntry, name: string): string {

--- a/src/drivers/cmakeLegacyDriver.ts
+++ b/src/drivers/cmakeLegacyDriver.ts
@@ -167,6 +167,9 @@ export class CMakeLegacyDriver extends CMakeDriver {
     get uniqueTargets() {
         return [];
     }
+    get cmakeFiles() {
+        return [];
+    }
 
     /**
      * Watcher for the CMake cache file on disk.

--- a/src/drivers/cmakeServerDriver.ts
+++ b/src/drivers/cmakeServerDriver.ts
@@ -254,6 +254,10 @@ export class CMakeServerDriver extends CMakeDriver {
         return this.targets.reduce(targetReducer, []);
     }
 
+    get cmakeFiles(): string[] {
+        return this._cmakeInputFileSet.inputFiles.map(file => file.filePath);
+    }
+
     get generatorName(): string | null {
         return this._globalSettings ? this._globalSettings.generator : null;
     }


### PR DESCRIPTION
## This change addresses item #2526

This leverages the CMake file API or server API drivers to obtain a list of CMake input files (`CMakeLists.txt` or included `.cmake` files) in order to detect when any of these were changed by the user to trigger a re-configuration.

I haven't been able to test the server API, unfortunately, as it always fails with
> connect ENOENT \\\\?\\pipe\\c:\\Users\\chris\\Desktop\\cmaketest2\\.vscode\\.cmserver-pipe

If somebody could give it a try, it would be much appreciated.