### PR TITLE
Fix Pass command line arguments for "Run Without Debugging"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Bug Fixes:
 - Fix the build task to return the error code. [#2799](https://github.com/microsoft/vscode-cmake-tools/issues/2799) [@BIKA-C](https://github.com/BIKA-C)
 - Generate correct ClangCL Kits. [#2790](https://github.com/microsoft/vscode-cmake-tools/issues/2790) [#2810](https://github.com/microsoft/vscode-cmake-tools/issues/2810)
 - ctest -N does not work with custom cmake path from preset. [#2842](https://github.com/microsoft/vscode-cmake-tools/issues/2842)
+- Resolve variables in args before passing them to the terminal. [#2846](https://github.com/microsoft/vscode-cmake-tools/issues/2846)
 
 ## 1.12.27
 Bug Fixes:

--- a/src/cmakeProject.ts
+++ b/src/cmakeProject.ts
@@ -2290,8 +2290,9 @@ export class CMakeProject {
         }
 
         let launchArgs = '';
-        if (userConfig && userConfig.args) {
-            launchArgs = userConfig.args.join(" ");
+        if (userConfig?.args?.length !== undefined && userConfig.args.length > 0) {
+            const args = await expandStrings(userConfig.args, await this.getExpansionOptions());
+            launchArgs = args.join(" ");
         }
 
         terminal.sendText(`${executablePath} ${launchArgs}`);


### PR DESCRIPTION
Addresses #2846.  We needed to resolve the variables before sending them to the terminal because VS Code does not intercept this step.