### PR TITLE
Improving stability of the test explorer

### DIFF
--- a/src/ctest.ts
+++ b/src/ctest.ts
@@ -506,24 +506,49 @@ export class CTestDriver implements vscode.Disposable {
         } else {
             buildConfigArgs.push('-C', driver.currentBuildType);
         }
-        const result = await driver.executeCommand(ctestpath, ['--show-only=json-v1', ...buildConfigArgs], undefined, { cwd: driver.binaryDir, silent: true }).result;
-        if (result.retc !== 0) {
-            // There was an error running CTest. Odd...
-            log.error(localize('ctest.error', 'There was an error running ctest to determine available test executables'));
-            return result.retc || -3;
+        if (!driver.cmake.version || util.versionLess(driver.cmake.version, { major: 3, minor: 14, patch: 0 })) {
+            // ctest --show-only=json-v1 was added in CMake 3.14
+            const result = await driver.executeCommand(ctestpath, ['-N', ...buildConfigArgs], undefined, { cwd: driver.binaryDir, silent: true }).result;
+            if (result.retc !== 0) {
+                // There was an error running CTest. Odd...
+                log.error(localize('ctest.error', 'There was an error running ctest to determine available test executables'));
+                return result.retc || -3;
+            }
+            const tests = result.stdout?.split('\n')
+                .map(l => l.trim())
+                .filter(l => /^Test\s*#(\d+):\s(.*)/.test(l))
+                .map(l => /^Test\s*#(\d+):\s(.*)/.exec(l)!)
+                .map(([, id, tname]) => ({ id: parseInt(id!), name: tname! })) ?? [];
+
+            // Add tests to the test explorer
+            for (const test of tests) {
+                testExplorerRoot.children.add(initializedTestExplorer.createTestItem(test.name, test.name));
+            }
+        } else {
+            const result = await driver.executeCommand(ctestpath, ['--show-only=json-v1', ...buildConfigArgs], undefined, { cwd: driver.binaryDir, silent: true }).result;
+            if (result.retc !== 0) {
+                // There was an error running CTest. Odd...
+                log.error(localize('ctest.error', 'There was an error running ctest to determine available test executables'));
+                return result.retc || -3;
+            }
+            this.tests = JSON.parse(result.stdout) ?? undefined;
+            if (this.tests && this.tests.kind === 'ctestInfo') {
+                this.tests.tests.forEach(test => {
+                    if (test.backtrace !== undefined && this.tests!.backtraceGraph.nodes[test.backtrace] !== undefined) {
+                        const testDefFile = this.tests!.backtraceGraph.files[this.tests!.backtraceGraph.nodes[test.backtrace].file];
+                        const testDefLine = this.tests!.backtraceGraph.nodes[test.backtrace].line;
+                        const testItem = initializedTestExplorer.createTestItem(test.name, test.name, vscode.Uri.file(testDefFile));
+                        if (testDefLine !== undefined) {
+                            testItem.range = new vscode.Range(new vscode.Position(testDefLine - 1, 0), new vscode.Position(testDefLine - 1, 0));
+                        }
+                        testExplorerRoot.children.add(testItem);
+                    } else {
+                        const testItem = initializedTestExplorer.createTestItem(test.name, test.name);
+                        testExplorerRoot.children.add(testItem);
+                    }
+                });
+            };
         }
-        this.tests = JSON.parse(result.stdout) ?? undefined;
-        if (this.tests && this.tests.kind === 'ctestInfo') {
-            this.tests.tests.forEach(test => {
-                const testDefFile = this.tests!.backtraceGraph.files[this.tests!.backtraceGraph.nodes[test.backtrace].file];
-                const testDefLine = this.tests!.backtraceGraph.nodes[test.backtrace].line;
-                const testItem = initializedTestExplorer.createTestItem(test.name, test.name, vscode.Uri.file(testDefFile));
-                if (testDefLine !== undefined) {
-                    testItem.range = new vscode.Range(new vscode.Position(testDefLine - 1, 0), new vscode.Position(testDefLine - 1, 0));
-                }
-                testExplorerRoot.children.add(testItem);
-            });
-        };
 
         return 0;
     }


### PR DESCRIPTION
This change addresses item #3069

Based on the discussion in the issue above, the test backtrace info may be lacking in certain cases. Therefore, adding some checks around node creation for the test explorer.

During investigation, I found that command `cmake --show-only=json-v1` was added in 3.14. So use `cmake -N` for older cmake.