### PR TITLE
docs/faq.md: fix cmake docs link + link to "Professional Cmake"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Improvements:
 - Triggering reconfigure after changes are made to included files. [#2526](https://github.com/microsoft/vscode-cmake-tools/issues/2526) [@chausner](https://github.com/chausner)
 - Support for presets version 4. [#2492](https://github.com/microsoft/vscode-cmake-tools/issues/2492) [@chausner](https://github.com/chausner)
 - Add target name to terminal window name for launch. [#2613](https://github.com/microsoft/vscode-cmake-tools/issues/2613)
+- Add Craig Scott's "Professional CMake" book to the list of resources in doc/faq.md for learning CMake. [#2679](https://github.com/microsoft/vscode-cmake-tools/pull/2679) [@david-fong](https://github.com/david-fong)
 
 Bug Fixes:
 - Set the working directory for the file api driver. [#2569](https://github.com/microsoft/vscode-cmake-tools/issues/2569)

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -18,7 +18,9 @@ CMake Tools was created separately from the [CMake extension](https://marketplac
 
 CMake Tools is not the same as CMake. There are many great resources around to learn how to use CMake. See Jason Turner's [C++ Weekly - Intro to CMake](https://www.youtube.com/watch?v=HPMvU64RUTY) for a good video introduction.
 
-[CMake's documentation](https://marketplace.visualstudio.com/items?itemName=twxs.cmake) is also available.
+[CMake's documentation](https://cmake.org/cmake/help/latest/) is also available.
+
+One of the maintainers of CMake, Craig Scott, publishes a (paid) book, ["Professional CMake"](https://crascit.com/professional-cmake/).
 
 ## How does CMake Tools work with C and C++ IntelliSense?
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -16,11 +16,12 @@ CMake Tools was created separately from the [CMake extension](https://marketplac
 
 ## How do I learn about CMake?
 
-CMake Tools is not the same as CMake. There are many great resources around to learn how to use CMake. See Jason Turner's [C++ Weekly - Intro to CMake](https://www.youtube.com/watch?v=HPMvU64RUTY) for a good video introduction.
+CMake Tools is not the same as CMake. There are many great resources around to learn how to use CMake.
 
-[CMake's documentation](https://cmake.org/cmake/help/latest/) is also available.
-
-One of the maintainers of CMake, Craig Scott, publishes a (paid) book, ["Professional CMake"](https://crascit.com/professional-cmake/).
+- Jason Turner's [C++ Weekly - Intro to CMake](https://www.youtube.com/watch?v=HPMvU64RUTY) is a good introduction.
+- [CMake's documentation](https://cmake.org/cmake/help/latest/)
+- [CMake's "Mastering CMake" book](https://cmake.org/cmake/help/book/mastering-cmake/)
+- ["Professional CMake"](https://crascit.com/professional-cmake/)- a $30 book by Craig Scott (one of the maintainers of CMake).
 
 ## How does CMake Tools work with C and C++ IntelliSense?
 


### PR DESCRIPTION
### This changes documentation

The following changes are proposed:

fix cmake docs link + link to "Professional Cmake"

## The purpose of this change

## Other Notes/Information

I haven't yet purchased "Professional CMake" myself, but I've heard good things about it on r/cpp, and I've found Craig's free teaching materials very helpful.
