### PR TITLE
update Docs on Clean and Install task

### DIFF
--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -84,21 +84,6 @@ You can chain a configure task to your build task by adding this to your task's 
         ]
 ```
 
-# Install with CMake Tools tasks
-Similarly, You can create an install task from the VS Code command pallette by running the **Tasks: Configure task** command.
-
-By selecting "CMake: install" template, this task will be generated in `tasks.json` file:
-
-```json
-    {
-        "type": "cmake",
-        "label": "CMake: install",
-        "command": "install",
-        "problemMatcher": [],
-        "detail": "CMake template install task"
-    }
-```
-
 # Test with CMake Tools tasks
 Similarly, You can create a test task from the VS Code command pallette by running the **Tasks: Configure task** command.
 
@@ -128,12 +113,18 @@ However, if you are using presets, this task will be generated in `tasks.json` f
 
 **Note**: When running this task, the test settings defined in `CMakeUserPresets.json`/`CMakePresets.json` will be used.
 
-# Clean/Clean-rebuild with CMake Tools tasks
-Similarly, you can create a Clean/Clean-rebuild task from the VS Code command pallette by running the **Tasks: Configure task** command.
+# Install/Clean/Clean-rebuild with CMake Tools tasks
+Similarly, you can create a Install/Clean/Clean-rebuild task from the VS Code command pallette by running the **Tasks: Configure task** command.
 
-By selecting "CMake: clean" or "CMake: clean rebuild" template, these task will be generated in `tasks.json` file:
+By selecting "CMake: install", "CMake: clean" or "CMake: clean rebuild" template, these tasks will be generated in `tasks.json` file:
 
 ```json
