### PR TITLE
Fix exception object type mismatch

### DIFF
--- a/src/rollbar.ts
+++ b/src/rollbar.ts
@@ -126,7 +126,7 @@ class RollbarController {
             log.trace(localize('invoking.function.rollbar', 'Invoking function [${0}] with Rollbar wrapping [${1}]', func.name, what));
             return func();
         } catch (e) {
-            this.exception(localize('unhandled.exception', 'Unhandled exception: {0}', what), e, additional);
+            this.exception(localize('unhandled.exception', 'Unhandled exception: {0}', what), e as Error, additional);
             throw e;
         }
     }


### PR DESCRIPTION
This fixes a type mismatch error that I often get after debugging the extension when starting the extension another time. For some reason, the TypeScript compiler does not complain on initial run, only on subsequent runs. I then have to close and reopen VS Code for it to work again.

The type error seems valid, though. `e` is of type `unknown` but `this.exception` requires an argument of type `Error`. I've seen multiple other places in the codebase where exceptions are casted to `Error` so it appears this is safe to do.