### PR TITLE
Fix an issue causing the Add Presets commands not to appear

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,16 @@ Improvements:
 
 Bug Fixes:
 - Compatibility between test and build presets was not enforced. [#2904](https://github.com/microsoft/vscode-cmake-tools/issues/2904)
-- Update quote function to fix path separator regression [#2974](https://github.com/microsoft/vscode-cmake-tools/pull/2974)
+
+## 1.13.43
+Bug Fixes:
+- Fix an issue causing the Add Presets commands not to appear.
 
 ## 1.13.42
 Bug Fixes:
 - Fix failed activation when using the `cmake.allowUnsupportedPresetsVersions` setting. [#2968](https://github.com/microsoft/vscode-cmake-tools/issues/2968)
 - Verify binary directories only if there are multiple sources. [#2963](https://github.com/microsoft/vscode-cmake-tools/issues/2963)
+- Update quote function to fix path separator regression [#2974](https://github.com/microsoft/vscode-cmake-tools/pull/2974)
 
 ## 1.13.41
 Bug Fixes:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ Bug Fixes:
 
 ## 1.13.43
 Bug Fixes:
-- Fix an issue causing the Add Presets commands not to appear.
+- Fix an issue causing the Add Presets commands not to appear. [PR #2977](https://github.com/microsoft/vscode-cmake-tools/pull/2977)
 
 ## 1.13.42
 Bug Fixes:


### PR DESCRIPTION
Discovered an issue with the presets state while debugging another issue.  This bug causes the "Add Configure Preset" etc commands not to appear after first loading a presets project.