### PR TITLE
resolving sourceDirectory relative paths in multi-root projects

### DIFF
--- a/src/cmakeTools.ts
+++ b/src/cmakeTools.ts
@@ -636,19 +636,21 @@ export class CMakeTools implements api.CMakeToolsAPI {
                             };
                             const cmakeListsFile = await vscode.window.showOpenDialog(openOpts);
                             if (cmakeListsFile) {
+                                // Keep the absolute path for CMakeLists.txt files that are located outside of the workspace folder.
                                 selectedFile = cmakeListsFile[0].fsPath;
                             }
                         } else {
-                            selectedFile = selection.fullPath;
+                            // Keep the relative path for CMakeLists.txt files that are located inside of the workspace folder.
+                            selectedFile = selection.label;
                         }
                         if (selectedFile) {
-                            const relPath = util.getRelativePath(selectedFile, this.folder.uri.fsPath);
-                            void vscode.workspace.getConfiguration('cmake', this.folder.uri).update("sourceDirectory", relPath);
+                            const newSourceDirectory = path.dirname(selectedFile);
+                            void vscode.workspace.getConfiguration('cmake', this.folder.uri).update("sourceDirectory", newSourceDirectory);
                             if (config) {
                                 // Updating sourceDirectory here, at the beginning of the configure process,
                                 // doesn't need to fire the settings change event (which would trigger unnecessarily
                                 // another immediate configure, which will be blocked anyway).
-                                config.updatePartial({ sourceDirectory: relPath }, false);
+                                config.updatePartial({ sourceDirectory: newSourceDirectory }, false);
 
                                 // Since the source directory is set via a file open dialog tuned to CMakeLists.txt,
                                 // we know that it exists and we don't need any other additional checks on its value,

--- a/src/cmakeTools.ts
+++ b/src/cmakeTools.ts
@@ -641,6 +641,7 @@ export class CMakeTools implements api.CMakeToolsAPI {
                             }
                         } else {
                             // Keep the relative path for CMakeLists.txt files that are located inside of the workspace folder.
+                            // selection.label is the relative path to the selected CMakeLists.txt.
                             selectedFile = selection.label;
                         }
                         if (selectedFile) {


### PR DESCRIPTION
In a multi-root project, if we locate a `CMakeLists.txt` that is outside of the `workspaceFolder`, the relative path that is being created will be resolved incorrectly later on (the path looks something like `"${workspaceFolder}/../../root2"`). 
So I changed the code to keep the absolute path for` CMakeLists.txt` files that are located outside of the `workspaceFolder`, and only use relative-path when `CMakeLists.txt` is inside the `workspaceFolder`.

The main source of the issue is not this part of the code, but this change avoids the error. 