### PR TITLE
Remove MinGW paths only when using a MinGW kit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## 1.15
 
 Bug Fixes:
-- When `cmake.buildTasks` is `true`, CMake tasks in `tasks.json` that do not specify `targets` will no longer cause the build to fail. [#3123] (https://github.com/microsoft/vscode-cmake-tools/issues/3123)
+- When `cmake.buildTasks` is `true`, CMake tasks in `tasks.json` that do not specify `targets` will no longer cause the build to fail. [#3123](https://github.com/microsoft/vscode-cmake-tools/issues/3123)
+- Paths containing `mingw` are no longer removed from the `PATH` environment variable when configuring a project without specifying a kit. [#3136](https://github.com/microsoft/vscode-cmake-tools/issues/3136)
 
 ## 1.14.30
 Bug Fixes:

--- a/src/kit.ts
+++ b/src/kit.ts
@@ -989,10 +989,12 @@ export async function effectiveKitEnvironment(kit: Kit, opts?: expand.ExpansionO
                 path_list.push(mingwPath);
             }
             if (env.hasOwnProperty('PATH')) {
-                // Remove other mingw from PATH as it will cause conflict
-                const current_path_list = (env['PATH']?.split(';') ?? []);
-                const current_path_list_without_mingw = current_path_list.filter(p => !isMingw(p));
-                path_list.unshift(current_path_list_without_mingw.join(';'));
+                let current_path_list = (env['PATH']?.split(';') ?? []);
+                if (mingwPath) {
+                    // Remove other mingw from PATH as it will cause conflict
+                    current_path_list = current_path_list.filter(p => !isMingw(p));
+                }
+                path_list.unshift(current_path_list.join(';'));
                 env['PATH'] = path_list.join(';');
             }
         }


### PR DESCRIPTION
Fixes #3136 and maybe #3125 and #3127

The issue with the old code was that it always stripped MinGW paths from the `PATH` environment variable even if a MinGW compiler hadn't been detected earlier and moved to the beginning of `PATH`. This causes problems when attempting to use MinGW without specifying a kit, as MinGW will vanish entirely from `PATH`.

FYI @philippewarren 