### PR TITLE
"build" task improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ Bug Fixes:
 - Quote launch arguments sent to the terminal if they have special characters. [#2898](https://github.com/microsoft/vscode-cmake-tools/issues/2898)
 - CMake Tools should choose cmake.exe from the newest VS when it's not found in the PATH. [#2753](https://github.com/microsoft/vscode-cmake-tools/issues/2753)
 - Calling build targets from CMake Project Outline always builds default target if useTasks option is set. [#2778](https://github.com/microsoft/vscode-cmake-tools/issues/2768) [@piomis]](https://github.com/piomis)
-- Build command is not able to properly pick-up tasks from tasks.json file if configured with isDefault option. [#2935](https://github.com/microsoft/vscode-cmake-tools/issues/2935) [@piomis]](https://github.com/piomis)
+- Build command is not able to properly pick-up tasks from tasks.json file if configured with isDefault option and cancellation of running build task is not working. [#2935](https://github.com/microsoft/vscode-cmake-tools/issues/2935) [@piomis]](https://github.com/piomis)
 
 ## 1.12.27
 Bug Fixes:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,8 @@ Bug Fixes:
 - Quote launch arguments sent to the terminal if they have special characters. [#2898](https://github.com/microsoft/vscode-cmake-tools/issues/2898)
 - CMake Tools should choose cmake.exe from the newest VS when it's not found in the PATH. [#2753](https://github.com/microsoft/vscode-cmake-tools/issues/2753)
 - Calling build targets from CMake Project Outline always builds default target if useTasks option is set. [#2778](https://github.com/microsoft/vscode-cmake-tools/issues/2768) [@piomis]](https://github.com/piomis)
-- Remove the default path for `cmake.mingwSearchDirs` since the path is world-writable. [PR #2942](https://github.com/microsoft/vscode-cmake-tools/pull/2942)- Build command is not able to properly pick-up tasks from tasks.json file if configured with isDefault option and cancellation of running build task is not working. [#2935](https://github.com/microsoft/vscode-cmake-tools/issues/2935) [@piomis]](https://github.com/piomis)
+- Remove the default path for `cmake.mingwSearchDirs` since the path is world-writable. [PR #2942](https://github.com/microsoft/vscode-cmake-tools/pull/2942)
+- Build command is not able to properly pick-up tasks from tasks.json file if configured with isDefault option and cancellation of running build task is not working. [#2935](https://github.com/microsoft/vscode-cmake-tools/issues/2935) [@piomis]](https://github.com/piomis)
 
 ## 1.12.27
 Bug Fixes:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Bug Fixes:
 - Quote launch arguments sent to the terminal if they have special characters. [#2898](https://github.com/microsoft/vscode-cmake-tools/issues/2898)
 - CMake Tools should choose cmake.exe from the newest VS when it's not found in the PATH. [#2753](https://github.com/microsoft/vscode-cmake-tools/issues/2753)
 - Calling build targets from CMake Project Outline always builds default target if useTasks option is set. [#2778](https://github.com/microsoft/vscode-cmake-tools/issues/2768) [@piomis]](https://github.com/piomis)
+- Build command is not able to properly pick-up tasks from tasks.json file if configured with isDefault option. [#2935](https://github.com/microsoft/vscode-cmake-tools/issues/2935) [@piomis]](https://github.com/piomis)
 
 ## 1.12.27
 Bug Fixes:

--- a/src/cmakeBuildRunner.ts
+++ b/src/cmakeBuildRunner.ts
@@ -36,6 +36,7 @@ export class CMakeBuildRunner {
         this.currentBuildProcess =  { child: undefined, result: new Promise<proc.ExecutionResult>(resolve => {
             const disposable: vscode.Disposable = vscode.tasks.onDidEndTask((endEvent: vscode.TaskEndEvent) => {
                 if (endEvent.execution === this.taskExecutor) {
+                    this.taskExecutor = undefined;
                     disposable.dispose();
                     resolve({ retc: 0, stdout: '', stderr: '' });
                 }
@@ -53,7 +54,6 @@ export class CMakeBuildRunner {
         }
         if (this.taskExecutor) {
             this.taskExecutor.terminate();
-            this.taskExecutor = undefined;
         }
     }
 

--- a/src/cmakeTaskProvider.ts
+++ b/src/cmakeTaskProvider.ts
@@ -190,7 +190,7 @@ export class CMakeTaskProvider implements vscode.TaskProvider {
         // Fetch all CMake task from `tasks.json` files.
         const allTasks: vscode.Task[] = await vscode.tasks.fetchTasks({ type: CMakeTaskProvider.CMakeScriptType });
         const tasks: (CMakeTask | undefined)[] = allTasks.map((task: any) => {
-            if (!task.definition.label || !task.group || (task.group && task.group !== vscode.TaskGroup.Build)) {
+            if (!task.definition.label || !task.group || (task.group && task.group.id !== vscode.TaskGroup.Build.id)) {
                 return undefined;
             }
             const definition: CMakeTaskDefinition = {
@@ -236,7 +236,7 @@ export class CMakeTaskProvider implements vscode.TaskProvider {
                 return matchingTargetTasks[0];
             } else {
                 // Search for the matching default task.
-                const defaultTask: CMakeTask[] = matchingTargetTasks.filter(task => task.group?.isDefault);
+                const defaultTask: CMakeTask[] = matchingTargetTasks.filter(task => task.isDefault);
                 if (defaultTask.length === 1) {
                     return defaultTask[0];
                 } else {


### PR DESCRIPTION
## This change addresses item #2935
Fixes #2935

### This changes how build tasks are selected when "useBuild" option is used and some tasks are defined in tasks.json file

The following changes are proposed:

- while filtering tasks from tasks.json to get only "build" tasks type compare TaskGroup.id instead of complete object
- use isDefault property from temporary created tasks instead of group of this task

## Other Notes/Information
See #2780 comment: https://github.com/microsoft/vscode-cmake-tools/pull/2780#discussion_r1038154473
