### PR TITLE
fix(presets): support optional generator for configure presets >= v3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Improvements:
 - Resolve workspace variables in `cmake-kits.json`. [#2737](https://github.com/microsoft/vscode-cmake-tools/issues/2737)
 - Use upper case drive letters on Windows for `cmake.sourceDirectory`. [PR #2665](https://github.com/microsoft/vscode-cmake-tools/pull/2665) [@Danielmelody](https://github.com/Danielmelody)
 - Custom browse configuration should not include (redundant) per-file arguments. [#2645](https://github.com/microsoft/vscode-cmake-tools/issues/2645)
+- Support optional generator in `configurePresets` for version 3 and higher. [#2734](https://github.com/microsoft/vscode-cmake-tools/issues/2734) [@jochil](https://github.com/jochil)
 
 Bug Fixes:
 - Fix warning message that appears when using a default build preset with a multi-config generator. [#2353](https://github.com/microsoft/vscode-cmake-tools/issues/2353)

--- a/src/cmakeProject.ts
+++ b/src/cmakeProject.ts
@@ -199,20 +199,22 @@ export class CMakeProject implements api.CMakeToolsAPI {
             configurePreset,
             lightNormalizePath(this.folder.uri.fsPath || '.'),
             this.sourceDir,
-            this.getPreferredGeneratorName(),
             true);
         if (!expandedConfigurePreset) {
             log.error(localize('failed.resolve.config.preset', 'Failed to resolve configure preset: {0}', configurePreset));
             return undefined;
         }
-        if (!expandedConfigurePreset.binaryDir) {
-            log.error(localize('binaryDir.not.set.config.preset', '{0} is not set in configure preset: {1}', "\"binaryDir\"", configurePreset));
-            return undefined;
+        if (expandedConfigurePreset.__file && expandedConfigurePreset.__file.version <= 2) {
+            if (!expandedConfigurePreset.binaryDir) {
+                log.error(localize('binaryDir.not.set.config.preset', '{0} is not set in configure preset: {1}', "\"binaryDir\"", configurePreset));
+                return undefined;
+            }
+            if (!expandedConfigurePreset.generator) {
+                log.error(localize('generator.not.set.config.preset', '{0} is not set in configure preset: {1}', "\"generator\"", configurePreset));
+                return undefined;
+            }
         }
-        if (!expandedConfigurePreset.generator) {
-            log.error(localize('generator.not.set.config.preset', '{0} is not set in configure preset: {1}', "\"generator\"", configurePreset));
-            return undefined;
-        }
+
         return expandedConfigurePreset;
     }
 

--- a/src/drivers/cmakeFileApiDriver.ts
+++ b/src/drivers/cmakeFileApiDriver.ts
@@ -193,9 +193,6 @@ export class CMakeFileApiDriver extends CMakeDriver {
             await this._cleanPriorConfiguration();
         }
         await cb();
-        if (!this.generator) {
-            throw new NoGeneratorError();
-        }
     }
 
     doSetBuildPreset(cb: () => Promise<void>): Promise<void> {

--- a/test/extension-tests/single-root-UI/project-folder/CMakeUserPresets.json
+++ b/test/extension-tests/single-root-UI/project-folder/CMakeUserPresets.json
@@ -19,19 +19,31 @@
       }
     },
     {
-        "name": "WindowsUser1",
-        "description": "Sets generator, build and install directory, vcpkg",
-        "generator": "Visual Studio 16 2019",
-        "binaryDir": "${workspaceFolder}/build",
-        "cacheVariables": {
-          "CMAKE_BUILD_TYPE": "Debug",
-          "CMAKE_C_COMPILER": "cl.exe",
-          "CMAKE_CXX_COMPILER": "cl.exe"
-        },
-        "environment": {
-          "TEST_VARIANT_ENV": "0cbfb6ae-f2ec-4017-8ded-89df8759c502"
-        }
+      "name": "WindowsUser1",
+      "description": "Sets generator, build and install directory, vcpkg",
+      "generator": "Visual Studio 16 2019",
+      "binaryDir": "${workspaceFolder}/build",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug",
+        "CMAKE_C_COMPILER": "cl.exe",
+        "CMAKE_CXX_COMPILER": "cl.exe"
+      },
+      "environment": {
+        "TEST_VARIANT_ENV": "0cbfb6ae-f2ec-4017-8ded-89df8759c502"
       }
-  
+    },
+    {
+      "name": "NoGenerator",
+      "description": "Skips setting a generator",
+      "binaryDir": "${workspaceFolder}/build",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug",
+        "CMAKE_C_COMPILER": "gcc",
+        "CMAKE_CXX_COMPILER": "g++"
+      },
+      "environment": {
+        "TEST_VARIANT_ENV": "0cbfb6ae-f2ec-4017-8ded-89df8759c502"
+      }
+    }
   ]
 }

--- a/test/extension-tests/single-root-UI/test/configure-and-build-presets.test.ts
+++ b/test/extension-tests/single-root-UI/test/configure-and-build-presets.test.ts
@@ -57,6 +57,23 @@ suite('Build using Presets', () => {
         expect(testEnv.projectFolder.buildDirectory.isCMakeCachePresent).to.eql(true, 'no expected cache present');
     }).timeout(100000);
 
+    // from v3 on configure presets are not required to have a generator defined
+    test('Configure >=v3 no fallback generator', async () => {
+        await vscode.commands.executeCommand('cmake.setConfigurePreset', 'NoGenerator');
+        expect(await vscode.commands.executeCommand('cmake.showConfigureCommand')).to.be.eq(0);
+
+        // make sure that cmake configure was not invoked with the -G (Generator) flag by checking the logs
+        const logDocuments = vscode.workspace.textDocuments.filter(document => document.languageId === 'Log');
+        expect(logDocuments).lengthOf(1);
+        const lines = logDocuments[0].getText().split('\n');
+        for (const line of lines) {
+            if (line.startsWith('[cmakefileapi-driver]')) {
+                expect(line).not.contain('-G');
+            }
+        }
+
+    });
+
     test('Build', async () => {
         expect(await vscode.commands.executeCommand('cmake.build')).to.be.eq(0);
 


### PR DESCRIPTION
Fixes #2734

## This change addresses item #2734

### This changes behavior

The following changes are proposed:

- Adding a configure preset (>=v3) that has no generator as a test case
- Remove requirement and fallback for a generator if preset is >= v3


