### PR TITLE
Show presets with hidden parent preset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 Improvements:
 - Add a setting to disable reading `compile_commands.json`. [#2586](https://github.com/microsoft/vscode-cmake-tools/issues/2586) [@xiaoyun94](https://github.com/xiaoyun94)
 
+Bug Fixes:
+- Show presets with hidden parent preset. [#2735](https://github.com/microsoft/vscode-cmake-tools/issues/2735)
+
 ## 1.12.26
 Improvements:
 - Support for presets version 4. [#2492](https://github.com/microsoft/vscode-cmake-tools/issues/2492) [@chausner](https://github.com/chausner)

--- a/src/presetsController.ts
+++ b/src/presetsController.ts
@@ -590,7 +590,7 @@ export class PresetsController {
         interface PresetItem extends vscode.QuickPickItem {
             preset: string;
         }
-        const presetsPool: preset.Preset[] = showHiddenPresets ? candidates : candidates.filter(_preset => !_preset.hidden && preset.evaluatePresetCondition(_preset, allPresets));
+        const presetsPool: preset.Preset[] = showHiddenPresets ? candidates : candidates.filter(_preset => !_preset.hidden && preset.evaluatePresetCondition(_preset, allPresets) !== undefined);
         const items: PresetItem[] = presetsPool.map(
             _preset => ({
                 label: _preset.displayName || _preset.name,


### PR DESCRIPTION

bugfix: https://github.com/microsoft/vscode-cmake-tools/issues/2735