### PR TITLE
Fix an issue with setKitByName ignoring the folder argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Improvements:
 
 Bug Fixes:
 - Check if "CMakeLists.txt" exists after renaming. [#2986](https://github.com/microsoft/vscode-cmake-tools/issues/2986)
+- `setKitByName` command ignores the workspace folder argument.
 
 ## 1.13.44
 Bug Fixes:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Improvements:
 
 Bug Fixes:
 - Check if "CMakeLists.txt" exists after renaming. [#2986](https://github.com/microsoft/vscode-cmake-tools/issues/2986)
-- `setKitByName` command ignores the workspace folder argument.
+- `setKitByName` command ignores the workspace folder argument. [PR #2991](https://github.com/microsoft/vscode-cmake-tools/pull/2991)
 
 ## 1.13.44
 Bug Fixes:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Improvements:
 
 Bug Fixes:
 - Check if "CMakeLists.txt" exists after renaming. [#2986](https://github.com/microsoft/vscode-cmake-tools/issues/2986)
+
+## 1.13.45
 - `setKitByName` command ignores the workspace folder argument. [PR #2991](https://github.com/microsoft/vscode-cmake-tools/pull/2991)
 
 ## 1.13.44

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -895,12 +895,9 @@ export class ExtensionManager implements vscode.Disposable {
      * For backward compatibility, apply kitName to all folders if folder is undefined
      */
     async setKitByName(kitName: string, folder?: vscode.WorkspaceFolder) {
-        if (folder) {
-            await this.getActiveProject()?.kitsController.setKitByName(kitName);
-        } else {
-            for (const project of this.projectController.getAllCMakeProjects()) {
-                await project.kitsController.setKitByName(kitName);
-            }
+        const projects = folder ? this.projectController.getProjectsForWorkspaceFolder(folder) : this.projectController.getAllCMakeProjects();
+        for (const project of projects || []) {
+            await project.kitsController.setKitByName(kitName);
         }
 
         const activeKit = this.getActiveProject()?.activeKit;


### PR DESCRIPTION
Addresses an issue with the `cmake.setKitByName` command reported by an extension author who used that command.