### PR TITLE
Add arm64 to MSVC hosts

### DIFF
--- a/src/installs/visualStudio.ts
+++ b/src/installs/visualStudio.ts
@@ -159,6 +159,13 @@ export function getHostTargetArchString(hostArch: string, targetArch?: string, a
         }
     }
 
+    // For arm64, cmake expects 'ARM64' for host toolset parameter, but
+    // then we fail the hostArch === targetArch below. This enables us to find
+    // all the Host ARM64 toolsets as well as still meet the `host=ARM64` requirement for cmake
+    if (hostArch === 'ARM64') {
+        hostArch = 'arm64';
+    }
+
     if (!targetArch) {
         targetArch = hostArch;
     }

--- a/src/installs/visualStudio.ts
+++ b/src/installs/visualStudio.ts
@@ -437,6 +437,11 @@ export async function getVcVarsBatScript(vsInstall: VSInstallation, hostArch: st
         devBatFolder = path.join(vsInstall.installationPath, 'VC');
     }
 
+    // ARM64 host support was added in version 17.4, so anything less that 17 will not have support.
+    if (majorVersion < 17 && hostArch === 'ARM64') {
+        return null;
+    }
+
     const devBat = path.join(devBatFolder, vcVarsScript);
     // The presence of vcvars[hostArch][targetArch].bat indicates whether targetArch is included
     // in the given VS installation.

--- a/src/installs/visualStudio.ts
+++ b/src/installs/visualStudio.ts
@@ -437,11 +437,6 @@ export async function getVcVarsBatScript(vsInstall: VSInstallation, hostArch: st
         devBatFolder = path.join(vsInstall.installationPath, 'VC');
     }
 
-    // ARM64 host support was added in version 17.4, so anything less that 17 will not have support.
-    if (majorVersion < 17 && hostArch === 'ARM64') {
-        return null;
-    }
-
     const devBat = path.join(devBatFolder, vcVarsScript);
     // The presence of vcvars[hostArch][targetArch].bat indicates whether targetArch is included
     // in the given VS installation.

--- a/src/kit.ts
+++ b/src/kit.ts
@@ -588,7 +588,7 @@ function vsKitName(inst: VSInstallation, hostArch: string, targetArch?: string):
 /**
  * Possible msvc host architectures
  */
-export const MSVC_HOST_ARCHES: string[] = ['x86', 'x64'];
+export const MSVC_HOST_ARCHES: string[] = ['x86', 'x64', 'arm64'];
 
 /**
  * Gets the environment variables set by a shell script.

--- a/src/kit.ts
+++ b/src/kit.ts
@@ -745,8 +745,13 @@ export async function scanForVSKits(pr?: ProgressReporter): Promise<Kit[]> {
         const version = util.tryParseVersion(inst.installationVersion);
 
         const sub_prs: Promise<Kit | null>[] = [];
-        MSVC_HOST_ARCHES.forEach(hostArch => {
-            if (hostArch === 'ARM64' && !(version && version.major >= 17 && version.minor >= 4)) {
+            if (
+                hostArch === 'ARM64' &&
+                (
+                    !version ||
+                    version.major < 17 || (version.major === 17 && version.minor < 4)
+                )
+            ) {
                 // ARM64 support as a host was added in Visual Studio 2022 17.4 and above,
                 // so we'll avoid checking it on anything lower.
                 return;

--- a/src/kit.ts
+++ b/src/kit.ts
@@ -588,7 +588,7 @@ function vsKitName(inst: VSInstallation, hostArch: string, targetArch?: string):
 /**
  * Possible msvc host architectures
  */
