### PR TITLE
Fix exportCompileCommandsFile scope access.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1920,7 +1920,8 @@
         "cmake.exportCompileCommandsFile": {
           "type": "boolean",
           "default": true,
-          "description": "%cmake-tools.configuration.cmake.exportCompileCommandsFile.description%"
+          "description": "%cmake-tools.configuration.cmake.exportCompileCommandsFile.description%",
+          "scope": "resource"
         },
         "cmake.useCMakePresets": {
           "type": "string",

--- a/src/drivers/cmakeDriver.ts
+++ b/src/drivers/cmakeDriver.ts
@@ -1496,13 +1496,14 @@ export abstract class CMakeDriver implements vscode.Disposable {
         }
 
         const configurationScope = this.workspaceFolder ? vscode.Uri.file(this.workspaceFolder) : null;
-        const config = vscode.workspace.getConfiguration("cmake", configurationScope);
+        const configResourceScope = vscode.workspace.getConfiguration("cmake", configurationScope);
+        const config= vscode.workspace.getConfiguration("cmake");
         // Export compile_commands.json
         const exportCompileCommandsSetting = config.get<boolean>("exportCompileCommandsFile");
         const exportCompileCommandsFile: boolean = exportCompileCommandsSetting === undefined ? true : (exportCompileCommandsSetting || false);
         settingMap.CMAKE_EXPORT_COMPILE_COMMANDS = util.cmakeify(exportCompileCommandsFile);
 
-        const allowBuildTypeOnMultiConfig = config.get<boolean>("setBuildTypeOnMultiConfig") || false;
+        const allowBuildTypeOnMultiConfig = configResourceScope.get<boolean>("setBuildTypeOnMultiConfig") || false;
 
         if (!this.isMultiConfFast || (this.isMultiConfFast && allowBuildTypeOnMultiConfig)) {
             // Mutliconf generators do not need the CMAKE_BUILD_TYPE property

--- a/src/drivers/cmakeDriver.ts
+++ b/src/drivers/cmakeDriver.ts
@@ -1496,14 +1496,13 @@ export abstract class CMakeDriver implements vscode.Disposable {
         }
 
         const configurationScope = this.workspaceFolder ? vscode.Uri.file(this.workspaceFolder) : null;
-        const configResourceScope = vscode.workspace.getConfiguration("cmake", configurationScope);
-        const config= vscode.workspace.getConfiguration("cmake");
+        const config = vscode.workspace.getConfiguration("cmake", configurationScope);
         // Export compile_commands.json
         const exportCompileCommandsSetting = config.get<boolean>("exportCompileCommandsFile");
         const exportCompileCommandsFile: boolean = exportCompileCommandsSetting === undefined ? true : (exportCompileCommandsSetting || false);
         settingMap.CMAKE_EXPORT_COMPILE_COMMANDS = util.cmakeify(exportCompileCommandsFile);
 
-        const allowBuildTypeOnMultiConfig = configResourceScope.get<boolean>("setBuildTypeOnMultiConfig") || false;
+        const allowBuildTypeOnMultiConfig = config.get<boolean>("setBuildTypeOnMultiConfig") || false;
 
         if (!this.isMultiConfFast || (this.isMultiConfFast && allowBuildTypeOnMultiConfig)) {
             // Mutliconf generators do not need the CMAKE_BUILD_TYPE property


### PR DESCRIPTION
Fix for the warning in the Extension Host logging:

> Accessing a window scoped configuration for a resource is not expected. To associate 'cmake.exportCompileCommandsFile' to a resource, define its scope to 'resource' in configuration contributions in 'package.json'.