### PR TITLE
Fix test explorer hang

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # What's New?
 
+## 1.15.0
+Bug Fixes:
+- Handle multiple test results in one test run. [#3160](https://github.com/microsoft/vscode-cmake-tools/pull/3160)
+- When starting test and test preset is not selected, prompt for test preset selection. [#3163](https://github.com/microsoft/vscode-cmake-tools/pull/3163)
+
 ## 1.14.31
 Bug Fixes:
 - When `cmake.buildTasks` is `true`, CMake tasks in `tasks.json` that do not specify `targets` will no longer cause the build to fail. [#3123](https://github.com/microsoft/vscode-cmake-tools/issues/3123)


### PR DESCRIPTION
Fix issue #3154, and show a test preset picker when it's not set when running tests.