### PR TITLE
Add option to create a new discussion from the new issue selection page

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Discussion or question
+    url: https://github.com/microsoft/vscode-cmake-tools/discussions/new
+    about: Please use our Discussions board to start a discussion or to ask a question.


### PR DESCRIPTION
This adds the option to create a new discussion when creating a new issue.

Example:
![image](https://user-images.githubusercontent.com/38734287/196775491-83e6e103-e15c-4de8-b3a3-8db49dad358e.png)
