### PR TITLE
Better root node label in test explorer

### DIFF
--- a/src/ctest.ts
+++ b/src/ctest.ts
@@ -834,7 +834,10 @@ export class CTestDriver implements vscode.Disposable {
             if (this.projectController) {
                 for (const project of this.projectController.getAllCMakeProjects()) {
                     const folderPath = util.platformNormalizePath(project.folderPath);
-                    testExplorer.items.add(testExplorer.createTestItem(folderPath, folderPath));
+                    const folderName = path.basename(project.folderPath);
+                    const testItem = testExplorer.createTestItem(folderPath, folderName);
+                    testItem.description = folderPath;
+                    testExplorer.items.add(testItem);
                 }
             }
 


### PR DESCRIPTION
In the test explorer, use folder name instead of the full path to the project folder as the root node label. Full path is now moved to the description.
![image](https://user-images.githubusercontent.com/44103947/228680015-34a78981-0287-4f17-80c8-5caa86dce088.png)