-export const MSVC_HOST_ARCHES: string[] = ['x86', 'x64', 'arm64'];
+export const MSVC_HOST_ARCHES: string[] = ['x86', 'x64', 'ARM64'];
 
 /**
  * Gets the environment variables set by a shell script.

--- a/src/kit.ts
+++ b/src/kit.ts
@@ -742,13 +742,11 @@ async function tryCreateNewVCEnvironment(inst: VSInstallation, hostArch: string,
 export async function scanForVSKits(pr?: ProgressReporter): Promise<Kit[]> {
     const installs = await vsInstallations();
 
-    // Exclude ARM64 host checking on x86, x64, and unknown PROCESSOR_ARCHITECTURE
+    // Exclude ARM64 host checking on x86 and x64
     const hostArches: MsvcHostArches[] = (
-        // To determine ARM64 host, we check the processor id, which for Qualcomm's 8cx starts with
-        // ARMv8. If we check the PROCESSOR_ARCHITECTURE it's possible that we're emulating
-        // x86_64 on ARM64 and getting AMD64 for example. The processor id doesn't change
-        // even during x86_64 emulation.
-        process.env.PROCESSOR_IDENTIFIER?.startsWith('ARMv8')
+        // To determine ARM64 host, we check the PROCESSOR_IDENTIFIER (please see: https://learn.microsoft.com/en-us/troubleshoot/windows-server/deployment/determine-the-type-of-processor)
+        // ARMv8 will be contained in the string on ARM64 devices.
+        process.env.PROCESSOR_IDENTIFIER?.includes('ARMv8')
     ) ?
         [...MSVC_HOST_ARCHES, 'ARM64'] :
         MSVC_HOST_ARCHES;

--- a/src/kit.ts
+++ b/src/kit.ts
@@ -742,12 +742,8 @@ async function tryCreateNewVCEnvironment(inst: VSInstallation, hostArch: string,
 export async function scanForVSKits(pr?: ProgressReporter): Promise<Kit[]> {
     const installs = await vsInstallations();
 
-    // Exclude ARM64 host checking on x86 and x64
-    const hostArches: MsvcHostArches[] = (
-        // To determine ARM64 host, we check the PROCESSOR_IDENTIFIER (please see: https://learn.microsoft.com/en-us/troubleshoot/windows-server/deployment/determine-the-type-of-processor)
-        // ARMv8 will be contained in the string on ARM64 devices.
-        process.env.PROCESSOR_IDENTIFIER?.includes('ARMv8')
-    ) ?
+    // Exclude ARM64 host checking on x86 and x64 since they cannot act as an arm64 host.
+    const hostArches: MsvcHostArches[] = (util.GetHostArchitecture() === 'arm64') ?
         [...MSVC_HOST_ARCHES, 'ARM64'] :
         MSVC_HOST_ARCHES;
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -352,17 +352,11 @@ export function parseVersion(str: string): Version {
 }
 
 export function tryParseVersion(str: string): Version | undefined {
-    const version_re = /(\d+)\.(\d+)\.(\d+)(.*)/;
-    const mat = version_re.exec(str);
-    if (!mat) {
+    try {
+        return parseVersion(str);
+    } catch {
         return undefined;
     }
-    const [, major, minor, patch] = mat;
-    return {
-        major: parseInt(major ?? '0'),
-        minor: parseInt(minor ?? '0'),
-        patch: parseInt(patch ?? '0')
-    };
 }
 
 export function compareVersion(va: Version, vb: Version) {

--- a/src/util.ts
+++ b/src/util.ts
@@ -351,6 +351,20 @@ export function parseVersion(str: string): Version {
     };
 }
 
+export function tryParseVersion(str: string): Version | undefined {
+    const version_re = /(\d+)\.(\d+)\.(\d+)(.*)/;
+    const mat = version_re.exec(str);
+    if (!mat) {
+        return undefined;
+    }
+    const [, major, minor, patch] = mat;
+    return {
+        major: parseInt(major ?? '0'),
+        minor: parseInt(minor ?? '0'),
+        patch: parseInt(patch ?? '0')
+    };
+}
+
 export function compareVersion(va: Version, vb: Version) {
     if (va.major !== vb.major) {
         return va.major - vb.major;

--- a/src/util.ts
+++ b/src/util.ts
@@ -4,6 +4,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as vscode from 'vscode';
 import * as nls from 'vscode-nls';
+import * as os from 'os';
 
 import { DebuggerEnvironmentVariable, execute } from '@cmt/proc';
 import rollbar from '@cmt/rollbar';
@@ -867,4 +868,18 @@ export async function scheduleAsyncTask<T>(task: () => Promise<T>): Promise<T> {
  */
 export function assertNever(value: never): never {
     throw new Error(`Unexpected value: ${value}`);
+}
+
+export function GetHostArchitecture() {
+    const arch = os.arch();
+    switch (arch) {
+        case 'arm64':
+        case 'arm':
+            return arch;
+        case 'x32':
+        case 'ia32':
+            return 'x86';
+        default:
+            return 'x64';
+    }
 }


### PR DESCRIPTION
### This enables using native arm64 toolset

The following changes are proposed:

- Add arm64 as a valid host for MSVC

## The purpose of this change

Visual Studio 2022 17.4 Preview introduced native build tools on arm64. This change enables the vscode-cmake-tools to detect the native tools so we can build with it instead of emulating x86/x64 to run the non-native build tools.

![image](https://user-images.githubusercontent.com/661373/205463105-b765c3c7-cc20-47f7-9a4c-647cf541d8f7.png)
