### PR TITLE
Cancellation of running build task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ Bug Fixes:
 - Quote launch arguments sent to the terminal if they have special characters. [#2898](https://github.com/microsoft/vscode-cmake-tools/issues/2898)
 - CMake Tools should choose cmake.exe from the newest VS when it's not found in the PATH. [#2753](https://github.com/microsoft/vscode-cmake-tools/issues/2753)
 - Calling build targets from CMake Project Outline always builds default target if useTasks option is set. [#2778](https://github.com/microsoft/vscode-cmake-tools/issues/2768) [@piomis]](https://github.com/piomis)
-- Cancelling running build task is not working. [#2937](https://github.com/microsoft/vscode-cmake-tools/issues/2937) [@piomis]](https://github.com/piomis)
+- Cancellation of running build task is not working. [#2937](https://github.com/microsoft/vscode-cmake-tools/issues/2937) [@piomis]](https://github.com/piomis)
 
 ## 1.12.27
 Bug Fixes:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Bug Fixes:
 - Quote launch arguments sent to the terminal if they have special characters. [#2898](https://github.com/microsoft/vscode-cmake-tools/issues/2898)
 - CMake Tools should choose cmake.exe from the newest VS when it's not found in the PATH. [#2753](https://github.com/microsoft/vscode-cmake-tools/issues/2753)
 - Calling build targets from CMake Project Outline always builds default target if useTasks option is set. [#2778](https://github.com/microsoft/vscode-cmake-tools/issues/2768) [@piomis]](https://github.com/piomis)
+- Cancelling running build task is not working. [#2937](https://github.com/microsoft/vscode-cmake-tools/issues/2937) [@piomis]](https://github.com/piomis)
 
 ## 1.12.27
 Bug Fixes:

--- a/src/cmakeBuildRunner.ts
+++ b/src/cmakeBuildRunner.ts
@@ -36,6 +36,7 @@ export class CMakeBuildRunner {
         this.currentBuildProcess =  { child: undefined, result: new Promise<proc.ExecutionResult>(resolve => {
             const disposable: vscode.Disposable = vscode.tasks.onDidEndTask((endEvent: vscode.TaskEndEvent) => {
                 if (endEvent.execution === this.taskExecutor) {
+                    this.taskExecutor = undefined;
                     disposable.dispose();
                     resolve({ retc: 0, stdout: '', stderr: '' });
                 }
@@ -53,7 +54,6 @@ export class CMakeBuildRunner {
         }
         if (this.taskExecutor) {
             this.taskExecutor.terminate();
-            this.taskExecutor = undefined;
         }
     }
 


### PR DESCRIPTION
## This fix #2937 

The following changes are proposed:

- this.taskExecutor must not be set to undefined before TaskEnd notification is resolved