### PR TITLE
Add trust to kit scanning paths

### DIFF
--- a/schemas/kits-schema.json
+++ b/schemas/kits-schema.json
@@ -96,6 +96,10 @@
                 "required": [
                     "name"
                 ]
+            },
+            "isTrusted": {
+                "type": "boolean",
+                "description": "True if this kit comes from a trusted path"
             }
         }
     }

--- a/src/kit.ts
+++ b/src/kit.ts
@@ -14,7 +14,7 @@ import CMakeProject from './cmakeProject';
 import * as expand from './expand';
 import { VSInstallation, vsInstallations, getHostTargetArchString, varsForVSInstallation, generatorPlatformFromVSArch } from './installs/visualStudio';
 import * as logging from './logging';
-import paths from './paths';
+import paths, { PathWithTrust } from './paths';
 import { fs } from './pr';
 import * as proc from './proc';
 import { loadSchema } from './schema';
@@ -146,6 +146,11 @@ export interface Kit extends KitDetect {
      * If `true`, keep this kit around even if it seems out-of-date
      */
     keep?: boolean;
+
+    /**
+     * If `true`, this kit comes from a trusted path.
+     */
+    isTrusted: boolean;
 }
 
 interface CompilerVersion {
@@ -334,9 +339,10 @@ async function asMingwKit(bin: string, kit: Kit): Promise<Kit> {
  * is a GCC or Clang compiler and gets its version. If it is not a compiler,
  * returns `null`.
  * @param bin Path to a binary
+ * @param isTrusted True iff the binary is in a trusted path. Default true.
  * @returns A CompilerKit, or null if `bin` is not a known compiler
  */
-export async function kitIfCompiler(bin: string, pr?: ProgressReporter): Promise<Kit | null> {
+export async function kitIfCompiler(bin: string, isTrusted: boolean = true, pr?: ProgressReporter): Promise<Kit | null> {
     const fname = path.basename(bin);
     // Check by filename what the compiler might be. This is just heuristic.
     const gcc_regex = /^((\w+-)*)gcc(-\d+(\.\d+(\.\d+)?)?)?(\.exe)?$/;
@@ -347,8 +353,8 @@ export async function kitIfCompiler(bin: string, pr?: ProgressReporter): Promise
     const clang_cl_res = clang_cl_regex.exec(fname);
 
     if (gcc_res) {
-        const version = await getCompilerVersion('GCC', bin, pr);
-        if (version === null) {
+        const version = isTrusted ? await getCompilerVersion('GCC', bin, pr) : null;
+        if (isTrusted && version === null) {
             return null;
         }
         const gccCompilers: { [lang: string]: string } = {};
@@ -365,8 +371,8 @@ export async function kitIfCompiler(bin: string, pr?: ProgressReporter): Promise
             const gxx_fname2 = fname2.replace(/gcc/, 'g++');
             const gxx_bin2 = path.join(path.dirname(bin), gxx_fname2);
             // Ensure the version is match
-            const version2 = await fs.exists(bin2) ? await getCompilerVersion('GCC', bin2, pr) : null;
-            const version_is_match = version2 === null ? false : version2.fullVersion === version.fullVersion;
+            const version2 = (isTrusted && await fs.exists(bin2)) ? await getCompilerVersion('GCC', bin2, pr) : null;
+            const version_is_match = version2 === null ? false : version === null ? false : version2.fullVersion === version.fullVersion;
             // For the kits with only `x86_64-pc-linux-gnu-gcc` provided:
             // We will have bin2 === bin1 because the regex did not make a replacement,
             // then version_match will be true, but no C++ compiler will be found,
@@ -384,33 +390,36 @@ export async function kitIfCompiler(bin: string, pr?: ProgressReporter): Promise
             }
         }
         const gccKit: Kit = {
-            name: version.detectedName,
-            compilers: gccCompilers
+            name: version?.detectedName ?? localize('unknown.gcc.kit.untrusted', "Unknown GCC kit (untrusted path)"),
+            compilers: gccCompilers,
+            isTrusted
         };
 
-        if (isMingw(bin)) {
+        if (isTrusted && isMingw(bin)) {
             return asMingwKit(bin, gccKit);
         } else {
             return gccKit;
         }
 
     } else if (clang_res || clang_cl_res) {
-        const version = await getCompilerVersion('Clang', bin, pr);
-        if (version === null) {
-            return null;
-        }
+        const version = isTrusted ? await getCompilerVersion('Clang', bin, pr) : null;
+        if (isTrusted) {
+            if (version === null) {
+                return null;
+            }
 
-        if (version.target && version.target.triple.includes('msvc') &&
-            version.installedDir && version.installedDir.includes("Microsoft Visual Studio")) {
-            // Skip MSVC ABI compatible Clang installations (bundled within VS), which will be handled in 'scanForClangForMSVCKits()' later.
-            // But still process any Clang installations outside VS (right in Program Files for example), even if their version
-            // mentions msvc.
-            return null;
-        }
-        if (version.target && version.target.triple.includes('msvc') && clang_cl_res && isMingw(bin)) {
-            // Skip clang-cl.exe from mingw, as it won't work (correct access to MSVC environment is not granted).
-            // TODO: handle this case correctly at some point.
-            return null;
+            if (version.target && version.target.triple.includes('msvc') &&
+                version.installedDir && version.installedDir.includes("Microsoft Visual Studio")) {
+                // Skip MSVC ABI compatible Clang installations (bundled within VS), which will be handled in 'scanForClangForMSVCKits()' later.
+                // But still process any Clang installations outside VS (right in Program Files for example), even if their version
+                // mentions msvc.
+                return null;
+            }
+            if (version.target && version.target.triple.includes('msvc') && clang_cl_res && isMingw(bin)) {
+                // Skip clang-cl.exe from mingw, as it won't work (correct access to MSVC environment is not granted).
+                // TODO: handle this case correctly at some point.
+                return null;
+            }
         }
 
         const clangCompilers: { [lang: string]: string } = {};
@@ -428,8 +437,8 @@ export async function kitIfCompiler(bin: string, pr?: ProgressReporter): Promise
             const clangxx_fname2 = clang_cl_res ? fname : fname2.replace(/clang/, 'clang++');
             const clangxx_bin2 = path.join(path.dirname(bin), clangxx_fname2);
             // Ensure the version is match
-            const version2 = await fs.exists(bin2) ? await getCompilerVersion('Clang', bin2, pr) : null;
-            const version_is_match = version2 === null ? false : version2.fullVersion === version.fullVersion;
+            const version2 = (isTrusted && await fs.exists(bin2)) ? await getCompilerVersion('Clang', bin2, pr) : null;
+            const version_is_match = version2 === null ? false : version === null ? false : version2.fullVersion === version.fullVersion;
             // For the kits with only `clang` provided:
             // We will have bin2 === bin1 because the regex did not make a replacement,
             // then version_match will be true, but no C++ compiler will be found,
@@ -447,11 +456,13 @@ export async function kitIfCompiler(bin: string, pr?: ProgressReporter): Promise
             }
         }
         const clangKit: Kit = {
-            name: clang_cl_res ? version.detectedName.replace(/^Clang/, 'Clang-cl') : version.detectedName,
-            compilers: clangCompilers
+            name: (clang_cl_res ? version?.detectedName.replace(/^Clang/, 'Clang-cl') : version?.detectedName)
+                ?? localize('unknown.clang.kit.untrusted', "Unknown Clang kit (untrusted path)"),
+            compilers: clangCompilers,
+            isTrusted
         };
 
-        if (isMingw(bin)) {
+        if (isTrusted && isMingw(bin)) {
             return asMingwKit(bin, clangKit);
         } else {
             return clangKit;
@@ -509,13 +520,14 @@ async function scanDirectory<Ret>(dir: string, mapper: (filePath: string) => Pro
 /**
  * Scans a directory for compiler binaries.
  * @param dir Directory containing candidate binaries
+ * @param isTrusted True iff the directory is a trusted path. Default true.
  * @returns A list of CompilerKits found
  */
-export async function scanDirForCompilerKits(dir: string, pr?: ProgressReporter): Promise<Kit[]> {
+export async function scanDirForCompilerKits(dir: string, isTrusted: boolean = true, pr?: ProgressReporter): Promise<Kit[]> {
     const kits = await scanDirectory(dir, async bin => {
         log.trace(localize('checking.file.for.compiler.features', 'Checking file for compiler features: {0}', bin));
         try {
-            const kit: Kit | null = await kitIfCompiler(bin, pr);
+            const kit: Kit | null = await kitIfCompiler(bin, isTrusted, pr);
             if (kit?.compilers) {
                 log.trace(`Kit found: ${kit.name}`);
                 log.trace(`        C: ${kit.compilers['C']}`);
@@ -745,7 +757,8 @@ async function tryCreateNewVCEnvironment(inst: VSInstallation, hostArch: string,
     const kit: Kit = {
         name,
         visualStudio: kitVSName(inst),
-        visualStudioArchitecture: hostArch
+        visualStudioArchitecture: hostArch,
+        isTrusted: true
     };
 
     const version = /^(\d+)+./.exec(inst.installationVersion);
@@ -812,16 +825,16 @@ export async function scanForVSKits(pr?: ProgressReporter): Promise<Kit[]> {
     return ([] as Kit[]).concat(...vs_kits);
 }
 
-async function scanDirForClangForMSVCKits(dir: string, vsInstalls: VSInstallation[], cmakePath?: string): Promise<Kit[]> {
-    const kits = await scanDirectory(dir, async (binPath): Promise<Kit[] | null> => {
+async function scanDirForClangForMSVCKits(dir: PathWithTrust, vsInstalls: VSInstallation[], cmakePath?: string): Promise<Kit[]> {
+    const kits = await scanDirectory(dir.path, async (binPath): Promise<Kit[] | null> => {
         const isClangGnuCli = (path.basename(binPath, '.exe') === 'clang');
         const isClangMsvcCli = (path.basename(binPath, '.exe') === 'clang-cl');
         if (!isClangGnuCli && !isClangMsvcCli) {
             return null;
         }
 
-        const version = await getCompilerVersion('Clang', binPath);
-        if (version === null) {
+        const version = dir.isTrusted ? await getCompilerVersion('Clang', binPath) : null;
+        if (dir.isTrusted && version === null) {
             return null;
         }
 
@@ -850,10 +863,10 @@ async function scanDirForClangForMSVCKits(dir: string, vsInstalls: VSInstallatio
         const clangKits: Kit[] = [];
         for (const vs of vsInstalls) {
             const install_name = vsDisplayName(vs);
-            const vsArch = (version.target && version.target.triple.includes('i686-pc')) ? 'x86' : 'x64';
+            const vsArch = (version?.target && version.target.triple.includes('i686-pc')) ? 'x86' : 'x64';
             const archForKitName = vsArch === 'x86' ? 'x86' : 'amd64';
             const clangArchPath = (vsArch === "x64") ? "x64\\" : "";
-            const clangKitName: string = `Clang ${version.version} ${clang_cli} for MSVC ${vs.installationVersion} (${install_name} - ${archForKitName})`;
+            const clangKitName: string = `Clang ${version?.version} ${clang_cli} for MSVC ${vs.installationVersion} (${install_name} - ${archForKitName})`;
             const clangExists = async () => {
                 const exists = binPath.startsWith(`${vs.installationPath}\\VC\\Tools\\Llvm\\${clangArchPath}bin`) && await util.checkFileExists(util.lightNormalizePath(binPath));
                 return exists;
@@ -867,7 +880,8 @@ async function scanDirForClangForMSVCKits(dir: string, vsInstalls: VSInstallatio
                         compilers: {
                             C: binPath,
                             CXX: binPath
-                        }
+                        },
+                        isTrusted: dir.isTrusted
                     });
                 }
             } else {
@@ -887,7 +901,8 @@ async function scanDirForClangForMSVCKits(dir: string, vsInstalls: VSInstallatio
                             compilers: {
                                 C: binPath,
                                 CXX: binPath
-                            }
+                            },
+                            isTrusted: dir.isTrusted
                         });
                     }
                 }
@@ -899,7 +914,7 @@ async function scanDirForClangForMSVCKits(dir: string, vsInstalls: VSInstallatio
     return ([] as Kit[]).concat(...kits);
 }
 
-export async function scanForClangForMSVCKits(searchPaths: string[], cmakePath?: string): Promise<Promise<Kit[]>[]> {
+export async function scanForClangForMSVCKits(searchPaths: PathWithTrust[], cmakePath?: string): Promise<Promise<Kit[]>[]> {
     const vs_installs = await vsInstallations();
     const results = searchPaths.map(p => scanDirForClangForMSVCKits(p, vs_installs, cmakePath));
     return results;
@@ -1027,12 +1042,20 @@ export async function scanForKits(cmakePath?: string, opt?: KitScanOptions) {
         title: localize('scanning.for.kits', 'Scanning for kits')
     };
 
-    return vscode.window.withProgress(prog, async pr => {
+    const untrusted_paths = new Set<string>();
+
+    const result = await vscode.window.withProgress(prog, async pr => {
         const isWin32 = process.platform === 'win32';
 
         pr.report({ message: localize('scanning.for.cmake.kits', 'Scanning for CMake kits...') });
 
-        const scan_paths = new Set<string>();
+        // Maps paths to booleans indicating if the path is trusted.
+        const scan_paths = new Map<string, boolean>();
+        function addScanPath(path: string, trusted: boolean, paths?: Map<string, boolean>) {
+            const normalizedPath = util.lightNormalizePath(path);
+            const map = paths ?? scan_paths;
+            map.set(normalizedPath, map.get(normalizedPath) || trusted);
+        }
 
         // Search directories on `PATH` for compiler binaries
         if (process.env.hasOwnProperty('PATH')) {
@@ -1041,14 +1064,15 @@ export async function scanForKits(cmakePath?: string, opt?: KitScanOptions) {
             } else {
                 const sep = isWin32 ? ';' : ':';
                 for (const dir of (process.env.PATH as string).split(sep)) {
-                    scan_paths.add(dir);
+                    // Directories on PATH are considered trusted
+                    addScanPath(dir, true);
                 }
             }
         }
 
         if (opt?.scanDirs) {
             for (const dir of opt.scanDirs) {
-                scan_paths.add(dir);
+                addScanPath(dir, true);
             }
         }
 
@@ -1056,24 +1080,24 @@ export async function scanForKits(cmakePath?: string, opt?: KitScanOptions) {
         let kit_promises = [] as Promise<Kit[]>[];
 
         // Default installation locations
-        paths.windows.defaultCompilerPaths.LLVM.forEach(scan_paths.add, scan_paths);
-        paths.windows.defaultCompilerPaths.MSYS2.forEach(scan_paths.add, scan_paths);
+        paths.windows.defaultCompilerPaths.LLVM.forEach(p => addScanPath(p.path, p.isTrusted));
+        paths.windows.defaultCompilerPaths.MSYS2.forEach(p => addScanPath(p.path, p.isTrusted));
 
-        const compiler_kits = Array.from(scan_paths).map(path_el => scanDirForCompilerKits(path_el, pr));
+        const compiler_kits = Array.from(scan_paths).map(path_el => scanDirForCompilerKits(path_el[0], path_el[1], pr));
         kit_promises = kit_promises.concat(compiler_kits);
 
         if (isWin32) {
             // Prepare clang-cl search paths
-            const clang_paths = new Set<string>();
+            const clang_paths = new Map<string, boolean>();
 
             // LLVM_ROOT environment variable location
             if (process.env.hasOwnProperty('LLVM_ROOT')) {
                 const llvm_root = path.normalize(process.env.LLVM_ROOT as string + "\\bin");
-                clang_paths.add(llvm_root);
+                addScanPath(llvm_root, true, clang_paths);
             }
 
             // PATH environment variable locations
-            scan_paths.forEach(path_el => clang_paths.add(path_el));
+            scan_paths.forEach((isTrusted, path) => addScanPath(path, isTrusted, clang_paths));
             // LLVM bundled in VS locations
             const vs_installs = await vsInstallations();
             const bundled_clang_paths: string[] = [];
@@ -1081,21 +1105,49 @@ export async function scanForKits(cmakePath?: string, opt?: KitScanOptions) {
                 bundled_clang_paths.push(vs_install.installationPath + "\\VC\\Tools\\Llvm\\bin");
                 bundled_clang_paths.push(vs_install.installationPath + "\\VC\\Tools\\Llvm\\x64\\bin");
             });
-            bundled_clang_paths.forEach(path_el => clang_paths.add(path_el));
+            bundled_clang_paths.forEach(path_el => addScanPath(path_el, true, clang_paths));
 
             // Scan for kits
             const vs_kits = scanForVSKits(pr);
             kit_promises.push(vs_kits);
-            const clang_kits = await scanForClangForMSVCKits(Array.from(clang_paths), cmakePath);
+            const clang_kits = await scanForClangForMSVCKits(
+                // eslint-disable-next-line arrow-body-style
+                Array.from(clang_paths).map(([path, isTrusted]) => {
+                    return { path, isTrusted };
+                }), cmakePath);
             kit_promises = kit_promises.concat(clang_kits);
         }
 
         const arrays = await Promise.all(kit_promises);
         const kits = ([] as Kit[]).concat(...arrays);
-        kits.map(k => log.info(localize('found.kit', 'Found Kit: {0}', k.name)));
+        kits.map(k => log.info(localize(
+            'found.kit',
+            'Found Kit ({0}): {1}',
+            k.isTrusted ? localize('trusted', 'trusted') : localize('untrusted', 'untrusted'),
+            k.name)));
+
+        scan_paths.forEach((isTrusted, path) => !isTrusted ? untrusted_paths.add(path) : undefined);
 
         return kits;
     });
+
+    const untrustedKits = result.filter(kit => !kit.isTrusted);
+    if (untrustedKits.length > 0) {
+        void vscode.window.showWarningMessage<{ action: 'trust' | 'ignore'; title: string }>(
+            localize('untrusted.kits.found', 'Kits were found in untrusted paths: {0}. Add these paths to "cmake.additionalCompilerSearchDirs" to trust them.', Array.from(untrusted_paths).toString()),
+            { action: 'trust', title: localize('trust', 'Trust') },
+            { action: 'ignore', title: localize('ignore', 'Ignore') }).then(async action => {
+            if (action?.action === 'trust') {
+                const settings = vscode.workspace.getConfiguration('cmake');
+                const additionalCompilerSearchDirs = settings.get<string[]>('additionalCompilerSearchDirs', []);
+                additionalCompilerSearchDirs.push(...Array.from(untrusted_paths));
+                await settings.update('additionalCompilerSearchDirs', additionalCompilerSearchDirs, vscode.ConfigurationTarget.Global);
+                await vscode.commands.executeCommand('cmake.scanForKits');
+            }
+        });
+    }
+
+    return result.filter(kit => kit.isTrusted);
 }
 
 // Rescan if the kits versions (extension context state var versus value defined for this release) don't match.
@@ -1186,7 +1238,11 @@ export async function readKitsFile(filePath: string, workspaceFolder?: string, e
         }
         return [];
     }
-    const kits = kits_raw as Kit[];
+    const kits = (kits_raw as Kit[]).map(kit => {
+        // Serialized kits are trusted for backwards compatibility if not otherwise specified.
+        kit.isTrusted = kit.isTrusted === undefined ? true : kit.isTrusted;
+        return kit;
+    });
     log.info(localize('successfully.loaded.kits', 'Successfully loaded {0} kits from {1}', kits.length, filePath));
 
     const expandedKits: Kit[] = [];

--- a/src/kitsController.ts
+++ b/src/kitsController.ts
@@ -117,9 +117,9 @@ export class KitsController {
         // Special kits - include order is important
         KitsController.specialKits = [
             // Spcial __scanforkits__ kit used for invoking the "Scan for kits"
-            { name: SpecialKits.ScanForKits },
+            { name: SpecialKits.ScanForKits, isTrusted: true },
             // Special __unspec__ kit for opting-out of kits
-            { name: SpecialKits.Unspecified }
+            { name: SpecialKits.Unspecified, isTrusted: true }
         ];
 
         // Load user-kits

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -17,19 +17,24 @@ interface VSCMakePaths {
     ninja?: string;
 }
 
+export interface PathWithTrust {
+    path: string;
+    isTrusted: boolean;
+}
+
 class WindowsDefaultCompilerPaths {
     constructor(private readonly _env: WindowsEnvironment) {
         this._env = _env;
     }
 
-    get LLVM(): string[] {
+    get LLVM(): PathWithTrust[] {
         return [
             this._env.ProgramFiles! + "\\LLVM\\bin",
             this._env.ProgramFilesX86! + "\\LLVM\\bin"
-        ];
+        ].map(p => ({ path: p, isTrusted: true }));
     }
 
-    get MSYS2(): string[] {
+    get MSYS2(): PathWithTrust[] {
         return [
             paths.windows.SystemDrive! + '\\msys64\\mingw32\\bin',
             paths.windows.SystemDrive! + '\\msys64\\mingw64\\bin',
@@ -37,7 +42,7 @@ class WindowsDefaultCompilerPaths {
             paths.windows.SystemDrive! + '\\msys64\\clang64\\bin',
             paths.windows.SystemDrive! + '\\msys64\\clangarm64\\bin',
             paths.windows.SystemDrive! + '\\msys64\\ucrt64\\bin'
-        ];
+        ].map(p => ({ path: p, isTrusted: false }));
     }
 }
 

--- a/test/smoke/smoke.ts
+++ b/test/smoke/smoke.ts
@@ -23,7 +23,7 @@ export class SmokeContext {
         const cmakeProject = cmakeProjects[0];
         if (opts.kit) {
             if (opts.kit === SpecialKits.Unspecified) {
-                await cmakeProject.setKit({ name: SpecialKits.Unspecified });
+                await cmakeProject.setKit({ name: SpecialKits.Unspecified, isTrusted: true });
             } else {
                 await cmakeProject.setKit(opts.kit);
             }

--- a/test/unit-tests/driver/driver-codemodel-tests.ts
+++ b/test/unit-tests/driver/driver-codemodel-tests.ts
@@ -46,7 +46,7 @@ export function makeCodeModelDriverTestsuite(driverName: string, driver_generato
                 preferredGenerator: {name: 'Visual Studio 16 2019', platform: 'x64', toolset: 'host=x64'}
             } as Kit;
         } else {
-            kitDefault = { name: 'GCC', compilers: { C: 'gcc', CXX: 'g++' }, preferredGenerator: { name: 'Unix Makefiles' } } as Kit;
+            kitDefault = { name: 'GCC', compilers: { C: 'gcc', CXX: 'g++' }, preferredGenerator: { name: 'Unix Makefiles' }, isTrusted: true } as Kit;
         }
 
         setup(async function (this: Mocha.Context, done) {

--- a/test/unit-tests/driver/driver-test.ts
+++ b/test/unit-tests/driver/driver-test.ts
@@ -43,7 +43,7 @@ export function makeDriverTestsuite(driverName: string, driver_generator: (cmake
                 preferredGenerator: { name: 'Ninja' }
             } as Kit;
         } else {
-            ninjaKitDefault = { name: 'GCC', compilers: { C: 'gcc', CXX: 'g++' }, preferredGenerator: { name: 'Ninja' } } as Kit;
+            ninjaKitDefault = { name: 'GCC', compilers: { C: 'gcc', CXX: 'g++' }, preferredGenerator: { name: 'Ninja' }, isTrusted: true } as Kit;
         }
         let secondaryKit: Kit;
         if (process.platform === 'win32') {
@@ -54,7 +54,7 @@ export function makeDriverTestsuite(driverName: string, driver_generator: (cmake
                 preferredGenerator: {name: 'Visual Studio 16 2019', platform: 'x64'}
             } as Kit;
         } else {
-            secondaryKit = { name: 'GCC', compilers: { C: 'gcc', CXX: 'g++' }, preferredGenerator: { name: 'Unix Makefiles' } } as Kit;
+            secondaryKit = { name: 'GCC', compilers: { C: 'gcc', CXX: 'g++' }, preferredGenerator: { name: 'Unix Makefiles' }, isTrusted: true } as Kit;
         }
 
         setup(async function (this: Mocha.Context, done) {
@@ -175,12 +175,12 @@ export function makeDriverTestsuite(driverName: string, driver_generator: (cmake
             driver = await driver_generator(executable, config, ninjaKitDefault, defaultWorkspaceFolder, async () => {}, []);
 
             // Set kit without a preferred generator
-            await driver.setKit({ name: 'GCC' }, []);
+            await driver.setKit({ name: 'GCC', isTrusted: true }, []);
             expect(await driver.cleanConfigure(ConfigureTrigger.runTests, [])).to.be.eq(0);
             const kit1 = driver.cmakeCacheEntries?.get('CMAKE_GENERATOR')!.value;
 
             // Set kit with a list of two default preferred generators, for comparison
-            await driver.setKit({ name: 'GCC' }, [{ name: 'Ninja' }, { name: 'Unix Makefiles' }]);
+            await driver.setKit({ name: 'GCC', isTrusted: true }, [{ name: 'Ninja' }, { name: 'Unix Makefiles' }]);
             expect(await driver.configure(ConfigureTrigger.runTests, [])).to.be.eq(0);
             const kit2 = driver.cmakeCacheEntries?.get('CMAKE_GENERATOR')!.value;
 

--- a/test/unit-tests/kitmanager.test.ts
+++ b/test/unit-tests/kitmanager.test.ts
@@ -55,7 +55,7 @@ suite('Kits test', () => {
             await fs.writeFile(script_path, `export "TESTVAR12=abc"\nexport "TESTVAR13=cde"`);
         }
 
-        const kit = { name: "Test Kit 1", environmentSetupScript: script_path };
+        const kit = { name: "Test Kit 1", environmentSetupScript: script_path, isTrusted: true };
         const env_vars = await getShellScriptEnvironment(kit);
         await fs.unlink(script_path);
         expect(env_vars).to.not.be.undefined;


### PR DESCRIPTION
This PR adds a notion of trust to each path used when scanning for kits. Paths from the `PATH` environment variable, in Program Files (on Windows), and from `settings.json` are implicitly trusted. Other paths are not trusted. Kits in untrusted paths will still be scanned, but the executables will not be invoked until the user has trusted them. If untrusted kits are found, the user is prompted to trust them with this notification. Clicking the "Trust" button will automatically edit `settings.json` to add the paths and scan again. 

![image](https://user-images.githubusercontent.com/6981284/226498309-fa8199d1-378d-4a74-916f-ed52fc44df8a.png)

This is a security follow-up from #3056. FYI @philippewarren 