### PR TITLE
remvove extra postWorkspaceOpen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ Improvements:
 Bug Fixes:
 - Check if "CMakeLists.txt" exists after renaming. [#2986](https://github.com/microsoft/vscode-cmake-tools/issues/2986)
 
+## 1.13.45
+Bug Fixes:
+- unwanted warning "Configuration is already in progress" in multi-root projects. [#2989](https://github.com/microsoft/vscode-cmake-tools/issues/2989)
+
 ## 1.13.44
 Bug Fixes:
 - Compatibility between test and build presets was not enforced. [#2904](https://github.com/microsoft/vscode-cmake-tools/issues/2904)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ Bug Fixes:
 
 ## 1.13.45
 Bug Fixes:
-- unwanted warning "Configuration is already in progress" in multi-root projects. [#2989](https://github.com/microsoft/vscode-cmake-tools/issues/2989)
+- Remove unwanted warning "Configuration is already in progress" in multi-root projects. [#2989](https://github.com/microsoft/vscode-cmake-tools/issues/2989)
 
 ## 1.13.44
 Bug Fixes:

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -172,9 +172,6 @@ export class ExtensionManager implements vscode.Disposable {
             if (this.workspaceConfig.autoSelectActiveFolder && isMultiProject) {
                 this.statusBar.setAutoSelectActiveProject(true);
             }
-            for (const project of this.projectController.getAllCMakeProjects()) {
-                rollbar.takePromise('Post-folder-open', { folder: project.folderPath, project: project }, this.postWorkspaceOpen(project));
-            }
             await this.initActiveProject();
         }
         const isFullyActivated: boolean = this.workspaceHasAtLeastOneProject();


### PR DESCRIPTION
`await this.projectController.loadAllProjects()` already calls `postWorkspaceOpen` on every project
bugfix:  https://github.com/microsoft/vscode-cmake-tools/issues/2989