+    {
+        "type": "cmake",
+        "label": "CMake: install",
+        "command": "install",
+        "detail": "CMake template install task"
+    },
     {
         "type": "cmake",
         "label": "CMake: clean",
@@ -147,5 +138,30 @@ By selecting "CMake: clean" or "CMake: clean rebuild" template, these task will 
         "detail": "CMake template clean rebuild task"
     }
 ```
+However, if you are using presets, these tasks will be generated in `tasks.json` file.
 
-**Note**: Currently, if you are using presets, the clean task is only available for the active build preset.
+**Note**: Install, Clean, and Clean-rebuild tasks will run based on the build preset settings.
+
+```json
+    {
+        "type": "cmake",
+        "label": "CMake: install",
+        "command": "install",
+        "preset": "${command:cmake.activeBuildPresetName}",
+        "detail": "CMake template install task"
+    },
+    {
+        "type": "cmake",
+        "label": "CMake: clean",
+        "command": "clean",
+        "preset": "${command:cmake.activeBuildPresetName}",
+        "detail": "CMake template clean task"
+    },
+    {
+        "type": "cmake",
+        "label": "CMake: clean rebuild",
+        "command": "cleanRebuild",
+        "preset": "${command:cmake.activeBuildPresetName}",
+        "detail": "CMake template clean rebuild task"
+    }
+```

--- a/package.json
+++ b/package.json
@@ -2060,11 +2060,6 @@
     "extensionTestsMultiRoot": "yarn run pretest && node ./out/test/extension-tests/multi-root-UI/runTest.js",
     "backendTests": "node ./node_modules/mocha/bin/_mocha -u tdd --timeout 999999 --colors -r ts-node/register -r tsconfig-paths/register ./test/backend-unit-tests/**/*.test.ts"
   },
-  "husky": {
-    "hooks": {
-      "pre-push": "yarn run lint"
-    }
-  },
   "devDependencies": {
     "@octokit/rest": "^18.1.1",
     "@types/ajv": "^0.0.5",

--- a/src/cmakeTaskProvider.ts
+++ b/src/cmakeTaskProvider.ts
@@ -323,7 +323,7 @@ export class CustomBuildTaskTerminal implements vscode.Pseudoterminal, proc.Outp
                 const buildPreset: preset.BuildPreset | undefined = await cmakeTools?.expandBuildPresetbyName(this.preset);
                 if (!buildPreset) {
                     log.debug(localize("build.preset.not.found", 'Build preset not found.'));
-                    this.writeEmitter.fire(localize("build.failed", "Build preset {0} not found. {1} failed.", this.preset, taskName) + endOfLine);
+                    this.writeEmitter.fire(localize("build.no.preset.failed", "Build preset {0} not found. {1} failed.", this.preset, taskName) + endOfLine);
                     if (doCloseEmitter) {
                         this.closeEmitter.fire(-1);
                     }

--- a/src/cmakeTaskProvider.ts
+++ b/src/cmakeTaskProvider.ts
@@ -77,6 +77,14 @@ async function getDefaultPresetName(commandType: CommandType, resolve: boolean =
             result = resolve ? await vscode.commands.executeCommand("cmake.activeBuildPresetName", []) as string :
                 "${command:cmake.activeBuildPresetName}";
             break;
+        case CommandType.install:
+            result = resolve ? await vscode.commands.executeCommand("cmake.activeBuildPresetName", []) as string :
+                "${command:cmake.activeBuildPresetName}";
+            break;
+        case CommandType.clean:
+            result = resolve ? await vscode.commands.executeCommand("cmake.activeBuildPresetName", []) as string :
+                "${command:cmake.activeBuildPresetName}";
+            break;
         case CommandType.cleanRebuild:
             result = resolve ? await vscode.commands.executeCommand("cmake.activeBuildPresetName", []) as string :
                 "${command:cmake.activeBuildPresetName}";
@@ -287,7 +295,7 @@ export class CustomBuildTaskTerminal implements vscode.Pseudoterminal, proc.Outp
         }
     }
 
-    private async runBuildTask(commandType: CommandType): Promise<any> {
+    private async runBuildTask(commandType: CommandType, doCloseEmitter: boolean = true): Promise<any> {
         let targets = this.targets;
         const taskName: string = localizeCommandType(commandType);
         if (commandType === CommandType.install) {
@@ -316,8 +324,10 @@ export class CustomBuildTaskTerminal implements vscode.Pseudoterminal, proc.Outp
                 if (!buildPreset) {
                     log.debug(localize("build.preset.not.found", 'Build preset not found.'));
                     this.writeEmitter.fire(localize("build.failed", "Build preset {0} not found. {1} failed.", this.preset, taskName) + endOfLine);
-                    this.closeEmitter.fire(-1);
-                    return;
+                    if (doCloseEmitter) {
+                        this.closeEmitter.fire(-1);
+                    }
+                    return -1;
                 }
                 fullCommand = await cmakeDriver.generateBuildCommandFromPreset(buildPreset, targets);
                 if (fullCommand) {
@@ -336,8 +346,10 @@ export class CustomBuildTaskTerminal implements vscode.Pseudoterminal, proc.Outp
         } else {
             log.debug(localize("cmake.driver.not.found", 'CMake driver not found.'));
             this.writeEmitter.fire(localize("build.failed", "{0} failed.", taskName) + endOfLine);
-            this.closeEmitter.fire(-1);
-            return;
+            if (doCloseEmitter) {
+                this.closeEmitter.fire(-1);
+            }
+            return -1;
         }
         this.writeEmitter.fire(localize("build.started", "{0} task started....", taskName) + endOfLine);
         this.writeEmitter.fire(proc.buildCmdStr(cmakePath, args) + endOfLine);
@@ -352,10 +364,16 @@ export class CustomBuildTaskTerminal implements vscode.Pseudoterminal, proc.Outp
             } else {
                 this.writeEmitter.fire(localize("build.finished.successfully", "{0} finished successfully.", taskName) + endOfLine);
             }
-            this.closeEmitter.fire(0);
+            if (doCloseEmitter) {
+                this.closeEmitter.fire(0);
+            }
+            return 0;
         } catch {
             this.writeEmitter.fire(localize("build.finished.with.error", "{0} finished with error(s).", taskName) + endOfLine);
-            this.closeEmitter.fire(-1);
+            if (doCloseEmitter) {
+                this.closeEmitter.fire(-1);
+            }
+            return -1;
         }
     }
 
@@ -395,10 +413,11 @@ export class CustomBuildTaskTerminal implements vscode.Pseudoterminal, proc.Outp
     }
 
     private async runCleanRebuildTask(): Promise<any> {
-        const cleanResult = await this.runBuildTask(CommandType.clean);
+        const cleanResult = await this.runBuildTask(CommandType.clean, false);
         if (cleanResult === 0) {
             await this.runBuildTask(CommandType.build);
         }
+        this.closeEmitter.fire(cleanResult);
     }
 }
 

--- a/src/cmakeTaskProvider.ts
+++ b/src/cmakeTaskProvider.ts
@@ -416,8 +416,9 @@ export class CustomBuildTaskTerminal implements vscode.Pseudoterminal, proc.Outp
         const cleanResult = await this.runBuildTask(CommandType.clean, false);
         if (cleanResult === 0) {
             await this.runBuildTask(CommandType.build);
+        } else {
+            this.closeEmitter.fire(cleanResult);
         }
-        this.closeEmitter.fire(cleanResult);
     }
 }
 


### PR DESCRIPTION
I added the default preset for the install and clean tasks.
clean-rebuild task needed a fix too. Clean task was closing the emitter and the result of build wouldn't be shown on screen after that.