### PR TITLE
Update documents for tasks

### DIFF
--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -3,7 +3,7 @@ You can create a configure task from the VS Code command pallette by running the
 
 ![Configure a task](images/configure_task.png)
 
-By selecting "CMake: configure" template, if you are not using presets, this task will be generated in *tasks.json* file: 
+By selecting "CMake: configure" template, if you are not using presets, this task will be generated in `tasks.json` file: 
 
 
 ```json
@@ -19,9 +19,9 @@ By selecting "CMake: configure" template, if you are not using presets, this tas
     }
 ```
 
-**Note**: When running this task, the configure settings (including configure options and configure environment) defined in *settings.json* will be used.
+**Note**: When running this task, the configure settings (including configure options and configure environment) defined in `settings.json` will be used.
 
-However, if you are using presets, this task will be generated in *tasks.json* file:
+However, if you are using presets, this task will be generated in `tasks.json` file:
 
 ```json
     {
@@ -34,7 +34,7 @@ However, if you are using presets, this task will be generated in *tasks.json* f
 ```
 You can modify "preset" option with your chosen configure preset name.
 
-**Note**: When running this task, the configure settings defined in *CMakeUserPresets.json*/*CMakePresets.json* will be used.
+**Note**: When running this task, the configure settings defined in `CMakeUserPresets.json`/`CMakePresets.json` will be used.
 
 **Note**: If you are using a preset other than the active configure preset, you can change this settings in *settings.json* to avoid re-configure based on the active preset when editing.
 
@@ -45,7 +45,7 @@ You can modify "preset" option with your chosen configure preset name.
 # Build with CMake Tools tasks
 Similarly, You can create a build task from the VS Code command pallette by running the **Tasks: Configure task** command.
 
-By selecting "CMake: build" template, if you are not using presets, this task will be generated in *tasks.json* file: 
+By selecting "CMake: build" template, if you are not using presets, this task will be generated in `tasks.json` file: 
 
 ```json
     {
@@ -60,9 +60,9 @@ By selecting "CMake: build" template, if you are not using presets, this task wi
         "detail": "CMake template build task"
     }
 ```
-**Note**: When running this task, the build settings (including buildArgs and build environment) defined in *settings.json* will be used.
+**Note**: When running this task, the build settings (including buildArgs and build environment) defined in `settings.json` will be used.
 
-However, if you are using presets, this task will be generated in *tasks.json* file:
+However, if you are using presets, this task will be generated in `tasks.json` file:
 
 ```json
     {
@@ -74,7 +74,7 @@ However, if you are using presets, this task will be generated in *tasks.json* f
     }
 ```
 
-**Note**: When running this task, the configure settings defined in *CMakeUserPresets.json*/*CMakePresets.json* will be used.
+**Note**: When running this task, the configure settings defined in `CMakeUserPresets.json`/`CMakePresets.json` will be used.
 
 You can chain a configure task to your build task by adding this to your task's definition:
 
@@ -87,7 +87,7 @@ You can chain a configure task to your build task by adding this to your task's 
 # Install with CMake Tools tasks
 Similarly, You can create an install task from the VS Code command pallette by running the **Tasks: Configure task** command.
 
