### PR TITLE
Build selected build-target when starting to debug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 1.14
 Improvements:
 - Add an optional description field to kits. [PR #2944](https://github.com/microsoft/vscode-cmake-tools/pull/2944) [@TisziV](https://github.com/TisziV)
-- When starting debugging, also build the selected build target. [PR #2987] [@Maddimax](https://github.com/Maddimax)
+- When starting debugging, also build the selected build target. [PR #2987](https://github.com/microsoft/vscode-cmake-tools/pull/2987) [@Maddimax](https://github.com/Maddimax)
 - Add support for CMake Presets V5. [#2979](https://github.com/microsoft/vscode-cmake-tools/issues/2979)
 
 Bug Fixes:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.14
 Improvements:
 - Add an optional description field to kits. [PR #2944](https://github.com/microsoft/vscode-cmake-tools/pull/2944) [@TisziV](https://github.com/TisziV)
+- When starting debugging, also build the selected build target. [PR #2987] [@Maddimax](https://github.com/Maddimax)
 
 Bug Fixes:
 - Check if "CMakeLists.txt" exists after renaming. [#2986](https://github.com/microsoft/vscode-cmake-tools/issues/2986)

--- a/src/cmakeProject.ts
+++ b/src/cmakeProject.ts
@@ -2162,7 +2162,13 @@ export class CMakeProject {
 
         const buildOnLaunch = this.workspaceContext.config.buildBeforeRun;
         if (buildOnLaunch || isReconfigurationNeeded) {
-            const buildResult = await this.build([chosen.name]);
+            const buildTargets = await this.getDefaultBuildTargets() || [];
+            const allTargetName = await this.allTargetName;
+            if (!buildTargets.includes(allTargetName) && !buildTargets.includes(chosen.name)) {
+                buildTargets.push(chosen.name);
+            }
+
+            const buildResult = await this.build(buildTargets);
             if (buildResult !== 0) {
                 log.debug(localize('build.failed', 'Build failed'));
                 return null;


### PR DESCRIPTION
### This changes visible behavior

The following changes are proposed:

- When launching, not only build the selected launch target, but also the selected build target if the two differ.

## The purpose of this change

For some projects, you always want to build ALL. This allows to set ALL as the build target, but still launch the selected launch target.

