### PR TITLE
cmakeFiles are not always needed by the file-api driver

### DIFF
--- a/src/drivers/cmakeFileApiDriver.ts
+++ b/src/drivers/cmakeFileApiDriver.ts
@@ -328,13 +328,13 @@ export class CMakeFileApiDriver extends CMakeDriver {
                 }
             }
 
-            // load cmake files
+            // load cmake files if available
             const cmakefiles_obj = indexFile.objects.find((value: Index.ObjectKind) => value.kind === 'cmakeFiles');
-            if (!cmakefiles_obj) {
-                throw Error('No cmake files object found');
+            if (cmakefiles_obj) {
+                this._cmakeFiles = await loadCMakeFiles(path.join(reply_path, cmakefiles_obj.jsonFile));
+            } else {
+                this._cmakeFiles = [];
             }
-
-            this._cmakeFiles = await loadCMakeFiles(path.join(reply_path, cmakefiles_obj.jsonFile));
 
             this._codeModelChanged.fire(this._codeModelContent);
         }


### PR DESCRIPTION
Fixes a regression caused by #2548.  A previously configured project did not have `cmakeFiles` in the file api query.  When the folder was reopened, the file api driver expected cmakeFiles to exist because the code model was updated before a new Configure took place.  We're softening the requirements for the existence of this file since the logic for auto-reconfigure will still work for CMakeLists.txt files even if the cmakeFiles entries are unavailable.