### PR TITLE
Added an example for msvc (launch.json)

### DIFF
--- a/docs/debug-launch.md
+++ b/docs/debug-launch.md
@@ -39,7 +39,9 @@ You can specify the working directory or command line arguments for debugging, o
 
 You'll need to know the path to the executable binary, which may be difficult to know in advance. CMake Tools can help by using [command substitution](https://github.com/microsoft/vscode-cmake-tools/blob/main/docs/cmake-settings.md#command-substitution) in the `launch.json` file. This is already used by things like process selection when attaching to a running process. It works by specifying a command-based substitution in the appropriate field of `launch.json`.
 
-Here is a minimal example of a `launch.json` file that uses `cmake.launchTargetPath` and `cmake.getLaunchTargetDirectory` to start a debugger on the active launch target:
+Here are minimal examples of a `launch.json` file that uses `cmake.launchTargetPath` and `cmake.getLaunchTargetDirectory` to start a debugger on the active launch target:
+
+### gdb
 
 ```jsonc
 {
@@ -79,6 +81,40 @@ Here is a minimal example of a `launch.json` file that uses `cmake.launchTargetP
     ]
 }
 ```
+### msvc
+```jsonc
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "(msvc) Launch",
+            "type": "cppvsdbg",
+            "request": "launch",
+            // Resolved by CMake Tools:
+            "program": "${command:cmake.launchTargetPath}",
+            "args": [],
+            "stopAtEntry": false,
+            "cwd": "${workspaceFolder}",
+            "environment": [
+                {
+                    // add the directory where our target was built to the PATHs
+                    // it gets resolved by CMake Tools:
+                    "name": "PATH",
+                    "value": "${env:PATH}:${command:cmake.getLaunchTargetDirectory}"
+                },
+                {
+                    "name": "OTHER_VALUE",
+                    "value": "Something something"
+                }
+            ],
+            "console": "externalTerminal"
+        }
+    ]
+}
+
+```
+
+
 
 The value of the `program` attribute is expanded by CMake Tools to be the absolute path of the program to run.
 


### PR DESCRIPTION
For copycats on windows

### This changes documentation

The following changes are proposed:
- add an example how to configure launch.json if using msvc

## The purpose of this change

I am using vs code + msvc and cmake tools, i always have to fix some issues if copying the minimal example from the docs. 
This pull-request solves it by supplying a minimal exampel for msvc, which can be copy and pasted.

## Additional info 

Thanks for vscode-cmake-tools - i appreciate the flexibility of this vs code plugin 👍 
