### PR TITLE
fixing warning identification in outputs when building through tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 Bug Fixes:
 - When `cmake.buildTasks` is `true`, CMake tasks in `tasks.json` that do not specify `targets` will no longer cause the build to fail. [#3123](https://github.com/microsoft/vscode-cmake-tools/issues/3123)
 - Paths containing `mingw` are no longer removed from the `PATH` environment variable when configuring a project without specifying a kit. [#3136](https://github.com/microsoft/vscode-cmake-tools/issues/3136)
+- Warning messages are no longer triggered by targets containing "warning" in the file path when running `Tasks: Run Build Task`. [#3118](https://github.com/microsoft/vscode-cmake-tools/issues/3118)
 
 ## 1.14.30
 Bug Fixes:

--- a/src/cmakeTaskProvider.ts
+++ b/src/cmakeTaskProvider.ts
@@ -492,7 +492,7 @@ export class CustomBuildTaskTerminal implements vscode.Pseudoterminal, proc.Outp
             this._process = undefined;
             if (result.retc) {
                 this.writeEmitter.fire(localize("build.finished.with.error", "{0} finished with error(s).", taskName) + endOfLine);
-            } else if (result.stderr || (result.stdout && result.stdout.includes("warning"))) {
+            } else if (result.stderr || (result.stdout && result.stdout.includes(": warning"))) {
                 this.writeEmitter.fire(localize("build.finished.with.warnings", "{0} finished with warning(s).", taskName) + endOfLine);
             } else {
                 this.writeEmitter.fire(localize("build.finished.successfully", "{0} finished successfully.", taskName) + endOfLine);


### PR DESCRIPTION
When running a build using tasks, if "warning" was a part of the target file path (which is part of the output), it would identify the output as "finished with warning(s)" because we would check for "warning" appearing anywhere in the output to identify actual compiler warnings. I changed the check from looking for "warning" to looking for ": warning" to be more specific. This addresses issue [3118](https://github.com/microsoft/vscode-cmake-tools/issues/3118).

I tested various compilers [here](https://godbolt.org/) to see how warning messages were structured:
![image](https://user-images.githubusercontent.com/113148726/234696506-7cc68d3f-48bb-4ac9-80e8-a289006dfb6f.png)
