### PR TITLE
Upgrade Nodejs to 14

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -5,7 +5,7 @@
 
 # To fully customize the contents of this image, use the following Dockerfile instead:
 # https://github.com/microsoft/vscode-dev-containers/tree/v0.128.0/containers/typescript-node-10/.devcontainer/Dockerfile
-FROM mcr.microsoft.com/vscode/devcontainers/typescript-node:12
+FROM mcr.microsoft.com/vscode/devcontainers/typescript-node:14
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \


### PR DESCRIPTION
## This changes the devcontainer environment

The following changes are proposed:

- Upgrade default node version to 14

## The purpose of this change

`yarn compile` in the devcontainer is unable to run because `eslint-plugin-jsdoc@39.3.0` expects a minimum node version of 14. Rebuilding the container using node 14 allows compilation.