### PR TITLE
Change project outline to respect `FOLDER` property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Improvements:
 - Add setting `cmake.showSystemKits`. [PR #2520](https://github.com/microsoft/vscode-cmake-tools/pull/2520) [@bharatvaj](https://github.com/bharatvaj)
 - Add support for "configure", "install" and "test" task. [#2452](https://github.com/microsoft/vscode-cmake-tools/issues/2452)
 - Add setting `cmake.ignoreCMakeListsMissing`. [PR #2537](https://github.com/microsoft/vscode-cmake-tools/pull/2537) [@ilg-ul](https://github.com/ilg-ul)
+- Change project outline to use targets `FOLDER` property. [#491](https://github.com/microsoft/vscode-cmake-tools/issues/491) [@NekkoDroid](https://github.com/NekkoDroid)
 
 Bug Fixes:
 - `Clean All Projects` menu item builds rather than cleans. [#2460](https://github.com/microsoft/vscode-cmake-tools/issues/2460)

--- a/package.json
+++ b/package.json
@@ -1948,6 +1948,12 @@
           "default": false,
           "description": "%cmake-tools.configuration.cmake.ignoreCMakeListsMissing.description%",
           "scope": "resource"
+        },
+        "cmake.useFilesystemStructure": {
+          "type": "boolean",
+          "default": false,
+          "description": "%cmake-tools.configuration.cmake.useFilesystemStructure.description%",
+          "scope": "resource"
         }
       }
     },

--- a/package.nls.json
+++ b/package.nls.json
@@ -143,6 +143,7 @@
     "cmake-tools.configuration.cmake.useCMakePresets.description": "Use CMakePresets.json to configure drive CMake configure, build, and test. When using CMakePresets.json, kits, variants, and some settings in settings.json will be ignored.",
     "cmake-tools.configuration.cmake.allowCommentsInPresetsFile.description": "Allow the use of JSON extensions such as comments in CMakePresets.json. Please note that your CMakePresets.json file may be considered invalid by other IDEs or on the command line if you use non-standard JSON.",
     "cmake-tools.configuration.cmake.ignoreCMakeListsMissing.description": "If true, the extension will not ask the user to select a CMakeLists.txt file for configuration when one is found in the workspace but not in the root folder.",
+    "cmake-tools.configuration.cmake.useFilesystemStructure.description": "If true, the extension will ignore CMake's `FOLDER` property and oragnize targets how they are layed out on the filesystem",
     "cmake-tools.configuration.cmake.launchBehavior.description": "Controls what happens with the launch terminal when you launch a target.",
     "cmake-tools.configuration.cmake.launchBehavior.reuseTerminal.description": "The launch terminal instance is reused and the target will launch as soon as the terminal is idle.",
     "cmake-tools.configuration.cmake.launchBehavior.breakAndReuseTerminal.description": "The launch terminal instance is reused and a break command is sent to terminate any active foreground process before launching the target.",

--- a/src/config.ts
+++ b/src/config.ts
@@ -141,6 +141,7 @@ export interface ExtensionConfigurationSettings {
     allowCommentsInPresetsFile: boolean;
     launchBehavior: string;
     ignoreCMakeListsMissing: boolean;
+    useFilesystemStructure: boolean;
 }
 
 type EmittersOf<T> = {
@@ -358,6 +359,10 @@ export class ConfigurationReader implements vscode.Disposable {
         return this.configData.ignoreCMakeListsMissing;
     }
 
+    get useFilesystemStructure(): boolean {
+        return this.configData.useFilesystemStructure;
+    }
+
     get cmakeCommunicationMode(): CMakeCommunicationMode {
         let communicationMode = this.configData.cmakeCommunicationMode;
         if (communicationMode === "automatic" && this.useCMakeServer) {
@@ -486,6 +491,7 @@ export class ConfigurationReader implements vscode.Disposable {
         useCMakePresets: new vscode.EventEmitter<UseCMakePresets>(),
         allowCommentsInPresetsFile: new vscode.EventEmitter<boolean>(),
         ignoreCMakeListsMissing: new vscode.EventEmitter<boolean>(),
+        useFilesystemStructure: new vscode.EventEmitter<boolean>(),
         launchBehavior: new vscode.EventEmitter<string>()
     };
 

--- a/src/drivers/cmakeFileApi.ts
+++ b/src/drivers/cmakeFileApi.ts
@@ -141,6 +141,10 @@ export namespace CodeModelKind {
         isGenerated?: boolean;
     }
 
+    export interface TargetFolderPath {
+        name: string;
+    }
+
     export interface TargetObject {
         name: string;
         type: string;
@@ -149,6 +153,7 @@ export namespace CodeModelKind {
         paths: PathInfo;
         sources: TargetSourcefile[];
         compileGroups?: CompileGroup[];
+        folder: TargetFolderPath;
     }
 }
 
@@ -431,7 +436,8 @@ async function loadCodeModelTarget(rootPaths: CodeModelKind.PathInfo, jsonFile: 
             a => convertToAbsolutePath(path.join(targetObject.paths.build, a.path), rootPaths.build))
             : [],
         fileGroups,
-        sysroot
+        sysroot,
+        folder: targetObject.folder?.name
     } as CodeModelTarget;
 }
 

--- a/src/drivers/codeModel.ts
+++ b/src/drivers/codeModel.ts
@@ -41,6 +41,11 @@ export interface CodeModelTarget {
      * Represents the CMAKE_SYSROOT variable
      */
     sysroot?: string;
+
+    /**
+     * Represents the CMAKE_FOLDER variable
+     */
+    folder?: string;
 }
 
 /**

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -696,7 +696,8 @@ class ExtensionManager implements vscode.Disposable {
             {
                 defaultTarget: cmt.defaultBuildTarget || undefined,
                 launchTargetName: cmt.launchTargetName
-            }
+            },
+            this.workspaceConfig.useFilesystemStructure
         );
         rollbar.invokeAsync(localize('update.code.model.for.cpptools', 'Update code model for cpptools'), {}, async () => {
             if (vscode.workspace.getConfiguration('C_Cpp', folder.folder).get<string>('intelliSenseEngine')?.toLocaleLowerCase() === 'disabled') {
@@ -751,7 +752,8 @@ class ExtensionManager implements vscode.Disposable {
                         {
                             defaultTarget: cmt.defaultBuildTarget || undefined,
                             launchTargetName: cmt.launchTargetName
-                        }
+                        },
+                        this.workspaceConfig.useFilesystemStructure
                     );
                 }
                 this.ensureCppToolsProviderRegistered();

--- a/src/tree.ts
+++ b/src/tree.ts
@@ -433,9 +433,7 @@ class ProjectNode extends BaseNode {
         };
 
         for (const target of pr.targets) {
-            const srcdir = target.sourceDirectory || '';
-            const relpath = path.relative(pr.sourceDirectory, srcdir);
-            addToTree(tree, relpath, target);
+            addToTree(tree, target.folder || '', target);
         }
         collapseTreeInplace(tree);
 

--- a/test/unit-tests/config.test.ts
+++ b/test/unit-tests/config.test.ts
@@ -61,7 +61,8 @@ function createConfig(conf: Partial<ExtensionConfigurationSettings>): Configurat
         useCMakePresets: 'never',
         allowCommentsInPresetsFile: false,
         launchBehavior: 'reuseTerminal',
-        ignoreCMakeListsMissing: false
+        ignoreCMakeListsMissing: false,
+        useFilesystemStructure: false
     });
     ret.updatePartial(conf);
     return ret;


### PR DESCRIPTION
## This change addresses item #491

### This changes visible behavior

The following changes are proposed:

- Change the project outline to respect `(CMAKE_)FOLDER` options of CMake

## Other Notes/Information

- the change completely replaces the old behavior of using relative paths for the targets
- possibly making old and new behavior user configurable might be worth exploring?
