### PR TITLE
Enhance config, install, clean tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ Improvements:
 - Support for presets version 4. [#2492](https://github.com/microsoft/vscode-cmake-tools/issues/2492) [@chausner](https://github.com/chausner)
 - Triggering reconfigure after changes are made to included files. [#2526](https://github.com/microsoft/vscode-cmake-tools/issues/2526) [@chausner](https://github.com/chausner)
 - Add target name to terminal window name for launch. [#2613](https://github.com/microsoft/vscode-cmake-tools/issues/2613)
-- Add support for "preset" and "env" in task provider. [#2636](https://github.com/microsoft/vscode-cmake-tools/issues/2636) [#2553](https://github.com/microsoft/vscode-cmake-tools/issues/2553)
+- Add support for "preset" and "env" in task provider. [#2636](https://github.com/microsoft/vscode-cmake-tools/issues/2636) [#2553](https://github.com/microsoft/vscode-cmake-tools/issues/2553) [#2714](https://github.com/microsoft/vscode-cmake-tools/issues/2714) [#2706](https://github.com/microsoft/vscode-cmake-tools/issues/2706)
 - Add Craig Scott's "Professional CMake" book to the list of resources in doc/faq.md for learning CMake. [#2679](https://github.com/microsoft/vscode-cmake-tools/pull/2679) [@david-fong](https://github.com/david-fong)
 
 Bug Fixes:

--- a/src/cmakeTaskProvider.ts
+++ b/src/cmakeTaskProvider.ts
@@ -315,7 +315,7 @@ export class CustomBuildTaskTerminal implements vscode.Pseudoterminal, proc.Outp
                 const buildPreset: preset.BuildPreset | undefined = await cmakeTools?.expandBuildPresetbyName(this.preset);
                 if (!buildPreset) {
                     log.debug(localize("build.preset.not.found", 'Build preset not found.'));
-                    this.writeEmitter.fire(localize("build.failed", "Build preset {0} not found. Build failed.", this.preset) + endOfLine);
+                    this.writeEmitter.fire(localize("build.failed", "Build preset {0} not found. {1} failed.", this.preset, taskName) + endOfLine);
                     this.closeEmitter.fire(-1);
                     return;
                 }
@@ -335,26 +335,26 @@ export class CustomBuildTaskTerminal implements vscode.Pseudoterminal, proc.Outp
             }
         } else {
             log.debug(localize("cmake.driver.not.found", 'CMake driver not found.'));
-            this.writeEmitter.fire(localize("task.failed", "{0} failed.", taskName) + endOfLine);
+            this.writeEmitter.fire(localize("build.failed", "{0} failed.", taskName) + endOfLine);
             this.closeEmitter.fire(-1);
             return;
         }
-        this.writeEmitter.fire(localize("task.started", "{0} task started....", taskName) + endOfLine);
+        this.writeEmitter.fire(localize("build.started", "{0} task started....", taskName) + endOfLine);
         this.writeEmitter.fire(proc.buildCmdStr(cmakePath, args) + endOfLine);
         try {
             const result: proc.ExecutionResult = await proc.execute(cmakePath, args, this, this.options).result;
             if (result.retc) {
-                this.writeEmitter.fire(localize("task.finished.with.error", "{0} finished with error(s).", taskName) + endOfLine);
+                this.writeEmitter.fire(localize("build.finished.with.error", "{0} finished with error(s).", taskName) + endOfLine);
             } else if (result.stderr && !result.stdout) {
-                this.writeEmitter.fire(localize("task.finished.with.warnings", "{0} finished with warning(s).", taskName) + endOfLine);
+                this.writeEmitter.fire(localize("build.finished.with.warnings", "{0} finished with warning(s).", taskName) + endOfLine);
             } else if (result.stdout && result.stdout.includes("warning")) {
-                this.writeEmitter.fire(localize("task.finished.with.warnings", "{0} finished with warning(s).", taskName) + endOfLine);
+                this.writeEmitter.fire(localize("build.finished.with.warnings", "{0} finished with warning(s).", taskName) + endOfLine);
             } else {
-                this.writeEmitter.fire(localize("task.finished.successfully", "{0} finished successfully.", taskName) + endOfLine);
+                this.writeEmitter.fire(localize("build.finished.successfully", "{0} finished successfully.", taskName) + endOfLine);
             }
             this.closeEmitter.fire(0);
         } catch {
-            this.writeEmitter.fire(localize("task.finished.with.error", "{0} finished with error(s).", taskName) + endOfLine);
+            this.writeEmitter.fire(localize("build.finished.with.error", "{0} finished with error(s).", taskName) + endOfLine);
             this.closeEmitter.fire(-1);
         }
     }

--- a/src/cmakeTaskProvider.ts
+++ b/src/cmakeTaskProvider.ts
@@ -182,16 +182,16 @@ export class CustomBuildTaskTerminal implements vscode.Pseudoterminal, proc.Outp
                 await this.runConfigTask();
                 break;
             case CommandType.build:
-                await this.runBuildTask();
+                await this.runBuildTask(CommandType.build);
                 break;
             case CommandType.install:
-                await this.runInstallTask();
+                await this.runBuildTask(CommandType.install);
                 break;
             case CommandType.test:
                 await this.runTestTask();
                 break;
             case CommandType.clean:
-                await this.runCleanTask();
+                await this.runBuildTask(CommandType.clean);
                 break;
             case CommandType.cleanRebuild:
                 await this.runCleanRebuildTask();
@@ -272,7 +272,7 @@ export class CustomBuildTaskTerminal implements vscode.Pseudoterminal, proc.Outp
 
             this.preset = await this.resolvePresetName(this.preset, cmakeTools.useCMakePresets, CommandType.config);
             const configPreset: preset.ConfigurePreset | undefined = await cmakeTools?.expandConfigPresetbyName(this.preset);
-            const result = await cmakeDriver.configure(ConfigureTrigger.taskProvider, [], this, false, false, configPreset);
+            const result = await cmakeDriver.configure(ConfigureTrigger.taskProvider, [], this, false, false, configPreset, this.options);
             if (result === undefined || result === null) {
                 this.writeEmitter.fire(localize('configure.terminated', 'Configure was terminated') + endOfLine);
                 this.closeEmitter.fire(-1);
@@ -287,7 +287,16 @@ export class CustomBuildTaskTerminal implements vscode.Pseudoterminal, proc.Outp
         }
     }
 
-    private async runBuildTask(): Promise<any> {
+    private async runBuildTask(commandType: CommandType): Promise<any> {
+        let targets = this.targets;
+        const taskName: string = localizeCommandType(commandType);
+        if (commandType === CommandType.install) {
+            this.checkTargets(true);
+            targets = ['install'];
+        } else if (commandType === CommandType.clean) {
+            this.checkTargets(true);
+            targets = ['clean'];
+        }
         let fullCommand: proc.BuildCommand | null;
         let args: string[] = [];
         const cmakeTools: CMakeTools | undefined = this.getCMakeTools();
@@ -310,14 +319,14 @@ export class CustomBuildTaskTerminal implements vscode.Pseudoterminal, proc.Outp
                     this.closeEmitter.fire(-1);
                     return;
                 }
-                fullCommand = await cmakeDriver.generateBuildCommandFromPreset(buildPreset, this.targets);
+                fullCommand = await cmakeDriver.generateBuildCommandFromPreset(buildPreset, targets);
                 if (fullCommand) {
                     cmakePath = fullCommand.command;
                     args = fullCommand.args || [];
                     this.options.environment = EnvironmentUtils.merge([ fullCommand.build_env, this.options.environment], {preserveNull: true});
                 }
             } else {
-                fullCommand = await cmakeDriver.generateBuildCommandFromSettings(this.targets);
+                fullCommand = await cmakeDriver.generateBuildCommandFromSettings(targets);
                 if (fullCommand) {
                     cmakePath = fullCommand.command;
                     args = fullCommand.args ? fullCommand.args : [];
@@ -326,44 +335,27 @@ export class CustomBuildTaskTerminal implements vscode.Pseudoterminal, proc.Outp
             }
         } else {
             log.debug(localize("cmake.driver.not.found", 'CMake driver not found.'));
-            this.writeEmitter.fire(localize("build.failed", "Build failed.") + endOfLine);
+            this.writeEmitter.fire(localize("task.failed", "{0} failed.", taskName) + endOfLine);
             this.closeEmitter.fire(-1);
             return;
         }
-        this.writeEmitter.fire(localize("build.started", "Build task started....") + endOfLine);
+        this.writeEmitter.fire(localize("task.started", "{0} task started....", taskName) + endOfLine);
         this.writeEmitter.fire(proc.buildCmdStr(cmakePath, args) + endOfLine);
         try {
             const result: proc.ExecutionResult = await proc.execute(cmakePath, args, this, this.options).result;
             if (result.retc) {
-                this.writeEmitter.fire(localize("build.finished.with.error", "Build finished with error(s).") + endOfLine);
+                this.writeEmitter.fire(localize("task.finished.with.error", "{0} finished with error(s).", taskName) + endOfLine);
             } else if (result.stderr && !result.stdout) {
-                this.writeEmitter.fire(localize("build.finished.with.warnings", "Build finished with warning(s).") + endOfLine);
+                this.writeEmitter.fire(localize("task.finished.with.warnings", "{0} finished with warning(s).", taskName) + endOfLine);
             } else if (result.stdout && result.stdout.includes("warning")) {
-                this.writeEmitter.fire(localize("build.finished.with.warnings", "Build finished with warning(s).") + endOfLine);
+                this.writeEmitter.fire(localize("task.finished.with.warnings", "{0} finished with warning(s).", taskName) + endOfLine);
             } else {
-                this.writeEmitter.fire(localize("build.finished.successfully", "Build finished successfully.") + endOfLine);
+                this.writeEmitter.fire(localize("task.finished.successfully", "{0} finished successfully.", taskName) + endOfLine);
             }
             this.closeEmitter.fire(0);
         } catch {
-            this.writeEmitter.fire(localize("build.finished.with.error", "Build finished with error(s).") + endOfLine);
+            this.writeEmitter.fire(localize("task.finished.with.error", "{0} finished with error(s).", taskName) + endOfLine);
             this.closeEmitter.fire(-1);
-        }
-    }
-
-    private async runInstallTask(): Promise<any> {
-        this.writeEmitter.fire(localize("install.started", "Install task started...") + endOfLine);
-        this.checkTargets(true);
-        const cmakeTools: CMakeTools | undefined = this.getCMakeTools();
-        if (!cmakeTools) {
-            return;
-        }
-        const result: number | undefined =  await cmakeTools.runBuild(['install'], false, this);
-        if (result === undefined) {
-            this.writeEmitter.fire(localize('install.terminated', 'Install was terminated') + endOfLine);
-            this.closeEmitter.fire(-1);
-        } else {
-            this.writeEmitter.fire(localize('install.finished.with.code', 'Install finished with return code {0}', result) + endOfLine);
-            this.closeEmitter.fire(result);
         }
     }
 
