### PR TITLE
Remove default value for mingwSearchDirs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Bug Fixes:
 - Quote launch arguments sent to the terminal if they have special characters. [#2898](https://github.com/microsoft/vscode-cmake-tools/issues/2898)
 - CMake Tools should choose cmake.exe from the newest VS when it's not found in the PATH. [#2753](https://github.com/microsoft/vscode-cmake-tools/issues/2753)
 - Calling build targets from CMake Project Outline always builds default target if useTasks option is set. [#2778](https://github.com/microsoft/vscode-cmake-tools/issues/2768) [@piomis]](https://github.com/piomis)
+- Remove the default path for `cmake.mingwSearchDirs` since the path is world-writable. 
 
 ## 1.12.27
 Bug Fixes:

--- a/package.json
+++ b/package.json
@@ -1527,9 +1527,7 @@
             "type": "string",
             "description": "%cmake-tools.configuration.cmake.searchDirs.items.description%"
           },
-          "default": [
-            "${env:SystemDrive}/MinGW"
-          ],
+          "default": [],
           "description": "%cmake-tools.configuration.cmake.mingwSearchDirs.description%",
           "scope": "window"
         },


### PR DESCRIPTION
Remove the default path for `cmake.mingwSearchDirs` since the path is world-writable. 