### PR TITLE
Fix broken file watcher for presets

### DIFF
--- a/src/presetsController.ts
+++ b/src/presetsController.ts
@@ -1086,10 +1086,13 @@ export class PresetsController {
             this._presetsWatcher.close().then(() => {}, () => {});
         }
 
+        const handler = async () => {
+            await this.reapplyPresets();
+        };
         this._presetsWatcher = chokidar.watch(this._referencedFiles, { ignoreInitial: true })
-            .on('add', this.reapplyPresets)
-            .on('change', this.reapplyPresets)
-            .on('unlink', this.reapplyPresets);
+            .on('add', handler)
+            .on('change', handler)
+            .on('unlink', handler);
     };
 
     dispose() {


### PR DESCRIPTION
## The purpose of this change

This fixes a bug introduced in #2544 where an exception would get thrown in `PresetsController.reapplyPresets` when called from the presets file watcher because the callbacks are invoked with the wrong `this` context. The fix is to pass them via arrow functions.

See also the bug report at https://github.com/microsoft/vscode-cmake-tools/pull/2544#issuecomment-1165257516.