@@ -402,28 +394,10 @@ export class CustomBuildTaskTerminal implements vscode.Pseudoterminal, proc.Outp
         }
     }
 
-    private async runCleanTask(ignoreTargets: boolean = true): Promise<any> {
-        this.writeEmitter.fire(localize("clean.started", "Clean task started...") + endOfLine);
-        this.checkTargets(ignoreTargets);
-        const cmakeTools: CMakeTools | undefined = this.getCMakeTools();
-        if (!cmakeTools) {
-            return;
-        }
-        const result: number | undefined =  await cmakeTools.runBuild(['clean'], false, this);
-        if (result === undefined || result !== 0) {
-            this.writeEmitter.fire(localize("clean.failed", "Clean task failed.") + endOfLine);
-            this.closeEmitter.fire(-1);
-        } else {
-            this.writeEmitter.fire(localize("clean.finished.with.code", "Clean finished with return code {0}", result) + endOfLine);
-            this.closeEmitter.fire(result);
-        }
-        return result;
-    }
-
     private async runCleanRebuildTask(): Promise<any> {
-        const cleanResult = await this.runCleanTask(false);
+        const cleanResult = await this.runBuildTask(CommandType.clean);
         if (cleanResult === 0) {
-            await this.runBuildTask();
+            await this.runBuildTask(CommandType.build);
         }
     }
 }

