### PR TITLE
Update quote function to fix path separator regression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Improvements:
 
 Bug Fixes:
 - Compatibility between test and build presets was not enforced. [#2904](https://github.com/microsoft/vscode-cmake-tools/issues/2904)
+- Update quote function to fix path separator regression [#2974](https://github.com/microsoft/vscode-cmake-tools/pull/2974)
 
 ## 1.13.42
 Bug Fixes:

--- a/src/shlex.ts
+++ b/src/shlex.ts
@@ -77,11 +77,7 @@ export function quote(str: string, opt?: ShlexOptions): string {
     if (str === '') {
         return '""';
     }
-    if (!/[\s]/g.test(str)) {
-        // Don't quote if the string doesn't have whitespace
-        return str;
-    }
-    if (/[^\w@%\-+=:,./|]/.test(str)) {
+    if (/[^\w@%\-+=:,./|><]/.test(str)) {
         str = str.replace(/"/g, '\\"');
         return `"${str}"`;
     } else {


### PR DESCRIPTION
## This change addresses item #2972

The following changes are proposed:

- Update quote function to add check for less than and greater than symbols in the existing character class check.
- Remove the white space check in the quote function.

## Other Notes/Information
N/A
