### PR TITLE
Fix Windows tests by pinning Node version

### DIFF
--- a/.github/workflows/ci-main-linux.yml
+++ b/.github/workflows/ci-main-linux.yml
@@ -13,10 +13,16 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Setup Yarn environment
-        uses: DerYeger/yarn-setup-action@v1.0.1
+      - name: Setup Node environment
+        uses: actions/setup-node@v3
         with:
           node-version: 16
+
+      - name: Install Yarn
+        run: npm install -g yarn
+
+      - name: Install dependencies
+        run: yarn install
 
       - name: Build the extension
         run: yarn compile-production

--- a/.github/workflows/ci-main-mac.yml
+++ b/.github/workflows/ci-main-mac.yml
@@ -13,10 +13,16 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Setup Yarn environment
-        uses: DerYeger/yarn-setup-action@v1.0.1
+      - name: Setup Node environment
+        uses: actions/setup-node@v3
         with:
           node-version: 16
+
+      - name: Install Yarn
+        run: npm install -g yarn
+
+      - name: Install dependencies
+        run: yarn install
 
       - name: Build the extension
         run: yarn compile-production

--- a/.github/workflows/ci-main.win.yml
+++ b/.github/workflows/ci-main.win.yml
@@ -14,10 +14,16 @@ jobs:
       - name: Checkout source code
         uses: actions/checkout@v3
 
-      - name: Setup Yarn environment
-        uses: DerYeger/yarn-setup-action@v1.0.1
+      - name: Setup Node environment
+        uses: actions/setup-node@v3
         with:
           node-version: 16
+
+      - name: Install Yarn
+        run: npm install -g yarn
+
+      - name: Install dependencies
+        run: yarn install
 
       - name: Build the extension
         run: yarn compile-production


### PR DESCRIPTION
The GitHub actions runners recently updated from Node 18.15.0 to 18.16.0, which broke the archive extraction that `@vscode/test-electron` uses when downloading a new version of VS Code. This change also exposed that the `yarn-setup-action` we were using before actually wasn't having any impact on the version of Node used by later Yarn commands. The fix manually pins the Node version and installs Yarn.