### PR TITLE
Ensure cmake.buildAll actually builds all targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Bug Fixes:
 - Implement cmake.parseBuildDiagnostics. [#1932](https://github.com/microsoft/vscode-cmake-tools/issues/1932)
 - CMake tools not fully loaded when opening multi-project folders. [#3000](https://github.com/microsoft/vscode-cmake-tools/issues/3000)
 - Fix typo in `cmake.skipConfigureWhenCachePresent`. [#3040](https://github.com/microsoft/vscode-cmake-tools/issues/3040) [@Mlekow](https://github.com/Mlekow)
+- `cmake.buildAll` now builds all targets even if a default build target is selected. [#3048](https://github.com/microsoft/vscode-cmake-tools/issues/3048)
 
 ## 1.13.45
 Bug Fixes:

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1082,9 +1082,9 @@ export class ExtensionManager implements vscode.Disposable {
 
     buildAll(name?: string | string[]) {
         telemetry.logEvent("build", { all: "true"});
-        return this.runCMakeCommandForAll(cmakeProject => {
+        return this.runCMakeCommandForAll(async cmakeProject => {
             const targets = util.isArrayOfString(name) ? name : util.isString(name) ? [name] : undefined;
-            return cmakeProject.build(targets);
+            return cmakeProject.build(targets || [await cmakeProject.allTargetName]);
         },
         this.ensureActiveBuildPreset,
         true);


### PR DESCRIPTION
Before this change, cmake.buildAll would fall back to the default build target if no targets were specified, which leads to the counter-intuitive behavior of not actually building all targets if a default build target was selected (e.g. in the statusbar).

Fixes #3048 
