### PR TITLE
When available, use the target from the toolchains file-api json

### DIFF
--- a/src/cpptools.ts
+++ b/src/cpptools.ts
@@ -485,12 +485,19 @@ export class CppConfigurationProvider implements cpptools.CustomConfigurationPro
         }
 
         if (sysroot) {
-            if (!useFragments) {
-                // Send sysroot with quoting for CppTools API V5 and below.
-                flags.push('--sysroot=' + shlex.quote(sysroot));
-            } else {
+            if (useFragments) {
                 // Pass sysroot (without quote added) as the only compilerArgs for CppTools API V6 and above.
-                flags.push(('--sysroot=' + sysroot));
+                flags.push(`--sysroot=${sysroot}`);
+            } else {
+                // Send sysroot with quoting for CppTools API V5 and below.
+                flags.push(`--sysroot=${shlex.quote(sysroot)}`);
+            }
+        }
+        if (targetFromToolchains) {
+            if (useFragments) {
+                compileCommandFragments?.push(`--target=${targetFromToolchains}`);
+            } else {
+                flags.push(`--target=${targetFromToolchains}`);
             }
         }
 


### PR DESCRIPTION
## This change addresses item #2800 #1896

I think this should be all we need to do to enable passing the `--target` option to cpptools.  @Colengms do you have a sample project you could help me test this with?