### PR TITLE
Add support for "args" and "environment" in build tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Bug Fixes:
 - Select the correct VS toolset for Ninja generators with CMake Presets. [#2423](https://github.com/microsoft/vscode-cmake-tools/issues/2423)
 - Fix unhandled exception with CMakePresets.json. [#2117](https://github.com/microsoft/vscode-cmake-tools/issues/2117)
 - Fix issues with compiler argument quoting when configuring IntelliSense. [#2563](https://github.com/microsoft/vscode-cmake-tools/pull/2563)
+- Add support for cpptools API V6. [2508](https://github.com/microsoft/vscode-cmake-tools/issues/2508)
 
 ## 1.10.5
 Bug Fixes:

--- a/package.json
+++ b/package.json
@@ -531,7 +531,7 @@
         "properties": {
           "label": {
             "type": "string",
-            "description": "The name of the task"
+            "description": "%cmake-tools.taskDefinitions.properties.label.description%"
           },
           "command": {
             "type": "string",
@@ -543,9 +543,16 @@
               "clean",
               "cleanRebuild"
             ],
-            "description": "CMake build command"
+            "description": "%cmake-tools.taskDefinitions.properties.command.description%"
           },
           "targets": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "%cmake-tools.taskDefinitions.properties.targets.description%"
+          },
+          "args": {
             "type": "array",
             "items": {
               "type": "string"
@@ -557,13 +564,29 @@
             "properties": {
               "cwd": {
                 "type": "string",
-                "description": "The current working directory of the executed program or script. If omitted Code's current workspace root is used."
+                "description": "%cmake-tools.taskDefinitions.properties.options.cwd.description%"
+              },
+              "environment": {
+                "type": "object",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "name": {
+                      "type": "string",
+                      "description": "%cmake-tools.taskDefinitions.properties.options.environment.name.description%"
+                    },
+                    "value": {
+                      "type": "string",
+                      "description": "%cmake-tools.taskDefinitions.properties.options.environment.value.description%"
+                    }
+                  }
+                }
               }
             }
           },
           "detail": {
             "type": "string",
-            "description": "Additional details of the task"
+            "description": "%cmake-tools.taskDefinitions.properties.details.description%"
           }
         }
       }

--- a/package.nls.json
+++ b/package.nls.json
@@ -146,5 +146,12 @@
     "cmake-tools.configuration.cmake.launchBehavior.description": "Controls what happens with the launch terminal when you launch a target.",
     "cmake-tools.configuration.cmake.launchBehavior.reuseTerminal.description": "The launch terminal instance is reused and the target will launch as soon as the terminal is idle.",
     "cmake-tools.configuration.cmake.launchBehavior.breakAndReuseTerminal.description": "The launch terminal instance is reused and a break command is sent to terminate any active foreground process before launching the target.",
-    "cmake-tools.configuration.cmake.launchBehavior.newTerminal.description": "A new terminal instance is created and the target is launched in it. Existing terminals are not automatically cleaned up."
+    "cmake-tools.configuration.cmake.launchBehavior.newTerminal.description": "A new terminal instance is created and the target is launched in it. Existing terminals are not automatically cleaned up.",
+    "cmake-tools.taskDefinitions.properties.label.description": "The name of the task",
+    "cmake-tools.taskDefinitions.properties.command.description": "CMake command",
+    "cmake-tools.taskDefinitions.properties.targets.description": "CMake build targets",
+    "cmake-tools.taskDefinitions.properties.options.cwd.description": "The current working directory of the executed program or script. If omitted Code's current workspace root is used.",
+    "cmake-tools.taskDefinitions.properties.options.environment.name.description": "Name of environment variable.",
+    "cmake-tools.taskDefinitions.properties.options.environment.value.description": "Value for the environment variable.",
+    "cmake-tools.taskDefinitions.properties.details.description": "Additional details of the task"
 }


### PR DESCRIPTION
when running a "build task" before running a "CMake: Configure", the task will fail:
`Error: could not load cache`
