### PR TITLE
Command palette should run proper task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Improvements:
 
 Bug Fixes:
 - Fix warning message that appears when using a default build preset with a multi-config generator. [#2353](https://github.com/microsoft/vscode-cmake-tools/issues/2353)
+- Commands from command palette should execute proper CMakeTask (build, clean, rebuild) when useTask option is configured [#2768](https://github.com/microsoft/vscode-cmake-tools/issues/2768) [@piomis](https://github.com/piomis)
 
 ## 1.12.27
 Bug Fixes:

--- a/src/cmakeTaskProvider.ts
+++ b/src/cmakeTaskProvider.ts
@@ -29,7 +29,7 @@ interface CMakeTaskDefinition extends vscode.TaskDefinition {
     options?: { cwd?: string ; environment?: Environment };
 }
 
-enum CommandType {
+export enum CommandType {
     build = "build",
     config = "configure",
     install = "install",


### PR DESCRIPTION
## This change addresses item #2768

### This changes visible behaviour of command palette and targets from CMake Outlline

The following changes are proposed:

- detect which task to run based on contents of targets list 
- config, install and test ignore rest of targets from list and call 'config', 'install', and 'test' task accordingly
- clean with  additional targets runs 'cleanRebuild' task, clean only calls 'clean' task
