### PR TITLE
Update actions to use node 16

### DIFF
--- a/.github/workflows/ci-main-linux.yml
+++ b/.github/workflows/ci-main-linux.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Setup Yarn environment
         uses: DerYeger/yarn-setup-action@v1.0.1
@@ -67,7 +67,7 @@ jobs:
 
       - name: Upload test logs if tests failed
         if: failure()
-        uses: actions/upload-artifact@v2.2.4
+        uses: actions/upload-artifact@v3
         with:
           name: TestLogs
           path: test/**/log.txt

--- a/.github/workflows/ci-main-mac.yml
+++ b/.github/workflows/ci-main-mac.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: macos-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Setup Yarn environment
         uses: DerYeger/yarn-setup-action@v1.0.1
@@ -57,7 +57,7 @@ jobs:
 
       - name: Upload test logs if tests failed
         if: failure()
-        uses: actions/upload-artifact@v2.2.4
+        uses: actions/upload-artifact@v3
         with:
           name: TestLogs
           path: test/**/log.txt

--- a/.github/workflows/ci-main.win.yml
+++ b/.github/workflows/ci-main.win.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup Yarn environment
         uses: DerYeger/yarn-setup-action@v1.0.1
@@ -59,7 +59,7 @@ jobs:
 
       - name: Upload test logs if tests failed
         if: failure()
-        uses: actions/upload-artifact@v2.2.4
+        uses: actions/upload-artifact@v3
         with:
           name: TestLogs
           path: test/**/log.txt


### PR DESCRIPTION
GitHub changed CI to require newer versions of the actions