-By selecting "CMake: install" template, this task will be generated in *tasks.json* file:
+By selecting "CMake: install" template, this task will be generated in `tasks.json` file:
 
 ```json
     {
@@ -102,7 +102,7 @@ By selecting "CMake: install" template, this task will be generated in *tasks.js
 # Test with CMake Tools tasks
 Similarly, You can create a test task from the VS Code command pallette by running the **Tasks: Configure task** command.
 
-By selecting "CMake: test" template, if you are not using presets, this task will be generated in *tasks.json* file: 
+By selecting "CMake: test" template, if you are not using presets, this task will be generated in `tasks.json` file: 
 
 ```json
     {
@@ -112,9 +112,9 @@ By selecting "CMake: test" template, if you are not using presets, this task wil
         "detail": "CMake template test task"
     }
 ```
-**Note**: When running this task, the test settings defined in *settings.json* will be used.
+**Note**: When running this task, the test settings defined in `settings.json` will be used.
 
-However, if you are using presets, this task will be generated in *tasks.json* file:
+However, if you are using presets, this task will be generated in `tasks.json` file:
 
 ```json
     {
@@ -126,12 +126,12 @@ However, if you are using presets, this task will be generated in *tasks.json* f
     }
 ```
 
-**Note**: When running this task, the test settings defined in *CMakeUserPresets.json*/*CMakePresets.json* will be used.
+**Note**: When running this task, the test settings defined in `CMakeUserPresets.json`/`CMakePresets.json` will be used.
 
 # Clean/Clean-rebuild with CMake Tools tasks
 Similarly, you can create a Clean/Clean-rebuild task from the VS Code command pallette by running the **Tasks: Configure task** command.
 
-By selecting "CMake: clean" or "CMake: clean rebuild" template, these task will be generated in *tasks.json* file:
+By selecting "CMake: clean" or "CMake: clean rebuild" template, these task will be generated in `tasks.json` file:
 
 ```json
     {

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -3,7 +3,7 @@ You can create a configure task from the VS Code command pallette by running the
 
 ![Configure a task](images/configure_task.png)
 
-By selecting "CMake: configure" template, if you are not using presets, this task will be generated in tasks.json file: 
+By selecting "CMake: configure" template, if you are not using presets, this task will be generated in *tasks.json* file: 
 
 
 ```json
@@ -19,9 +19,9 @@ By selecting "CMake: configure" template, if you are not using presets, this tas
     }
 ```
 
-Note: When running this task, the configure settings (including configure options and configure environment) defined in settings.json will be used.
+**Note**: When running this task, the configure settings (including configure options and configure environment) defined in *settings.json* will be used.
 
-However, if you are using presets, this task will be generated in tasks.json file:
+However, if you are using presets, this task will be generated in *tasks.json* file:
 
 ```json
     {
@@ -33,13 +33,19 @@ However, if you are using presets, this task will be generated in tasks.json fil
     }
 ```
 You can modify "preset" option with your chosen configure preset name.
-Note: When running this task, the configure settings defined in CMakeUserPresets.json/CMakePresets.json will be used.
 
+**Note**: When running this task, the configure settings defined in *CMakeUserPresets.json*/*CMakePresets.json* will be used.
+
+**Note**: If you are using a preset other than the active configure preset, you can change this settings in *settings.json* to avoid re-configure based on the active preset when editing.
+
+```json
+    "cmake.configureOnEdit": false
+```
 
 # Build with CMake Tools tasks
 Similarly, You can create a build task from the VS Code command pallette by running the **Tasks: Configure task** command.
 
-By selecting "CMake: build" template, if you are not using presets, this task will be generated in tasks.json file: 
+By selecting "CMake: build" template, if you are not using presets, this task will be generated in *tasks.json* file: 
 
 ```json
     {
@@ -54,9 +60,9 @@ By selecting "CMake: build" template, if you are not using presets, this task wi
         "detail": "CMake template build task"
     }
 ```
-Note: When running this task, the build settings (including buildArgs and build environment) defined in settings.json will be used.
+**Note**: When running this task, the build settings (including buildArgs and build environment) defined in *settings.json* will be used.
 
-However, if you are using presets, this task will be generated in tasks.json file:
+However, if you are using presets, this task will be generated in *tasks.json* file:
 
 ```json
     {
@@ -68,7 +74,7 @@ However, if you are using presets, this task will be generated in tasks.json fil
     }
 ```
 
-Note: When running this task, the configure settings defined in CMakeUserPresets.json/CMakePresets.json will be used.
+**Note**: When running this task, the configure settings defined in *CMakeUserPresets.json*/*CMakePresets.json* will be used.
 
 You can chain a configure task to your build task by adding this to your task's definition:
 
@@ -81,7 +87,7 @@ You can chain a configure task to your build task by adding this to your task's 
 # Install with CMake Tools tasks
 Similarly, You can create an install task from the VS Code command pallette by running the **Tasks: Configure task** command.
 
-By selecting "CMake: install" template, this task will be generated in tasks.json file:
+By selecting "CMake: install" template, this task will be generated in *tasks.json* file:
 
 ```json
     {
@@ -96,7 +102,7 @@ By selecting "CMake: install" template, this task will be generated in tasks.jso
 # Test with CMake Tools tasks
 Similarly, You can create a test task from the VS Code command pallette by running the **Tasks: Configure task** command.
 
-By selecting "CMake: test" template, if you are not using presets, this task will be generated in tasks.json file: 
+By selecting "CMake: test" template, if you are not using presets, this task will be generated in *tasks.json* file: 
 
 ```json
     {
@@ -106,9 +112,9 @@ By selecting "CMake: test" template, if you are not using presets, this task wil
         "detail": "CMake template test task"
     }
 ```
-Note: When running this task, the test settings defined in settings.json will be used.
+**Note**: When running this task, the test settings defined in *settings.json* will be used.
 
-However, if you are using presets, this task will be generated in tasks.json file:
+However, if you are using presets, this task will be generated in *tasks.json* file:
 
 ```json
     {
@@ -120,12 +126,12 @@ However, if you are using presets, this task will be generated in tasks.json fil
     }
 ```
 
-Note: When running this task, the test settings defined in CMakeUserPresets.json/CMakePresets.json will be used.
+**Note**: When running this task, the test settings defined in *CMakeUserPresets.json*/*CMakePresets.json* will be used.
 
 # Clean/Clean-rebuild with CMake Tools tasks
 Similarly, you can create a Clean/Clean-rebuild task from the VS Code command pallette by running the **Tasks: Configure task** command.
 
-By selecting "CMake: clean" or "CMake: clean rebuild" template, these task will be generated in tasks.json file:
+By selecting "CMake: clean" or "CMake: clean rebuild" template, these task will be generated in *tasks.json* file:
 
 ```json
     {
@@ -141,3 +147,5 @@ By selecting "CMake: clean" or "CMake: clean rebuild" template, these task will 
         "detail": "CMake template clean rebuild task"
     }
 ```
+
+**Note**: Currently, if you are using presets, the clean task is only available for the active build preset.


### PR DESCRIPTION
This note is added:

**Note**: If you are using a preset other than the active configure preset, you can change this settings in *settings.json* to avoid re-configure based on the active preset when editing.

```json
    "cmake.configureOnEdit": false
```