### PR TITLE
fix precedence order of cmake.parallelJobs setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Bug Fixes:
 Improvements:
 - Decreased the number of cases where we reconfigure erroneously upon usage of `cmake.getLaunchTargetPath` [#2878](https://github.com/microsoft/vscode-cmake-tools/issues/2878)
 - Fix our checking for invalid settings when CMakeUserPresets version is different than CMakePresets [#2897](https://github.com/microsoft/vscode-cmake-tools/issues/2897)
+- Fix the precendence order that we evaluate the `cmake.parallelJobs` setting. [#3206](https://github.com/microsoft/vscode-cmake-tools/issues/3206)
 
 ## 1.14.33
 Bug Fixes:

--- a/src/drivers/cmakeDriver.ts
+++ b/src/drivers/cmakeDriver.ts
@@ -1715,7 +1715,7 @@ export abstract class CMakeDriver implements vscode.Disposable {
 
         const configurationScope = this.workspaceFolder ? vscode.Uri.file(this.workspaceFolder) : null;
         const parallelJobsSetting = vscode.workspace.getConfiguration("cmake", configurationScope).inspect<number | undefined>('parallelJobs');
-        let numJobs: number | undefined = (parallelJobsSetting?.globalValue || parallelJobsSetting?.workspaceValue || parallelJobsSetting?.workspaceFolderValue);
+        let numJobs: number | undefined = (parallelJobsSetting?.workspaceFolderLanguageValue || parallelJobsSetting?.workspaceFolderValue || parallelJobsSetting?.globalValue);
         // for Ninja generator, don't '-j' argument if user didn't define number of jobs
         // let numJobs: number | undefined = this.config.numJobs;
         if (numJobs === undefined && gen && !/Ninja/.test(gen)) {


### PR DESCRIPTION
<!-- Delete the following heading if there is no corresponding issue -->
## This change addresses item [#3206](https://github.com/microsoft/vscode-cmake-tools/issues/3206)

This fixes the precedence order of the `cmake.parallelJobs` setting.