### PR TITLE
Dev/snehara/sidebar ab testing

### DIFF
--- a/package.json
+++ b/package.json
@@ -1998,6 +1998,7 @@
           "type": "string",
           "default": "default",
           "description": "%cmake-tools.configuration.cmake.statusbar.visibility.description%",
+          "markdownDescription": "%cmake-tools.configuration.cmake.statusbar.advanced.visibility.markdownDescription%",
           "enum": [
             "default",
             "compact",
@@ -2218,6 +2219,12 @@
             }
           }
         },
+        "cmake.useProjectStatusView": {
+          "type": "boolean",
+          "default": true,
+          "description": "%cmake-tools.configuration.cmake.useProjectStatusView.description%",
+          "scope": "window"
+        },
         "cmake.additionalKits": {
           "type": "array",
           "default": [],
@@ -2343,7 +2350,7 @@
         {
           "id": "cmake.projectStatus",
           "name": "%cmake-tools.configuration.views.cmake.projectStatus.description%",
-          "when": "cmake:enableFullFeatureSet"
+          "when": "cmake:enableFullFeatureSet && config.cmake.useProjectStatusView != false"
         },
         {
           "id": "cmake.outline",

--- a/package.json
+++ b/package.json
@@ -89,16 +89,44 @@
         "category": "CMake"
       },
       {
+        "command": "cmake.projectStatus.selectConfigurePreset",
+        "title": "%cmake-tools.command.cmake.selectConfigurePreset.title%",
+        "when": "cmake:enableFullFeatureSet && useCMakePresets",
+        "category": "CMake",
+        "icon": "$(edit)"
+      },
+      {
         "command": "cmake.selectBuildPreset",
         "title": "%cmake-tools.command.cmake.selectBuildPreset.title%",
         "when": "cmake:enableFullFeatureSet && useCMakePresets",
         "category": "CMake"
       },
       {
+        "command": "cmake.projectStatus.selectBuildPreset",
+        "title": "%cmake-tools.command.cmake.selectBuildPreset.title%",
+        "when": "cmake:enableFullFeatureSet && useCMakePresets",
+        "category": "CMake",
+        "icon": "$(edit)"
+      },
+      {
         "command": "cmake.selectTestPreset",
         "title": "%cmake-tools.command.cmake.selectTestPreset.title%",
         "when": "cmake:enableFullFeatureSet && useCMakePresets",
         "category": "CMake"
+      },
+      {
+        "command": "cmake.projectStatus.selectTestPreset",
+        "title": "%cmake-tools.command.cmake.selectTestPreset.title%",
+        "when": "cmake:enableFullFeatureSet && useCMakePresets",
+        "category": "CMake",
+        "icon": "$(edit)"
+      },
+      {
+        "command": "cmake.projectStatus.setTestTarget",
+        "title": "%cmake-tools.command.cmake.projectStatus.selectTestPreset.title%",
+        "when": "cmake:enableFullFeatureSet && useCMakePresets",
+        "category": "CMake",
+        "icon": "$(edit)"
       },
       {
         "command": "cmake.viewLog",
@@ -117,6 +145,13 @@
         "title": "%cmake-tools.command.cmake.selectActiveFolder.title%",
         "when": "cmake:enableFullFeatureSet",
         "category": "CMake"
+      },
+      {
+        "command": "cmake.projectStatus.selectActiveProject",
+        "title": "%cmake-tools.command.cmake.selectActiveFolder.title%",
+        "when": "cmake:enableFullFeatureSet",
+        "category": "CMake",
+        "icon": "$(edit)"
       },
       {
         "command": "cmake.outline.selectWorkspace",
@@ -149,10 +184,24 @@
         "category": "CMake"
       },
       {
+        "command": "cmake.projectStatus.selectKit",
+        "title": "%cmake-tools.command.cmake.selectKit.title%",
+        "when": "cmake:enableFullFeatureSet",
+        "category": "CMake",
+        "icon": "$(edit)"
+      },
+      {
         "command": "cmake.setVariant",
         "title": "%cmake-tools.command.cmake.setVariant.title%",
         "when": "cmake:enableFullFeatureSet && !useCMakePresets",
         "category": "CMake"
+      },
+      {
+        "command": "cmake.projectStatus.setVariant",
+        "title": "%cmake-tools.command.cmake.setVariant.title%",
+        "when": "cmake:enableFullFeatureSet && !useCMakePresets",
+        "category": "CMake",
+        "icon": "$(edit)"
       },
       {
         "command": "cmake.setVariantAll",
@@ -172,6 +221,16 @@
           "dark": "res/dark/configure-icon.svg",
           "light": "res/light/configure-icon.svg"
         }
+      },
+      {
+        "command": "cmake.projectStatus.configure",
+        "title": "%cmake-tools.command.cmake.configure.title%",
+        "icon": {
+          "dark": "res/dark/configure-icon.svg",
+          "light": "res/light/configure-icon.svg"
+        },
+        "when": "cmake:enableFullFeatureSet",
+        "category": "CMake"
       },
       {
         "command": "cmake.showConfigureCommand",
@@ -199,6 +258,15 @@
       },
       {
         "command": "cmake.outline.build",
+        "title": "%cmake-tools.command.cmake.build.title%",
+        "when": "cmake:enableFullFeatureSet",
+        "icon": {
+          "dark": "res/dark/build-icon.svg",
+          "light": "res/light/build-icon.svg"
+        }
+      },
+      {
+        "command": "cmake.projectStatus.build",
         "title": "%cmake-tools.command.cmake.build.title%",
         "when": "cmake:enableFullFeatureSet",
         "icon": {
@@ -290,6 +358,13 @@
         "title": "%cmake-tools.command.cmake.outline.setDefaultTarget.title%"
       },
       {
+        "command": "cmake.projectStatus.setDefaultTarget",
+        "title": "%cmake-tools.command.cmake.setDefaultTarget.title%",
+        "when": "cmake:enableFullFeatureSet",
+        "category": "CMake",
+        "icon": "$(edit)"
+      },
+      {
         "command": "cmake.cleanConfigure",
         "title": "%cmake-tools.command.cmake.cleanConfigure.title%",
         "category": "CMake"
@@ -369,6 +444,13 @@
         "category": "CMake"
       },
       {
+        "command": "cmake.projectStatus.ctest",
+        "title": "%cmake-tools.command.cmake.ctest.title%",
+        "when": "cmake:enableFullFeatureSet",
+        "icon": "$(beaker)",
+        "category": "CMake"
+      },
+      {
         "command": "cmake.ctestAll",
         "title": "%cmake-tools.command.cmake.ctestAll.title%",
         "when": "cmake:enableFullFeatureSet",
@@ -415,10 +497,23 @@
         "title": "%cmake-tools.command.cmake.outline.debugTarget.title%"
       },
       {
+        "command": "cmake.projectStatus.debugTarget",
+        "when": "cmake:enableFullFeatureSet",
+        "title": "%cmake-tools.command.cmake.debugTarget.title%",
+        "category": "CMake",
+        "icon": "$(debug-alt)"
+      },
+      {
         "command": "cmake.debugTargetAll",
         "title": "%cmake-tools.command.cmake.debugTargetAll.title%",
         "when": "cmake:enableFullFeatureSet",
         "category": "CMake"
+      },
+      {
+        "command": "cmake.projectStatus.setDebugTarget",
+        "when": "cmake:enableFullFeatureSet",
+        "title": "%cmake-tools.command.cmake.selectLaunchTarget.title%",
+        "icon": "$(edit)"
       },
       {
         "command": "cmake.launchTarget",
@@ -430,6 +525,13 @@
         "command": "cmake.outline.launchTarget",
         "when": "cmake:enableFullFeatureSet",
         "title": "%cmake-tools.command.cmake.outline.launchTarget.title%"
+      },
+      {
+        "command": "cmake.projectStatus.launchTarget",
+        "when": "cmake:enableFullFeatureSet",
+        "title": "%cmake-tools.command.cmake.outline.launchTarget.title%",
+        "category": "CMake",
+        "icon": "$(run)"
       },
       {
         "command": "cmake.launchTargetAll",
@@ -449,19 +551,29 @@
         "title": "%cmake-tools.command.cmake.outline.setLaunchTarget.title%"
       },
       {
+        "command": "cmake.projectStatus.setLaunchTarget",
+        "when": "cmake:enableFullFeatureSet",
+        "title": "%cmake-tools.command.cmake.outline.setLaunchTarget.title%",
+        "icon": "$(edit)"
+      },
+      {
         "command": "cmake.stop",
         "title": "%cmake-tools.command.cmake.stop.title%",
         "when": "cmake:enableFullFeatureSet",
         "category": "CMake"
       },
       {
+        "command": "cmake.projectStatus.stop",
+        "title": "%cmake-tools.command.cmake.stop.title%",
+        "when": "cmake:enableFullFeatureSet",
+        "category": "CMake",
+        "icon": "$(x)"
+      },
+      {
         "command": "cmake.outline.stop",
         "title": "%cmake-tools.command.cmake.stop.title%",
         "when": "cmake:enableFullFeatureSet",
-        "icon": {
-          "dark": "res/dark/stop-icon.svg",
-          "light": "res/light/stop-icon.svg"
-        }
+        "icon": "$(x)"
       },
       {
         "command": "cmake.stopAll",
@@ -473,10 +585,7 @@
         "command": "cmake.outline.stopAll",
         "title": "%cmake-tools.command.cmake.stopAll.title%",
         "when": "cmake:enableFullFeatureSet",
-        "icon": {
-          "dark": "res/dark/stop-icon.svg",
-          "light": "res/light/stop-icon.svg"
-        }
+        "icon": "$(x)"
       },
       {
         "command": "cmake.resetState",
@@ -492,6 +601,13 @@
         "command": "cmake.outline.revealInCMakeLists",
         "when": "cmake:enableFullFeatureSet",
         "title": "%cmake-tools.command.cmake.outline.revealInCMakeLists.title%"
+      },
+      {
+        "command": "cmake.projectStatus.update",
+        "when": "cmake:enableFullFeatureSet",
+        "title": "%cmake-tools.command.cmake.projectStatus.update.title%",
+        "category": "CMake",
+        "icon": "$(refresh)"      
       }
     ],
     "taskDefinitions": [
@@ -825,9 +941,89 @@
         {
           "command": "cmake.outline.revealInCMakeLists",
           "when": "never"
+        },
+        {
+          "command": "cmake.projectStatus.update",
+          "when": "never"
+        },
+        {
+          "command": "cmake.projectStatus.stop",
+          "when": "never"
+        },
+        {
+          "command": "cmake.projectStatus.selectKit",
+          "when": "never"
+        },
+        {
+          "command": "cmake.projectStatus.configure",
+          "when": "never"
+        },
+        {
+          "command": "cmake.projectStatus.setVariant",
+          "when": "never"
+        },
+        {
+          "command": "cmake.projectStatus.selectConfigurePreset",
+          "when": "never"
+        },
+        {
+          "command": "cmake.projectStatus.build",
+          "when": "never"
+        },
+        {
+          "command": "cmake.projectStatus.setDefaultTarget",
+          "when": "never"
+        },
+        {
+          "command": "cmake.projectStatus.selectBuildPreset",
+          "when": "never"
+        },
+        {
+          "command": "cmake.projectStatus.ctest",
+          "when": "never"
+        },
+        {
+          "command": "cmake.projectStatus.debugTarget",
+          "when": "never"
+        },
+        {
+          "command": "cmake.projectStatus.launchTarget",
+          "when": "never"
+        },
+        {
+          "command": "cmake.projectStatus.setDebugTarget",
+          "when": "never"
+        },
+        {
+          "command": "cmake.projectStatus.setLaunchTarget",
+          "when": "never"
+        },
+        {
+          "command": "cmake.projectStatus.selectActiveProject",
+          "when": "never"
         }
       ],
       "view/title": [
+        {
+          "command": "cmake.projectStatus.update",
+          "when": "view == cmake.projectStatus && cmake:enableFullFeatureSet",
+          "group": "navigation@1"
+        },
+        {
+          "command": "cmake.projectStatus.stop",
+          "when": "view == cmake.projectStatus && cmake:isBuilding && cmake:enableFullFeatureSet",
+          "group": "navigation@2"
+        },
+        {
+          "command": "cmake.projectStatus.debugTarget",
+          "when": "view == cmake.projectStatus && !cmake:isBuilding && !cmake:hideDebugCommand && cmake:enableFullFeatureSet",
+          "group": "navigation@3"
+        },
+        {
+          "command": "cmake.projectStatus.launchTarget",
+          "when": "view == cmake.projectStatus && !cmake:isBuilding && !cmake:hideLaunchCommand && cmake:enableFullFeatureSet",
+          "group": "navigation@3"
+        },
         {
           "command": "cmake.outline.configureAll",
           "when": "view == cmake.outline && !cmake:isBuilding",
@@ -865,6 +1061,86 @@
         }
       ],
       "view/item/context": [
+        {
+          "command": "cmake.projectStatus.stop",
+          "when": "view == cmake.projectStatus && cmake:enableFullFeatureSet && viewItem == 'stop'",
+          "group": "inline"
+        },
+        {
+          "command": "cmake.projectStatus.selectKit",
+          "when": "view == cmake.projectStatus && cmake:enableFullFeatureSet && viewItem == 'kit'",
+          "group": "inline"
+        },
+        {
+          "command": "cmake.projectStatus.configure",
+          "when": "view == cmake.projectStatus && cmake:enableFullFeatureSet && viewItem == 'configure'",
+          "group": "inline"
+        },
+        {
+          "command": "cmake.projectStatus.setVariant",
+          "when": "view == cmake.projectStatus && cmake:enableFullFeatureSet && viewItem == 'variant'",
+          "group": "inline"
+        },
+        {
+          "command": "cmake.projectStatus.selectConfigurePreset",
+          "when": "view == cmake.projectStatus && cmake:enableFullFeatureSet && viewItem == 'configPreset'",
+          "group": "inline"
+        },
+        {
+          "command": "cmake.projectStatus.build",
+          "when": "view == cmake.projectStatus && cmake:enableFullFeatureSet && viewItem == 'build'",
+          "group": "inline"
+        },
+        {
+          "command": "cmake.projectStatus.setDefaultTarget",
+          "when": "view == cmake.projectStatus && cmake:enableFullFeatureSet && viewItem == 'buildTarget'",
+          "group": "inline"
+        },
+        {
+          "command": "cmake.projectStatus.selectBuildPreset",
+          "when": "view == cmake.projectStatus && cmake:enableFullFeatureSet && viewItem == 'buildPreset'",
+          "group": "inline"
+        },
+        {
+          "command": "cmake.projectStatus.ctest",
+          "when": "view == cmake.projectStatus && cmake:enableFullFeatureSet && viewItem == 'test'",
+          "group": "inline"
+        },
+        {
+          "command": "cmake.projectStatus.setTestTarget",
+          "when": "view == cmake.projectStatus && cmake:enableFullFeatureSet && viewItem == 'testTarget'",
+          "group": "inline"
+        },
+        {
+          "command": "cmake.projectStatus.selectTestPreset",
+          "when": "view == cmake.projectStatus && cmake:enableFullFeatureSet && viewItem == 'testPreset'",
+          "group": "inline"
+        },
+        {
+          "command": "cmake.projectStatus.debugTarget",
+          "when": "view == cmake.projectStatus && cmake:enableFullFeatureSet && viewItem == 'debug'",
+          "group": "inline"
+        },
+        {
+          "command": "cmake.projectStatus.setDebugTarget",
+          "when": "view == cmake.projectStatus && cmake:enableFullFeatureSet && viewItem == 'debugTarget'",
+          "group": "inline"
+        },
+        {
+          "command": "cmake.projectStatus.launchTarget",
+          "when": "view == cmake.projectStatus && cmake:enableFullFeatureSet && viewItem == 'launch'",
+          "group": "inline"
+        },
+        {
+          "command": "cmake.projectStatus.setLaunchTarget",
+          "when": "view == cmake.projectStatus && cmake:enableFullFeatureSet && viewItem == 'launchTarget'",
+          "group": "inline"
+        },
+        {
+          "command": "cmake.projectStatus.selectActiveProject",
+          "when": "view == cmake.projectStatus && cmake:enableFullFeatureSet && viewItem == 'activeProject'",
+          "group": "inline"
+        },
         {
           "command": "cmake.outline.buildTarget",
           "when": "view == cmake.outline && cmake:enableFullFeatureSet && viewItem =~ /canBuild=true|canRun=true/",
@@ -2055,7 +2331,7 @@
     "viewsContainers": {
       "activitybar": [
         {
-          "id": "cmake__viewContainer",
+          "id": "cmake-view",
           "title": "CMake",
           "icon": "res/cmake-view-icon2.svg",
           "when": "cmake:enableFullFeatureSet"
@@ -2063,7 +2339,12 @@
       ]
     },
     "views": {
-      "cmake__viewContainer": [
+      "cmake-view": [
+        {
+          "id": "cmake.projectStatus",
+          "name": "%cmake-tools.configuration.views.cmake.projectStatus.description%",
+          "when": "cmake:enableFullFeatureSet"
+        },
         {
           "id": "cmake.outline",
           "name": "%cmake-tools.configuration.views.cmake.outline.description%",

--- a/package.nls.json
+++ b/package.nls.json
@@ -161,7 +161,7 @@
     },
     "cmake-tools.configuration.cmake.statusbar.advanced.ctest.color.description": "Enables a change in color for this button depending on test results.",
     "cmake-tools.configuration.cmake.statusbar.advanced.length.description": "Configures the maximum length of visible text in 'compact' mode.",
-    "cmake-tools.configuration.cmake.useProjectStatusView.description": "Enables the Project Status view in the side bar and hides the status bar buttons.",
+    "cmake-tools.configuration.cmake.useProjectStatusView.description": "Enables the Project Status view in the CMake side panel and hides the status bar buttons.",
     "cmake-tools.configuration.views.cmake.folders.description": "Folders",
     "cmake-tools.configuration.views.cmake.projectStatus.description": "Project Status",
     "cmake-tools.configuration.views.cmake.outline.description": "Project Outline",

--- a/package.nls.json
+++ b/package.nls.json
@@ -153,8 +153,15 @@
     "cmake-tools.configuration.cmake.statusbar.visibility.description": "Configures how the extension displays the buttons in the status bar.",
     "cmake-tools.configuration.cmake.statusbar.advanced.description": "Configures the settings for individual status bar buttons. These settings overwrite the more general 'cmake.statusbar.visibility' setting.",
     "cmake-tools.configuration.cmake.statusbar.advanced.visibility.description": "Configures how the extension displays this button in the status bar.",
+    "cmake-tools.configuration.cmake.statusbar.advanced.visibility.markdownDescription": {
+        "message": "Configures how the extension displays this button in the status bar. Only applies when `#cmake.useProjectStatusView#` is set to `false`.",
+        "comment": [
+            "Markdown text between `` should not be translated or localized (they represent literal text) and the capitalization, spacing, and punctuation (including the ``) should not be altered."
+        ]
+    },
     "cmake-tools.configuration.cmake.statusbar.advanced.ctest.color.description": "Enables a change in color for this button depending on test results.",
     "cmake-tools.configuration.cmake.statusbar.advanced.length.description": "Configures the maximum length of visible text in 'compact' mode.",
+    "cmake-tools.configuration.cmake.useProjectStatusView.description": "Enables the Project Status view in the side bar and hides the status bar buttons.",
     "cmake-tools.configuration.views.cmake.folders.description": "Folders",
     "cmake-tools.configuration.views.cmake.projectStatus.description": "Project Status",
     "cmake-tools.configuration.views.cmake.outline.description": "Project Outline",

--- a/src/cmakeProject.ts
+++ b/src/cmakeProject.ts
@@ -2712,15 +2712,17 @@ export class CMakeProject {
     public hideDebugButton: boolean = false;
     public hideLaunchButton: boolean = false;
     doStatusBarChange(statusbar: StatusBarConfig) {
-        if (statusbar.visibility === "hidden") {
-            this.hideBuildButton = true;
-            this.hideDebugButton = true;
-            this.hideLaunchButton = true;
-            return;
+        if (!vscode.workspace.getConfiguration('cmake').get('useProjectStatusView', true)) {
+            if (statusbar.visibility === "hidden") {
+                this.hideBuildButton = true;
+                this.hideDebugButton = true;
+                this.hideLaunchButton = true;
+                return;
+            }
+            this.hideBuildButton = (statusbar.advanced?.build?.visibility === "hidden") ? true : false;
+            this.hideDebugButton = (statusbar.advanced?.debug?.visibility === "hidden") ? true : false;
+            this.hideLaunchButton = (statusbar.advanced?.launch?.visibility === "hidden") ? true : false;
         }
-        this.hideBuildButton = (statusbar.advanced?.build?.visibility === "hidden") ? true : false;
-        this.hideDebugButton = (statusbar.advanced?.debug?.visibility === "hidden") ? true : false;
-        this.hideLaunchButton = (statusbar.advanced?.launch?.visibility === "hidden") ? true : false;
     }
 
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -139,6 +139,7 @@ export interface ExtensionConfigurationSettings {
     additionalKits: string[];
     touchbar: TouchBarConfig;
     statusbar: StatusBarConfig;
+    useProjectStatusView: boolean;
     useCMakePresets: UseCMakePresets;
     allowCommentsInPresetsFile: boolean;
     allowUnsupportedPresetsVersions: boolean;
@@ -446,8 +447,13 @@ export class ConfigurationReader implements vscode.Disposable {
     get touchbar(): TouchBarConfig {
         return this.configData.touchbar;
     }
+
     get statusbar() {
         return this.configData.statusbar;
+    }
+
+    get useProjectStatusView(): boolean {
+        return this.configData.useProjectStatusView;
     }
 
     get launchBehavior(): string {
@@ -509,6 +515,7 @@ export class ConfigurationReader implements vscode.Disposable {
         additionalKits: new vscode.EventEmitter<string[]>(),
         touchbar: new vscode.EventEmitter<TouchBarConfig>(),
         statusbar: new vscode.EventEmitter<StatusBarConfig>(),
+        useProjectStatusView: new vscode.EventEmitter<boolean>(),
         useCMakePresets: new vscode.EventEmitter<UseCMakePresets>(),
         allowCommentsInPresetsFile: new vscode.EventEmitter<boolean>(),
         allowUnsupportedPresetsVersions: new vscode.EventEmitter<boolean>(),

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -210,7 +210,8 @@ export class ExtensionManager implements vscode.Disposable {
     }
 
     public showStatusBar(fullFeatureSet: boolean) {
-        if (true) { // TODO: set some variable to see what setting they have
+        const useProjectStatusView = vscode.workspace.getConfiguration('cmake').get('useProjectStatusView', true);
+        if (!useProjectStatusView) {
             this.statusBar.setVisible(fullFeatureSet);
         }
     }
@@ -237,14 +238,13 @@ export class ExtensionManager implements vscode.Disposable {
     /**
      * The status bar controller
      */
-    private readonly statusBar = new StatusBar(this.workspaceConfig);       //st
+    private readonly statusBar = new StatusBar(this.workspaceConfig);
     // Subscriptions for status bar items:
-    private statusMessageSub: vscode.Disposable = new DummyDisposable();    //st
-    private targetNameSub: vscode.Disposable = new DummyDisposable();       //both
-    private buildTypeSub: vscode.Disposable = new DummyDisposable();        //st
-    private launchTargetSub: vscode.Disposable = new DummyDisposable();     //both
-    // SideBar
-    private projectSubscriptions: vscode.Disposable[] = [                   //sb
+    private statusMessageSub: vscode.Disposable = new DummyDisposable();
+    private targetNameSub: vscode.Disposable = new DummyDisposable();
+    private buildTypeSub: vscode.Disposable = new DummyDisposable();
+    private launchTargetSub: vscode.Disposable = new DummyDisposable();
+    private projectSubscriptions: vscode.Disposable[] = [
         this.targetNameSub,
         this.launchTargetSub
     ];
@@ -254,7 +254,7 @@ export class ExtensionManager implements vscode.Disposable {
     private activeBuildPresetSub: vscode.Disposable = new DummyDisposable();
     private activeTestPresetSub: vscode.Disposable = new DummyDisposable();
 
-    // Watch the code model so that we may update teh tree view
+    // Watch the code model so that we may update the tree view
     // <fspath, sub>
     private readonly codeModelUpdateSubs = new Map<string, vscode.Disposable[]>();
 
@@ -736,7 +736,11 @@ export class ExtensionManager implements vscode.Disposable {
         } else {
             // this.targetNameSub = cmakeProject.onTargetNameChanged(FireNow, target => this.onBuildTargetChangedEmitter.fire(target));
             // this.launchTargetSub = cmakeProject.onLaunchTargetNameChanged(FireNow, target => this.onLaunchTargetChangedEmitter.fire(target || ''));
-            this.statusBar.setVisible(true);
+            if (vscode.workspace.getConfiguration('cmake').get('useProjectStatusView', true)) {
+                this.statusBar.setVisible(false);
+            } else {
+                this.statusBar.setVisible(true);
+            }
             this.statusMessageSub = cmakeProject.onStatusMessageChanged(FireNow, s => this.statusBar.setStatusMessage(s));
             this.targetNameSub = cmakeProject.onTargetNameChanged(FireNow, t => {
                 this.statusBar.setBuildTargetName(t);

--- a/src/projectController.ts
+++ b/src/projectController.ts
@@ -8,19 +8,19 @@ import * as util from '@cmt/util';
 import * as logging from '@cmt/logging';
 import CMakeProject from '@cmt/cmakeProject';
 import rollbar from '@cmt/rollbar';
-// import { disposeAll, DummyDisposable } from '@cmt/util';
-import { disposeAll } from '@cmt/util';
-// import { ConfigurationReader, StatusBarConfig } from './config';
-import { ConfigurationReader } from './config';
+import { disposeAll, DummyDisposable } from '@cmt/util';
+// import { disposeAll } from '@cmt/util';
+import { ConfigurationReader, StatusBarConfig } from './config';
+// import { ConfigurationReader } from './config';
 import { CMakeDriver } from './drivers/drivers';
 import { DirectoryContext } from './workspace';
 import { StateManager } from './state';
 import { getStatusBar } from './extension';
 import * as telemetry from './telemetry';
 import { StatusBar } from './status';
-// import { FireNow } from './prop';
-// import { projectStatus } from './extension';
-// import * as ext from './extension';
+import { FireNow } from './prop';
+import { projectStatus } from './extension';
+import * as ext from './extension';
 
 nls.config({ messageFormat: nls.MessageFormat.bundle, bundleFormat: nls.BundleFormat.standalone })();
 const localize: nls.LocalizeFunc = nls.loadMessageBundle();
@@ -34,7 +34,7 @@ export class ProjectController implements vscode.Disposable {
     private readonly buildDirectorySub = new Map<vscode.WorkspaceFolder, vscode.Disposable>();
     private readonly installPrefixSub = new Map<vscode.WorkspaceFolder, vscode.Disposable>();
     private readonly useCMakePresetsSub = new Map<vscode.WorkspaceFolder, vscode.Disposable>();
-    // private readonly hideDebugButtonSub  = new Map<vscode.WorkspaceFolder, vscode.Disposable>();
+    private readonly hideDebugButtonSub  = new Map<vscode.WorkspaceFolder, vscode.Disposable>();
 
     private readonly beforeAddFolderEmitter = new vscode.EventEmitter<vscode.WorkspaceFolder>();
     private readonly afterAddFolderEmitter = new vscode.EventEmitter<FolderProjectType>();
@@ -47,25 +47,25 @@ export class ProjectController implements vscode.Disposable {
         this.afterRemoveFolderEmitter
     ];
 
-    // // Subscription on active project
-    // private targetNameSub: vscode.Disposable = new DummyDisposable();
-    // private variantNameSub: vscode.Disposable = new DummyDisposable();
-    // private launchTargetSub: vscode.Disposable = new DummyDisposable();
-    // private ctestEnabledSub: vscode.Disposable = new DummyDisposable();
-    // private activeConfigurePresetSub: vscode.Disposable = new DummyDisposable();
-    // private activeBuildPresetSub: vscode.Disposable = new DummyDisposable();
-    // private activeTestPresetSub: vscode.Disposable = new DummyDisposable();
-    // private isBusySub = new DummyDisposable();
-    // private projectSubscriptions: vscode.Disposable[] = [
-    //     this.targetNameSub,
-    //     this.variantNameSub,
-    //     this.launchTargetSub,
-    //     this.ctestEnabledSub,
-    //     this.activeConfigurePresetSub,
-    //     this.activeBuildPresetSub,
-    //     this.activeTestPresetSub,
-    //     this.isBusySub
-    // ];
+    // Subscription on active project
+    private targetNameSub: vscode.Disposable = new DummyDisposable();
+    private variantNameSub: vscode.Disposable = new DummyDisposable();
+    private launchTargetSub: vscode.Disposable = new DummyDisposable();
+    private ctestEnabledSub: vscode.Disposable = new DummyDisposable();
+    private activeConfigurePresetSub: vscode.Disposable = new DummyDisposable();
+    private activeBuildPresetSub: vscode.Disposable = new DummyDisposable();
+    private activeTestPresetSub: vscode.Disposable = new DummyDisposable();
+    private isBusySub = new DummyDisposable();
+    private projectSubscriptions: vscode.Disposable[] = [
+        this.targetNameSub,
+        this.variantNameSub,
+        this.launchTargetSub,
+        this.ctestEnabledSub,
+        this.activeConfigurePresetSub,
+        this.activeBuildPresetSub,
+        this.activeTestPresetSub,
+        this.isBusySub
+    ];
 
     get onBeforeAddFolder() {
         return this.beforeAddFolderEmitter.event;
@@ -94,22 +94,22 @@ export class ProjectController implements vscode.Disposable {
     }
 
     private activeProject: CMakeProject | undefined;
-    // async updateActiveProject(workspaceFolder?: vscode.WorkspaceFolder, openEditor?: vscode.TextEditor): Promise<void> {
-    updateActiveProject(workspaceFolder?: vscode.WorkspaceFolder, openEditor?: vscode.TextEditor): void {
+    async updateActiveProject(workspaceFolder?: vscode.WorkspaceFolder, openEditor?: vscode.TextEditor): Promise<void> {
+    // updateActiveProject(workspaceFolder?: vscode.WorkspaceFolder, openEditor?: vscode.TextEditor): void {
         const projects: CMakeProject[] | undefined = this.getProjectsForWorkspaceFolder(workspaceFolder);
         if (projects && projects.length > 0) {
             if (openEditor) {
                 for (const project of projects) {
                     if (util.isFileInsideFolder(openEditor.document.uri, project.folderPath)) {
-                        // await this.setActiveProject(project);
-                        this.setActiveProject(project);
+                        await this.setActiveProject(project);
+                        // this.setActiveProject(project);
                         break;
                     }
                 }
                 if (!this.activeProject) {
                     if (util.isFileInsideFolder(openEditor.document.uri, projects[0].workspaceFolder.uri.fsPath)) {
-                        // await this.setActiveProject(projects[0]);
-                        this.setActiveProject(projects[0]);
+                        await this.setActiveProject(projects[0]);
+                        // this.setActiveProject(projects[0]);
                     }
                 }
                 // If active project is found, return.
@@ -118,48 +118,48 @@ export class ProjectController implements vscode.Disposable {
                 }
             } else {
                 // Set a default active project.
-                // await this.setActiveProject(projects[0]);
-                this.setActiveProject(projects[0]);
+                await this.setActiveProject(projects[0]);
+                // this.setActiveProject(projects[0]);
                 return;
             }
         }
-        // await this.setActiveProject(undefined);
-        this.setActiveProject(undefined);
+        await this.setActiveProject(undefined);
+        // this.setActiveProject(undefined);
     }
 
-    // async setActiveProject(project?: CMakeProject): Promise<void> {
-    setActiveProject(project?: CMakeProject): void {
+    async setActiveProject(project?: CMakeProject): Promise<void> {
+    // setActiveProject(project?: CMakeProject): void {
         this.activeProject = project;
         void this.updateUsePresetsState(this.activeProject);
-        // await projectStatus.updateActiveProject(project);
-        // await this.setupProjectSubscriptions(project);
+        await projectStatus.updateActiveProject(project);
+        await this.setupProjectSubscriptions(project);
     }
 
-    // async setupProjectSubscriptions(project?: CMakeProject): Promise<void> {
-    //     disposeAll(this.projectSubscriptions);
-    //     if (!project) {
-    //         this.targetNameSub = new DummyDisposable();
-    //         this.variantNameSub = new DummyDisposable();
-    //         this.launchTargetSub = new DummyDisposable();
-    //         this.ctestEnabledSub = new DummyDisposable();
-    //         this.activeConfigurePresetSub = new DummyDisposable();
-    //         this.activeBuildPresetSub = new DummyDisposable();
-    //         this.activeTestPresetSub = new DummyDisposable();
-    //         this.isBusySub = new DummyDisposable();
-    //     } else {
-    //         this.targetNameSub = project.onTargetNameChanged(FireNow, () => void projectStatus.refresh());
-    //         this.variantNameSub = project.onActiveVariantNameChanged(FireNow, () => void projectStatus.refresh());
-    //         this.launchTargetSub = project.onLaunchTargetNameChanged(FireNow, () => void projectStatus.refresh());
-    //         this.ctestEnabledSub = project.onCTestEnabledChanged(FireNow, () => void projectStatus.refresh());
-    //         this.activeConfigurePresetSub = project.onActiveConfigurePresetChanged(FireNow, () => void projectStatus.refresh());
-    //         this.activeBuildPresetSub = project.onActiveConfigurePresetChanged(FireNow, () => void projectStatus.refresh());
-    //         this.activeTestPresetSub = project.onActiveTestPresetChanged(FireNow, () => void projectStatus.refresh());
-    //         this.isBusySub = project.onIsBusyChanged(FireNow, (isBusy) => void projectStatus.setIsBusy(isBusy));
-    //         await util.setContextValue(ext.hideBuildCommandKey, project.hideBuildButton);
-    //         await util.setContextValue(ext.hideDebugCommandKey, project.hideDebugButton);
-    //         await util.setContextValue(ext.hideLaunchCommandKey, project.hideLaunchButton);
-    //     }
-    // }
+    async setupProjectSubscriptions(project?: CMakeProject): Promise<void> {
+        disposeAll(this.projectSubscriptions);
+        if (!project) {
+            this.targetNameSub = new DummyDisposable();
+            this.variantNameSub = new DummyDisposable();
+            this.launchTargetSub = new DummyDisposable();
+            this.ctestEnabledSub = new DummyDisposable();
+            this.activeConfigurePresetSub = new DummyDisposable();
+            this.activeBuildPresetSub = new DummyDisposable();
+            this.activeTestPresetSub = new DummyDisposable();
+            this.isBusySub = new DummyDisposable();
+        } else {
+            this.targetNameSub = project.onTargetNameChanged(FireNow, () => void projectStatus.refresh());
+            this.variantNameSub = project.onActiveVariantNameChanged(FireNow, () => void projectStatus.refresh());
+            this.launchTargetSub = project.onLaunchTargetNameChanged(FireNow, () => void projectStatus.refresh());
+            this.ctestEnabledSub = project.onCTestEnabledChanged(FireNow, () => void projectStatus.refresh());
+            this.activeConfigurePresetSub = project.onActiveConfigurePresetChanged(FireNow, () => void projectStatus.refresh());
+            this.activeBuildPresetSub = project.onActiveConfigurePresetChanged(FireNow, () => void projectStatus.refresh());
+            this.activeTestPresetSub = project.onActiveTestPresetChanged(FireNow, () => void projectStatus.refresh());
+            this.isBusySub = project.onIsBusyChanged(FireNow, (isBusy) => void projectStatus.setIsBusy(isBusy));
+            await util.setContextValue(ext.hideBuildCommandKey, project.hideBuildButton);
+            await util.setContextValue(ext.hideDebugCommandKey, project.hideDebugButton);
+            await util.setContextValue(ext.hideLaunchCommandKey, project.hideLaunchButton);
+        }
+    }
 
     public getActiveCMakeProject(): CMakeProject | undefined {
         return this.activeProject;
@@ -211,14 +211,14 @@ export class ProjectController implements vscode.Disposable {
 
     async dispose() {
         disposeAll(this.subscriptions);
-        // disposeAll(this.projectSubscriptions);
+        disposeAll(this.projectSubscriptions);
         // Dispose of each CMakeProject we have loaded.
         for (const project of this.getAllCMakeProjects()) {
             await project.asyncDispose();
         }
-        // if (projectStatus) {
-        //     projectStatus.dispose();
-        // }
+        if (projectStatus) {
+            projectStatus.dispose();
+        }
     }
 
     /**
@@ -346,7 +346,7 @@ export class ProjectController implements vscode.Disposable {
                 this.buildDirectorySub.set(folder, config.onChange('buildDirectory', async () => this.refreshDriverSettings(config, folder)));
                 this.installPrefixSub.set(folder, config.onChange('installPrefix', async () => this.refreshDriverSettings(config, folder)));
                 this.useCMakePresetsSub.set(folder, config.onChange('useCMakePresets', async (useCMakePresets: string) => this.doUseCMakePresetsChange(folder, useCMakePresets)));
-                // this.hideDebugButtonSub.set(folder, config.onChange('statusbar', async (statusbar: StatusBarConfig) => this.doStatusBarChange(folder, statusbar)));
+                this.hideDebugButtonSub.set(folder, config.onChange('statusbar', async (statusbar: StatusBarConfig) => this.doStatusBarChange(folder, statusbar)));
             }
         }
         this.afterAddFolderEmitter.fire({ folder: folder, projects: projects });
@@ -424,8 +424,8 @@ export class ProjectController implements vscode.Disposable {
             for (let i = 0; i < sourceDirectories.length; i++) {
                 const cmakeProject: CMakeProject = await CMakeProject.create(workspaceContext, sourceDirectories[i], this, sourceDirectories.length > 1);
                 if (activeProjectPath === cmakeProject.sourceDir) {
-                    // await this.setActiveProject(cmakeProject);
-                    this.setActiveProject(cmakeProject);
+                    await this.setActiveProject(cmakeProject);
+                    // this.setActiveProject(cmakeProject);
 
                     activeProjectPath = undefined;
                 }
@@ -435,8 +435,8 @@ export class ProjectController implements vscode.Disposable {
 
             if (activeProjectPath !== undefined) {
                 // Active project is no longer available. Pick a different one.
-                // await this.setActiveProject(projects.length > 0 ? projects[0] : undefined);
-                this.setActiveProject(projects.length > 0 ? projects[0] : undefined);
+                await this.setActiveProject(projects.length > 0 ? projects[0] : undefined);
+                // this.setActiveProject(projects.length > 0 ? projects[0] : undefined);
 
             }
 
@@ -473,38 +473,38 @@ export class ProjectController implements vscode.Disposable {
         }
     }
 
-    // private async doStatusBarChange(folder: vscode.WorkspaceFolder, statusbar: StatusBarConfig): Promise<void> {
-    //     const projects: CMakeProject[] | undefined = this.getProjectsForWorkspaceFolder(folder);
-    //     if (projects) {
-    //         for (const project of projects) {
-    //             project.doStatusBarChange(statusbar);
-    //         }
-    //     }
-    //     await projectStatus.doStatusBarChange();
-    //     await util.setContextValue(ext.hideBuildCommandKey, (statusbar.advanced?.build?.visibility === "hidden") ? true : false);
-    //     await util.setContextValue(ext.hideDebugCommandKey, (statusbar.advanced?.debug?.visibility === "hidden") ? true : false);
-    //     await util.setContextValue(ext.hideLaunchCommandKey, (statusbar.advanced?.launch?.visibility === "hidden") ? true : false);
-    // }
+    private async doStatusBarChange(folder: vscode.WorkspaceFolder, statusbar: StatusBarConfig): Promise<void> {
+        const projects: CMakeProject[] | undefined = this.getProjectsForWorkspaceFolder(folder);
+        if (projects) {
+            for (const project of projects) {
+                project.doStatusBarChange(statusbar);
+            }
+        }
+        await projectStatus.doStatusBarChange();
+        await util.setContextValue(ext.hideBuildCommandKey, (statusbar.advanced?.build?.visibility === "hidden") ? true : false);
+        await util.setContextValue(ext.hideDebugCommandKey, (statusbar.advanced?.debug?.visibility === "hidden") ? true : false);
+        await util.setContextValue(ext.hideLaunchCommandKey, (statusbar.advanced?.launch?.visibility === "hidden") ? true : false);
+    }
 
-    // async hideBuildButton(isHidden: boolean) {
-    //     await projectStatus.hideBuildButton(isHidden);
-    //     await util.setContextValue(ext.hideBuildCommandKey, isHidden);
-    // }
+    async hideBuildButton(isHidden: boolean) {
+        await projectStatus.hideBuildButton(isHidden);
+        await util.setContextValue(ext.hideBuildCommandKey, isHidden);
+    }
 
-    // async hideDebugButton(isHidden: boolean) {
-    //     await projectStatus.hideDebugButton(isHidden);
-    //     await util.setContextValue(ext.hideDebugCommandKey, isHidden);
-    // }
+    async hideDebugButton(isHidden: boolean) {
+        await projectStatus.hideDebugButton(isHidden);
+        await util.setContextValue(ext.hideDebugCommandKey, isHidden);
+    }
 
-    // async hideLaunchButton(isHidden: boolean) {
-    //     await projectStatus.hideLaunchButton(isHidden);
-    //     await util.setContextValue(ext.hideLaunchCommandKey, isHidden);
-    // }
+    async hideLaunchButton(isHidden: boolean) {
+        await projectStatus.hideLaunchButton(isHidden);
+        await util.setContextValue(ext.hideLaunchCommandKey, isHidden);
+    }
 
     private async updateUsePresetsState(project?: CMakeProject): Promise<void> {
         const state: boolean = project?.useCMakePresets || false;
         await util.setContextValue('useCMakePresets', state);
-        // await projectStatus.refresh();
+        await projectStatus.refresh();
         const statusBar: StatusBar | undefined = getStatusBar();
         if (statusBar) {
             statusBar.useCMakePresets(state);

--- a/src/projectController.ts
+++ b/src/projectController.ts
@@ -9,9 +9,7 @@ import * as logging from '@cmt/logging';
 import CMakeProject from '@cmt/cmakeProject';
 import rollbar from '@cmt/rollbar';
 import { disposeAll, DummyDisposable } from '@cmt/util';
-// import { disposeAll } from '@cmt/util';
 import { ConfigurationReader, StatusBarConfig } from './config';
-// import { ConfigurationReader } from './config';
 import { CMakeDriver } from './drivers/drivers';
 import { DirectoryContext } from './workspace';
 import { StateManager } from './state';
@@ -34,6 +32,7 @@ export class ProjectController implements vscode.Disposable {
     private readonly buildDirectorySub = new Map<vscode.WorkspaceFolder, vscode.Disposable>();
     private readonly installPrefixSub = new Map<vscode.WorkspaceFolder, vscode.Disposable>();
     private readonly useCMakePresetsSub = new Map<vscode.WorkspaceFolder, vscode.Disposable>();
+    private readonly useProjectStatusView = new Map<vscode.WorkspaceFolder, vscode.Disposable>();
     private readonly hideDebugButtonSub  = new Map<vscode.WorkspaceFolder, vscode.Disposable>();
 
     private readonly beforeAddFolderEmitter = new vscode.EventEmitter<vscode.WorkspaceFolder>();
@@ -346,6 +345,7 @@ export class ProjectController implements vscode.Disposable {
                 this.buildDirectorySub.set(folder, config.onChange('buildDirectory', async () => this.refreshDriverSettings(config, folder)));
                 this.installPrefixSub.set(folder, config.onChange('installPrefix', async () => this.refreshDriverSettings(config, folder)));
                 this.useCMakePresetsSub.set(folder, config.onChange('useCMakePresets', async (useCMakePresets: string) => this.doUseCMakePresetsChange(folder, useCMakePresets)));
+                this.useProjectStatusView.set(folder, config.onChange('useProjectStatusView', async (useProjectStatusView: boolean) => this.doProjectStatusChange(useProjectStatusView)));
                 this.hideDebugButtonSub.set(folder, config.onChange('statusbar', async (statusbar: StatusBarConfig) => this.doStatusBarChange(folder, statusbar)));
             }
         }
@@ -473,6 +473,13 @@ export class ProjectController implements vscode.Disposable {
         }
     }
 
+    private async doProjectStatusChange(useProjectStatusView: boolean): Promise<void> {
+        const statusBar: StatusBar | undefined = getStatusBar();
+        if (statusBar) {
+            statusBar.setVisible(!useProjectStatusView);
+        }
+    }
+
     private async doStatusBarChange(folder: vscode.WorkspaceFolder, statusbar: StatusBarConfig): Promise<void> {
         const projects: CMakeProject[] | undefined = this.getProjectsForWorkspaceFolder(folder);
         if (projects) {
@@ -487,17 +494,20 @@ export class ProjectController implements vscode.Disposable {
     }
 
     async hideBuildButton(isHidden: boolean) {
-        await projectStatus.hideBuildButton(isHidden);
+        // Doesn't hide the button in the Side Bar because there are no space-saving issues there vs status bar
+        // await projectStatus.hideBuildButton(isHidden);
         await util.setContextValue(ext.hideBuildCommandKey, isHidden);
     }
 
     async hideDebugButton(isHidden: boolean) {
-        await projectStatus.hideDebugButton(isHidden);
+        // Doesn't hide the button in the Side Bar because there are no space-saving issues there vs status bar
+        // await projectStatus.hideDebugButton(isHidden);
         await util.setContextValue(ext.hideDebugCommandKey, isHidden);
     }
 
     async hideLaunchButton(isHidden: boolean) {
-        await projectStatus.hideLaunchButton(isHidden);
+        // Doesn't hide the button in the Side Bar because there are no space-saving issues there vs status bar
+        // await projectStatus.hideLaunchButton(isHidden);
         await util.setContextValue(ext.hideLaunchCommandKey, isHidden);
     }
 

--- a/src/sideBar.ts
+++ b/src/sideBar.ts
@@ -1,0 +1,767 @@
+import * as vscode from 'vscode';
+import * as nls from 'vscode-nls';
+import CMakeProject from './cmakeProject';
+import * as preset from './preset';
+import { runCommand } from './util';
+
+nls.config({ messageFormat: nls.MessageFormat.bundle, bundleFormat: nls.BundleFormat.standalone })();
+const localize: nls.LocalizeFunc = nls.loadMessageBundle();
+const noKitSelected = localize('no.kit.selected', '[No Kit Selected]');
+const noConfigPresetSelected = localize('no.configure.preset.selected', '[No Configure Preset Selected]');
+const noBuildPresetSelected = localize('no.build.preset.selected', '[No Build Preset Selected]');
+const noTestPresetSelected = localize('no.test.preset.selected', '[No Test Preset Selected]');
+
+let treeDataProvider: TreeDataProvider;
+
+export class ProjectStatus {
+
+    protected disposables: vscode.Disposable[] = [];
+
+    constructor() {
+        treeDataProvider = new TreeDataProvider();
+        this.disposables.push(...[
+            // Commands for projectStatus items
+            vscode.commands.registerCommand('cmake.projectStatus.stop', async (_node: Node) => {
+                await runCommand('stop');
+            }),
+            vscode.commands.registerCommand('cmake.projectStatus.selectKit', async (node: Node) => {
+                await runCommand('selectKit');
+                await this.refresh(node);
+            }),
+            vscode.commands.registerCommand('cmake.projectStatus.selectConfigurePreset', async (node: Node) => {
+                await runCommand('selectConfigurePreset');
+                await this.refresh(node);
+            }),
+            vscode.commands.registerCommand('cmake.projectStatus.configure', async (_node: Node) => {
+                void runCommand('configure');
+            }),
+            vscode.commands.registerCommand('cmake.projectStatus.setVariant', async (node: Node) => {
+                await runCommand('setVariant');
+                await this.refresh(node);
+            }),
+            vscode.commands.registerCommand('cmake.projectStatus.build', async (_node: Node) => {
+                void runCommand('build');
+            }),
+            vscode.commands.registerCommand('cmake.projectStatus.setDefaultTarget', async (node: Node) => {
+                await runCommand('setDefaultTarget');
+                await this.refresh(node);
+            }),
+            vscode.commands.registerCommand('cmake.projectStatus.selectBuildPreset', async (node: Node) => {
+                await runCommand('selectBuildPreset');
+                await this.refresh(node);
+            }),
+            vscode.commands.registerCommand('cmake.projectStatus.ctest', async (_node: Node) => {
+                void runCommand('ctest');
+            }),
+            vscode.commands.registerCommand('cmake.projectStatus.setTestTarget', async (_node: Node) => {
+                // Do nothing
+            }),
+            vscode.commands.registerCommand('cmake.projectStatus.selectTestPreset', async (node: Node) => {
+                await runCommand('selectTestPreset');
+                await this.refresh(node);
+            }),
+            vscode.commands.registerCommand('cmake.projectStatus.debugTarget', async (_node: Node) => {
+                await runCommand('debugTarget');
+            }),
+            vscode.commands.registerCommand('cmake.projectStatus.setDebugTarget', async (node: Node) => {
+                await runCommand('selectLaunchTarget');
+                await this.refresh(node);
+            }),
+            vscode.commands.registerCommand('cmake.projectStatus.launchTarget', async (_node: Node) => {
+                await runCommand('launchTarget');
+            }),
+            vscode.commands.registerCommand('cmake.projectStatus.setLaunchTarget', async (node: Node) => {
+                await runCommand('selectLaunchTarget');
+                await this.refresh(node);
+            }),
+            vscode.commands.registerCommand('cmake.projectStatus.selectActiveProject', async () => {
+                await runCommand('selectActiveFolder');
+                await this.refresh();
+            }),
+            vscode.commands.registerCommand('cmake.projectStatus.update', async () => {
+                await this.refresh();
+            })
+        ]);
+    }
+
+    async updateActiveProject(cmakeProject?: CMakeProject): Promise<void> {
+        // Update Active Project
+        await treeDataProvider.updateActiveProject(cmakeProject);
+    }
+
+    refresh(node?: Node): Promise<any> {
+        return treeDataProvider.refresh(node);
+    }
+
+    clear(): Promise<any> {
+        return treeDataProvider.clear();
+    }
+
+    dispose() {
+        vscode.Disposable.from(...this.disposables).dispose();
+        treeDataProvider.dispose();
+    }
+
+    async hideBuildButton(isHidden: boolean) {
+        await treeDataProvider.hideBuildButton(isHidden);
+    }
+
+    async hideDebugButton(isHidden: boolean) {
+        await treeDataProvider.hideDebugButton(isHidden);
+    }
+
+    async hideLaunchButton(isHidden: boolean) {
+        await treeDataProvider.hideLaunchButton(isHidden);
+    }
+
+    async setIsBusy(isBusy: boolean) {
+        await treeDataProvider.setIsBusy(isBusy);
+    }
+
+    async doStatusBarChange() {
+        await treeDataProvider.doStatusBarChange();
+    }
+
+}
+
+class TreeDataProvider implements vscode.TreeDataProvider<Node>, vscode.Disposable {
+
+    private treeView: vscode.TreeView<Node>;
+    private _onDidChangeTreeData: vscode.EventEmitter<any> = new vscode.EventEmitter<any>();
+    private activeCMakeProject?: CMakeProject;
+    private isBuildButtonHidden: boolean = false;
+    private isDebugButtonHidden: boolean = false;
+    private isLaunchButtonHidden: boolean = false;
+    private isBusy: boolean = false;
+
+    get onDidChangeTreeData(): vscode.Event<Node | undefined> {
+        return this._onDidChangeTreeData.event;
+    }
+
+    constructor() {
+        this.treeView = vscode.window.createTreeView('cmake.projectStatus', { treeDataProvider: this });
+    }
+
+    get cmakeProject(): CMakeProject | undefined {
+        return this.activeCMakeProject;
+    }
+
+    async updateActiveProject(cmakeProject?: CMakeProject): Promise<void> {
+        // Use project to create the tree
+        if (cmakeProject) {
+            this.activeCMakeProject = cmakeProject;
+            this.isBuildButtonHidden = cmakeProject.hideBuildButton;
+            this.isDebugButtonHidden = cmakeProject.hideDebugButton;
+            this.isLaunchButtonHidden = cmakeProject.hideLaunchButton;
+        } else {
+            this.isBuildButtonHidden = false;
+            this.isDebugButtonHidden = false;
+            this.isLaunchButtonHidden = false;
+        }
+        await this.refresh();
+    }
+
+    public async refresh(node?: Node): Promise<any> {
+        if (node) {
+            await node.refresh();
+            this._onDidChangeTreeData.fire(node);
+        } else {
+            this._onDidChangeTreeData.fire(undefined);
+        }
+    }
+
+    clear(): Promise<any> {
+        this.activeCMakeProject = undefined;
+        return this.refresh();
+    }
+
+    dispose(): void {
+        this.treeView.dispose();
+    }
+
+    getTreeItem(node: Node): vscode.TreeItem {
+        return node.getTreeItem();
+    }
+
+    async getChildren(node?: Node | undefined): Promise<Node[]> {
+        if (node) {
+            return node.getChildren();
+        } else {
+            // Initializing the tree for the first time
+            const nodes: Node[] = [];
+            const configNode = new ConfigNode();
+            await configNode.initialize();
+            if (this.isBusy) {
+                configNode.convertToStopCommand();
+            }
+            nodes.push(configNode);
+            if (!this.isBuildButtonHidden) {
+                const buildNode = new BuildNode();
+                await buildNode.initialize();
+                if (this.isBusy) {
+                    buildNode.convertToStopCommand();
+                }
+                nodes.push(buildNode);
+            }
+            const testNode = new TestNode();
+            await testNode.initialize();
+            nodes.push(testNode);
+            if (!this.isDebugButtonHidden) {
+                const debugNode = new DebugNode();
+                await debugNode.initialize();
+                nodes.push(debugNode);
+            }
+            if (!this.isLaunchButtonHidden) {
+                const launchNode = new LaunchNode();
+                await launchNode.initialize();
+                nodes.push(launchNode);
+            }
+            const projectNode = new ProjectNode();
+            await projectNode.initialize();
+            nodes.push(projectNode);
+            return nodes;
+        }
+    }
+
+    public async doStatusBarChange() {
+        let didChange: boolean = false;
+        if (this.activeCMakeProject) {
+            if (this.isBuildButtonHidden !== this.activeCMakeProject.hideBuildButton) {
+                didChange = true;
+                this.isBuildButtonHidden = this.activeCMakeProject.hideBuildButton;
+            }
+            if (this.isDebugButtonHidden !== this.activeCMakeProject.hideDebugButton) {
+                didChange = true;
+                this.isDebugButtonHidden = this.activeCMakeProject.hideDebugButton;
+            }
+            if (this.isLaunchButtonHidden !== this.activeCMakeProject.hideLaunchButton) {
+                didChange = true;
+                this.isLaunchButtonHidden = this.activeCMakeProject.hideLaunchButton;
+            }
+            if (didChange) {
+                await this.refresh();
+            }
+        }
+    }
+
+    public async hideBuildButton(isHidden: boolean) {
+        if (isHidden !== this.isBuildButtonHidden) {
+            if (this.activeCMakeProject) {
+                this.activeCMakeProject.hideBuildButton = isHidden;
+            }
+            this.isBuildButtonHidden = isHidden;
+            await this.refresh();
+        }
+    }
+
+    public async hideDebugButton(isHidden: boolean): Promise<void> {
+        if (isHidden !== this.isDebugButtonHidden) {
+            if (this.activeCMakeProject) {
+                this.activeCMakeProject.hideDebugButton = isHidden;
+            }
+            this.isDebugButtonHidden = isHidden;
+            await this.refresh();
+        }
+    }
+
+    public async hideLaunchButton(isHidden: boolean): Promise<void> {
+        if (isHidden !== this.isLaunchButtonHidden) {
+            if (this.activeCMakeProject) {
+                this.activeCMakeProject.hideLaunchButton = isHidden;
+            }
+            this.isLaunchButtonHidden = isHidden;
+            await this.refresh();
+        }
+    }
+
+    async setIsBusy(isBusy: boolean): Promise<void> {
+        if (this.isBusy !== isBusy) {
+            this.isBusy = isBusy;
+            await this.refresh();
+        }
+    }
+
+}
+
+class Node extends vscode.TreeItem {
+
+    constructor(label?: string | vscode.TreeItemLabel) {
+        super(label ? label : "");
+    }
+
+    getTreeItem(): vscode.TreeItem {
+        return this;
+    }
+
+    getChildren(): Node[] {
+        return [];
+    }
+
+    async initialize(): Promise<void> {
+    }
+
+    async refresh(): Promise<void> {
+    }
+
+    convertToStopCommand(): void {
+    }
+
+    convertToOriginalCommand(): void {
+    }
+}
+
+class ConfigNode extends Node {
+
+    private kit?: Kit;
+    private variant?: Variant;
+    private configPreset?: ConfigPreset;
+
+    async initialize(): Promise<void> {
+        if (!treeDataProvider.cmakeProject) {
+            return;
+        }
+        this.label = localize('Configure', 'Configure');
+        this.tooltip = this.label;
+        this.collapsibleState = vscode.TreeItemCollapsibleState.Expanded;
+        this.contextValue = "configure";
+        await this.InitializeChildren();
+    }
+
+    async InitializeChildren(): Promise<void> {
+        if (!treeDataProvider.cmakeProject) {
+            return;
+        }
+        if (!treeDataProvider.cmakeProject.useCMakePresets) {
+            this.kit = new Kit();
+            await this.kit.initialize();
+            this.variant = new Variant();
+            await this.variant.initialize();
+        } else {
+            this.configPreset = new ConfigPreset();
+            await this.configPreset.initialize();
+        }
+    }
+
+    getChildren(): Node[] {
+        if (!treeDataProvider.cmakeProject) {
+            return [];
+        }
+        if (!treeDataProvider.cmakeProject.useCMakePresets) {
+            return [this.kit!, this.variant!];
+        } else {
+            return [this.configPreset!];
+        }
+    }
+
+    convertToStopCommand(): void {
+        this.label = localize("configure.running", "Configure (Running)");
+        const title: string = localize('Stop', 'Stop');
+        this.tooltip = title;
+        this.contextValue = "stop";
+    }
+
+    convertToOriginalCommand(): Promise<void> {
+        return this.initialize();
+    }
+
+}
+
+class BuildNode extends Node {
+
+    private buildTarget?: BuildTarget;
+    private buildPreset?: BuildPreset;
+
+    async initialize(): Promise<void> {
+        if (!treeDataProvider.cmakeProject) {
+            return;
+        }
+        this.label = localize('Build', 'Build');
+        this.tooltip = this.label;
+        this.collapsibleState = vscode.TreeItemCollapsibleState.Expanded;
+        this.contextValue = 'build';
+        await this.InitializeChildren();
+    }
+
+    async InitializeChildren(): Promise<void> {
+        if (!treeDataProvider.cmakeProject) {
+            return;
+        }
+        if (!treeDataProvider.cmakeProject.useCMakePresets) {
+            this.buildTarget = new BuildTarget();
+            await this.buildTarget.initialize();
+        } else {
+            this.buildPreset = new BuildPreset();
+            await this.buildPreset.initialize();
+        }
+    }
+
+    getChildren(): Node[] {
+        if (!treeDataProvider.cmakeProject) {
+            return [];
+        }
+        if (!treeDataProvider.cmakeProject.useCMakePresets) {
+            return [this.buildTarget!];
+        } else {
+            return [this.buildPreset!];
+        }
+    }
+
+    convertToStopCommand(): void {
+        this.label = localize("build.running", "Build (Running)");
+        const title: string = localize('Stop', 'Stop');
+        this.tooltip = title;
+        this.contextValue = "stop";
+    }
+
+    convertToOriginalCommand(): Promise<void> {
+        return this.initialize();
+    }
+
+}
+
+class TestNode extends Node {
+
+    private testTarget?: TestTarget;
+    private testPreset?: TestPreset;
+
+    async initialize(): Promise<void> {
+        if (!treeDataProvider.cmakeProject) {
+            return;
+        }
+        this.label = localize('Test', 'Test');
+        this.tooltip = this.label;
+        this.collapsibleState = vscode.TreeItemCollapsibleState.Expanded;
+        this.contextValue = 'test';
+        await this.InitializeChildren();
+    }
+
+    async InitializeChildren(): Promise<void> {
+        if (!treeDataProvider.cmakeProject) {
+            return;
+        }
+        if (!treeDataProvider.cmakeProject.useCMakePresets) {
+            this.testTarget = new TestTarget();
+            await this.testTarget.initialize();
+        } else {
+            this.testPreset = new TestPreset();
+            await this.testPreset.initialize();
+        }
+    }
+
+    getChildren(): Node[] {
+        if (!treeDataProvider.cmakeProject) {
+            return [];
+        }
+        if (!treeDataProvider.cmakeProject.useCMakePresets) {
+            return [this.testTarget!];
+        } else {
+            return [this.testPreset!];
+        }
+    }
+
+}
+
+class DebugNode extends Node {
+
+    private target?: DebugTarget;
+
+    async initialize(): Promise<void> {
+        if (!treeDataProvider.cmakeProject) {
+            return;
+        }
+        this.label = localize('Debug', 'Debug');
+        this.tooltip = this.label;
+        this.collapsibleState = vscode.TreeItemCollapsibleState.Expanded;
+        this.contextValue = 'debug';
+        await this.InitializeChildren();
+    }
+
+    async InitializeChildren(): Promise<void> {
+        if (!treeDataProvider.cmakeProject) {
+            return;
+        }
+        this.target = new DebugTarget();
+        await this.target.initialize();
+    }
+
+    getChildren(): Node[] {
+        if (!treeDataProvider.cmakeProject) {
+            return [];
+        }
+        return [this.target!];
+    }
+
+}
+
+class LaunchNode extends Node {
+
+    private launchTarget?: LaunchTarget;
+
+    async initialize(): Promise<void> {
+        if (!treeDataProvider.cmakeProject) {
+            return;
+        }
+        this.label = localize('Launch', 'Launch');
+        this.tooltip = this.label;
+        this.collapsibleState = vscode.TreeItemCollapsibleState.Expanded;
+        this.contextValue = 'launch';
+        await this.InitializeChildren();
+    }
+
+    async InitializeChildren(): Promise<void> {
+        if (!treeDataProvider.cmakeProject) {
+            return;
+        }
+        this.launchTarget = new LaunchTarget();
+        await this.launchTarget.initialize();
+    }
+
+    getChildren(): Node[] {
+        if (!treeDataProvider.cmakeProject) {
+            return [];
+        }
+        return [this.launchTarget!];
+    }
+
+}
+
+class ProjectNode extends Node {
+
+    private project?: Project;
+
+    async initialize(): Promise<void> {
+        if (!treeDataProvider.cmakeProject) {
+            return;
+        }
+        this.label = localize('Project', 'Project');
+        this.tooltip = localize('active.project', 'Active project');
+        this.collapsibleState = vscode.TreeItemCollapsibleState.Expanded;
+        await this.InitializeChildren();
+    }
+
+    async InitializeChildren(): Promise<void> {
+        if (!treeDataProvider.cmakeProject) {
+            return;
+        }
+        this.project = new Project();
+        await this.project!.initialize();
+    }
+
+    getChildren(): Node[] {
+        if (!treeDataProvider.cmakeProject) {
+            return [];
+        }
+        return [this.project!];
+    }
+
+}
+
+class ConfigPreset extends Node {
+
+    async initialize(): Promise<void> {
+        if (!treeDataProvider.cmakeProject || !treeDataProvider.cmakeProject.useCMakePresets) {
+            return;
+        }
+        this.label = (treeDataProvider.cmakeProject.configurePreset?.displayName ?? treeDataProvider.cmakeProject.configurePreset?.name) || noConfigPresetSelected;
+        this.tooltip = 'Change Configure Preset';
+        this.contextValue = 'configPreset';
+        this.collapsibleState = vscode.TreeItemCollapsibleState.None;
+    }
+
+    async refresh() {
+        if (!treeDataProvider.cmakeProject) {
+            return;
+        }
+        this.label = (treeDataProvider.cmakeProject.configurePreset?.displayName ?? treeDataProvider.cmakeProject.configurePreset?.name) || noConfigPresetSelected;
+    }
+}
+
+class BuildPreset extends Node {
+
+    async initialize(): Promise<void> {
+        if (!treeDataProvider.cmakeProject || !treeDataProvider.cmakeProject.useCMakePresets) {
+            return;
+        }
+        this.label = treeDataProvider.cmakeProject.buildPreset?.name || noBuildPresetSelected;
+        if (this.label === preset.defaultBuildPreset.name) {
+            this.label = preset.defaultBuildPreset.displayName;
+        }
+        this.tooltip = 'Change Build Preset';
+        this.contextValue = 'buildPreset';
+        this.collapsibleState = vscode.TreeItemCollapsibleState.None;
+    }
+
+    async refresh() {
+        if (!treeDataProvider.cmakeProject) {
+            return;
+        }
+        this.label = treeDataProvider.cmakeProject.buildPreset?.name || noBuildPresetSelected;
+    }
+}
+
+class TestPreset extends Node {
+
+    async initialize(): Promise<void> {
+        if (!treeDataProvider.cmakeProject || !treeDataProvider.cmakeProject.useCMakePresets) {
+            return;
+        }
+        this.label = treeDataProvider.cmakeProject.testPreset?.name || noTestPresetSelected;
+        if (this.label === preset.defaultTestPreset.name) {
+            this.label = preset.defaultTestPreset.displayName;
+        }
+        this.tooltip = 'Change Test Preset';
+        this.contextValue = 'testPreset';
+        this.collapsibleState = vscode.TreeItemCollapsibleState.None;
+    }
+
+    async refresh() {
+        if (!treeDataProvider.cmakeProject) {
+            return;
+        }
+        this.label = treeDataProvider.cmakeProject.testPreset?.name  || noTestPresetSelected;
+    }
+}
+
+class Kit extends Node {
+
+    async initialize(): Promise<void> {
+        if (!treeDataProvider.cmakeProject) {
+            return;
+        }
+        this.label = treeDataProvider.cmakeProject.activeKit?.name || noKitSelected;
+        this.tooltip = "Change Kit";
+        this.collapsibleState = vscode.TreeItemCollapsibleState.None;
+        this.contextValue = 'kit';
+    }
+
+    getTreeItem(): vscode.TreeItem {
+        if (!treeDataProvider.cmakeProject) {
+            return this;
+        }
+        this.label = treeDataProvider.cmakeProject.activeKit?.name || noKitSelected;
+        return this;
+    }
+}
+
+class BuildTarget extends Node {
+
+    async initialize(): Promise<void> {
+        if (!treeDataProvider.cmakeProject) {
+            return;
+        }
+        const title: string = localize('set.build.target', 'Set Build Target');
+        this.label = await treeDataProvider.cmakeProject.buildTargetName() || await treeDataProvider.cmakeProject.allTargetName;
+        this.tooltip = title;
+        this.collapsibleState = vscode.TreeItemCollapsibleState.None;
+        this.contextValue = 'buildTarget';
+    }
+
+    async refresh() {
+        if (!treeDataProvider.cmakeProject) {
+            return;
+        }
+        this.label = await treeDataProvider.cmakeProject.buildTargetName() || await treeDataProvider.cmakeProject.allTargetName;
+    }
+}
+
+class TestTarget extends Node {
+
+    async initialize(): Promise<void> {
+        if (!treeDataProvider.cmakeProject) {
+            return;
+        }
+        this.label = "[All tests]";
+        this.collapsibleState = vscode.TreeItemCollapsibleState.None;
+        // Set the contextValue to 'testTarget' when we implement setTestTarget to choose a target for a test.
+    }
+
+    async refresh() {
+        if (!treeDataProvider.cmakeProject) {
+            return;
+        }
+        this.label = "[All tests]";
+    }
+}
+
+class DebugTarget extends Node {
+
+    async initialize(): Promise<void> {
+        if (!treeDataProvider.cmakeProject) {
+            return;
+        }
+        this.label = treeDataProvider.cmakeProject.launchTargetName || await treeDataProvider.cmakeProject.allTargetName;
+        const title: string = localize('set.debug.target', 'Set debug target');
+        this.tooltip = title;
+        this.collapsibleState = vscode.TreeItemCollapsibleState.None;
+        this.contextValue = 'debugTarget';
+    }
+
+    async refresh() {
+        if (!treeDataProvider.cmakeProject) {
+            return;
+        }
+        this.label = treeDataProvider.cmakeProject.launchTargetName || await treeDataProvider.cmakeProject.allTargetName;
+    }
+}
+
+class LaunchTarget extends Node {
+
+    async initialize(): Promise<void> {
+        if (!treeDataProvider.cmakeProject) {
+            return;
+        }
+        this.label = treeDataProvider.cmakeProject.launchTargetName || await treeDataProvider.cmakeProject.allTargetName;
+        const title: string = localize('set.launch.target', 'Set Launch Target');
+        this.tooltip = title;
+        this.collapsibleState = vscode.TreeItemCollapsibleState.None;
+        this.contextValue = 'launchTarget';
+    }
+
+    async refresh() {
+        if (!treeDataProvider.cmakeProject) {
+            return;
+        }
+        this.label = treeDataProvider.cmakeProject.launchTargetName || await treeDataProvider.cmakeProject.allTargetName;
+    }
+}
+
+class Project extends Node {
+
+    async initialize(): Promise<void> {
+        if (!treeDataProvider.cmakeProject) {
+            return;
+        }
+        this.label = treeDataProvider.cmakeProject.folderName;
+        const title: string = localize('select.active.project', 'Select active project');
+        this.tooltip = title;
+        this.collapsibleState = vscode.TreeItemCollapsibleState.None;
+        this.contextValue = 'activeProject';
+    }
+
+    async refresh() {
+        if (!treeDataProvider.cmakeProject) {
+            return;
+        }
+        this.label = treeDataProvider.cmakeProject.folderName;
+    }
+}
+class Variant extends Node {
+
+    async initialize(): Promise<void> {
+        if (!treeDataProvider.cmakeProject) {
+            return;
+        }
+        this.label = treeDataProvider.cmakeProject.activeVariantName || "Debug";
+        this.tooltip = "Set variant";
+        this.collapsibleState = vscode.TreeItemCollapsibleState.None;
+        this.contextValue = 'variant';
+    }
+
+    async refresh(): Promise<void> {
+        if (!treeDataProvider.cmakeProject) {
+            return;
+        }
+        this.label = treeDataProvider.cmakeProject.activeVariantName || "Debug";
+    }
+
+}

--- a/src/sideBar.ts
+++ b/src/sideBar.ts
@@ -189,6 +189,9 @@ class TreeDataProvider implements vscode.TreeDataProvider<Node>, vscode.Disposab
         } else {
             // Initializing the tree for the first time
             const nodes: Node[] = [];
+            const projectNode = new ProjectNode();
+            await projectNode.initialize();
+            nodes.push(projectNode);
             const configNode = new ConfigNode();
             await configNode.initialize();
             if (this.isBusy) {
@@ -216,9 +219,6 @@ class TreeDataProvider implements vscode.TreeDataProvider<Node>, vscode.Disposab
                 await launchNode.initialize();
                 nodes.push(launchNode);
             }
-            const projectNode = new ProjectNode();
-            await projectNode.initialize();
-            nodes.push(projectNode);
             return nodes;
         }
     }

--- a/test/unit-tests/config.test.ts
+++ b/test/unit-tests/config.test.ts
@@ -60,6 +60,7 @@ function createConfig(conf: Partial<ExtensionConfigurationSettings>): Configurat
             advanced: {},
             visibility: "default"
         },
+        useProjectStatusView: true,
         useCMakePresets: 'never',
         allowCommentsInPresetsFile: false,
         allowUnsupportedPresetsVersions: false,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,6 +23,5 @@
     "exclude": [
         "node_modules",
         ".vscode-test",
-        "src/sideBar.ts"
     ]
 }


### PR DESCRIPTION
### This changes where the extension's buttons show (side bar vs status bar) depending on an extension setting.

The following changes are proposed:

- Adding a toggle in the extension to allow switching between the status bar and side bar (project status view).
- Prevented the status bar visibility setting from affecting side bar buttons.
- Moving the active project selection to the top of the side bar.

## The purpose of this change

To allow for A/B testing. 