--- a/src/drivers/cmakeLegacyDriver.ts
+++ b/src/drivers/cmakeLegacyDriver.ts
@@ -76,7 +76,7 @@ export class CMakeLegacyDriver extends CMakeDriver {
         this._cacheWatcher.dispose();
     }
 
-    async doConfigure(args_: string[], outputConsumer?: proc.OutputConsumer, showCommandOnly?: boolean, configurePreset?: ConfigurePreset | null): Promise<number> {
+    async doConfigure(args_: string[], outputConsumer?: proc.OutputConsumer, showCommandOnly?: boolean, configurePreset?: ConfigurePreset | null, options?: proc.ExecutionOptions): Promise<number> {
         // Ensure the binary directory exists
         const binaryDir = configurePreset?.binaryDir ?? this.binaryDir;
         await fs.mkdir_p(binaryDir);
@@ -113,19 +113,19 @@ export class CMakeLegacyDriver extends CMakeDriver {
             return 0;
         } else {
             log.debug(localize('invoking.cmake.with.arguments', 'Invoking CMake {0} with arguments {1}', cmake, JSON.stringify(args)));
-            const res = await this.executeCommand(cmake, args, outputConsumer, {
-                environment: await this.getConfigureEnvironment(configurePreset),
-                cwd: binaryDir
+            const result = await this.executeCommand(cmake, args, outputConsumer, {
+                environment: await this.getConfigureEnvironment(configurePreset, options?.environment),
+                cwd: options?.cwd ?? binaryDir
             }).result;
-            log.trace(res.stderr);
-            log.trace(res.stdout);
-            if (res.retc === 0 && !configurePreset) {
+            log.trace(result.stderr);
+            log.trace(result.stdout);
+            if (result.retc === 0 && !configurePreset) {
                 this._needsReconfigure = false;
             }
             if (!configurePreset) {
                 await this._reloadPostConfigure();
             }
-            return res.retc === null ? -1 : res.retc;
+            return result.retc === null ? -1 : result.retc;
         }
     }
 

--- a/src/drivers/cmakeServerDriver.ts
+++ b/src/drivers/cmakeServerDriver.ts
@@ -154,7 +154,7 @@ export class CMakeServerDriver extends CMakeDriver {
         })();
     }
 
-    protected async doConfigure(args: string[], consumer?: proc.OutputConsumer, showCommandOnly?: boolean, configurePreset?: ConfigurePreset | null) {
+    protected async doConfigure(args: string[], consumer?: proc.OutputConsumer, showCommandOnly?: boolean, configurePreset?: ConfigurePreset | null, _options?: proc.ExecutionOptions) {
         await this._clientChangeInProgress;
         const cl = await this.getClient();
         const sub = this.onMessage(msg => {


### PR DESCRIPTION
Add "`env`" variables to "`configure`" and "`install`" tasks: https://github.com/microsoft/vscode-cmake-tools/issues/2714
Add "`preset`" to "`Install`" and "`clean`" task: https://github.com/microsoft/vscode-cmake-tools/issues/2706

(Need to test)
Question: how will Cmake Server be changed?