### PR TITLE
Fix EACCES error code name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Bug Fixes:
 - Expand variables in task's targets while searching matching taks. [#2970](https://github.com/microsoft/vscode-cmake-tools/issues/2970) [@piomis](https://github.com/piomis)
 - Fix typo in `cmake.skipConfigureWhenCachePresent`. [#3040](https://github.com/microsoft/vscode-cmake-tools/issues/3040) [@Mlekow](https://github.com/Mlekow)
 - Fix MinGW detection when not in PATH using `cmake.mingwSearchDirs` (now named `cmake.additionalCompilerSearchDirs`). [PR #3056](https://github.com/microsoft/vscode-cmake-tools/pull/3056) [@philippewarren](https://github.com/philippewarren)
+- Fix check for `EACCES` error code [#3097](https://github.com/microsoft/vscode-cmake-tools/pull/3097)
 
 ## 1.13.45
 Bug Fixes:

--- a/src/kit.ts
+++ b/src/kit.ts
@@ -505,7 +505,7 @@ async function scanDirectory<Ret>(dir: string, mapper: (filePath: string) => Pro
         bins = (await fs.readdir(dir)).map(f => path.join(dir, f));
     } catch (ce) {
         const e = ce as NodeJS.ErrnoException;
-        if (e.code === 'EACCESS' || e.code === 'EPERM') {
+        if (e.code === 'EACCES' || e.code === 'EPERM') {
             return [];
         }
         console.log('unexpected file system error');


### PR DESCRIPTION
## The purpose of this change

The error code is actually [`EACCES`](https://nodejs.org/api/errors.html#common-system-errors), not `EACCESS`.
