### PR TITLE
Handle build failure for task support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,13 @@ Improvements:
 - Use upper case drive letters on Windows for `cmake.sourceDirectory`. [PR #2665](https://github.com/microsoft/vscode-cmake-tools/pull/2665) [@Danielmelody](https://github.com/Danielmelody)
 - Custom browse configuration should not include (redundant) per-file arguments. [#2645](https://github.com/microsoft/vscode-cmake-tools/issues/2645)
 - Support optional generator in `configurePresets` for version 3 and higher. [#2734](https://github.com/microsoft/vscode-cmake-tools/issues/2734) [@jochil](https://github.com/jochil)
+- Add handling for build task failure. Reveal the Problem Panel when build task has failed (non zero exited code) or the compiler outputs warning. [PR #2803](https://github.com/microsoft/vscode-cmake-tools/pull/2803) [@BIKA-C](https://github.com/BIKA-C)
 
 Bug Fixes:
 - Fix warning message that appears when using a default build preset with a multi-config generator. [#2353](https://github.com/microsoft/vscode-cmake-tools/issues/2353)
 - Avoid calling build tasks for "Clean", "Install" and "Run Tests" commands when "cmake: buildTask" setting is true. [#2768](https://github.com/microsoft/vscode-cmake-tools/issues/2768)
 - Generate the correct `configurePresets` for Clang or GCC compilers on Windows. [#2733](https://github.com/microsoft/vscode-cmake-tools/issues/2773)
+- Fix the build task output when warnings are generated but reported no warning. [PR #2803](https://github.com/microsoft/vscode-cmake-tools/pull/2803) [@BIKA-C](https://github.com/BIKA-C)
 
 ## 1.12.27
 Bug Fixes:

--- a/src/cmakeTaskProvider.ts
+++ b/src/cmakeTaskProvider.ts
@@ -373,6 +373,11 @@ export class CustomBuildTaskTerminal implements vscode.Pseudoterminal, proc.Outp
             const result: proc.ExecutionResult = await proc.execute(cmakePath, args, this, this.options).result;
             if (result.retc) {
                 this.writeEmitter.fire(localize("build.finished.with.error", "{0} finished with error(s).", taskName) + endOfLine);
+                if (doCloseEmitter) {
+                    this.closeEmitter.fire(result.retc);
+                }
+                vscode.commands.executeCommand("workbench.actions.view.problems")
+                return result.retc;
             } else if (result.stderr && !result.stdout) {
                 this.writeEmitter.fire(localize("build.finished.with.warnings", "{0} finished with warning(s).", taskName) + endOfLine);
             } else if (result.stdout && result.stdout.includes("warning")) {

--- a/src/cmakeTaskProvider.ts
+++ b/src/cmakeTaskProvider.ts
@@ -378,10 +378,12 @@ export class CustomBuildTaskTerminal implements vscode.Pseudoterminal, proc.Outp
                 }
                 vscode.commands.executeCommand("workbench.actions.view.problems")
                 return result.retc;
-            } else if (result.stderr && !result.stdout) {
+                
+              // to capture warning message. Previously the condition could not capture the case if both stderr and stdout have output
+            } else if (result.stderr || (result.stdout && result.stdout.includes("warning"))) {
                 this.writeEmitter.fire(localize("build.finished.with.warnings", "{0} finished with warning(s).", taskName) + endOfLine);
-            } else if (result.stdout && result.stdout.includes("warning")) {
-                this.writeEmitter.fire(localize("build.finished.with.warnings", "{0} finished with warning(s).", taskName) + endOfLine);
+                vscode.commands.executeCommand("workbench.actions.view.problems")
+                vscode.commands.executeCommand("workbench.action.focusActiveEditorGroup")
             } else {
                 this.writeEmitter.fire(localize("build.finished.successfully", "{0} finished successfully.", taskName) + endOfLine);
             }

--- a/src/cmakeTaskProvider.ts
+++ b/src/cmakeTaskProvider.ts
@@ -372,8 +372,8 @@ export class CustomBuildTaskTerminal implements vscode.Pseudoterminal, proc.Outp
         try {
             const result: proc.ExecutionResult = await proc.execute(cmakePath, args, this, this.options).result;
             if (result.retc) {
-                this.writeEmitter.fire(localize("build.finished.with.error", "{0} finished with error(s).", taskName) + endOfLine);             
-              // to capture warning message. Previously the condition could not capture the case if both stderr and stdout have output
+                this.writeEmitter.fire(localize("build.finished.with.error", "{0} finished with error(s).", taskName) + endOfLine);
+                // to capture warning message. Previously the condition could not capture the case if both stderr and stdout have output
             } else if (result.stderr || (result.stdout && result.stdout.includes("warning"))) {
                 this.writeEmitter.fire(localize("build.finished.with.warnings", "{0} finished with warning(s).", taskName) + endOfLine);
             } else {

--- a/src/cmakeTaskProvider.ts
+++ b/src/cmakeTaskProvider.ts
@@ -372,25 +372,17 @@ export class CustomBuildTaskTerminal implements vscode.Pseudoterminal, proc.Outp
         try {
             const result: proc.ExecutionResult = await proc.execute(cmakePath, args, this, this.options).result;
             if (result.retc) {
-                this.writeEmitter.fire(localize("build.finished.with.error", "{0} finished with error(s).", taskName) + endOfLine);
-                if (doCloseEmitter) {
-                    this.closeEmitter.fire(result.retc);
-                }
-                vscode.commands.executeCommand("workbench.actions.view.problems")
-                return result.retc;
-                
+                this.writeEmitter.fire(localize("build.finished.with.error", "{0} finished with error(s).", taskName) + endOfLine);             
               // to capture warning message. Previously the condition could not capture the case if both stderr and stdout have output
             } else if (result.stderr || (result.stdout && result.stdout.includes("warning"))) {
                 this.writeEmitter.fire(localize("build.finished.with.warnings", "{0} finished with warning(s).", taskName) + endOfLine);
-                vscode.commands.executeCommand("workbench.actions.view.problems")
-                vscode.commands.executeCommand("workbench.action.focusActiveEditorGroup")
             } else {
                 this.writeEmitter.fire(localize("build.finished.successfully", "{0} finished successfully.", taskName) + endOfLine);
             }
             if (doCloseEmitter) {
-                this.closeEmitter.fire(0);
+                this.closeEmitter.fire(result.retc ?? 0);
             }
-            return 0;
+            return result.retc ?? 0;
         } catch {
             this.writeEmitter.fire(localize("build.finished.with.error", "{0} finished with error(s).", taskName) + endOfLine);
             if (doCloseEmitter) {


### PR DESCRIPTION
<!-- Thanks for your contribution! To make things easier, please fill out the template below. -->

<!-- Please delete any unused sections. -->

<!-- Delete the following heading if there is no corresponding issue -->
## This change addresses item #2799

### This changes report when build has failed when using task

The following changes are proposed:

- Return error code when build has failed to indicate the task has faield
- Reveal the problem panel when build has failed like the java debugger extension