### PR TITLE
check for incorrect versioning and settings before expanding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Bug Fixes:
 
 Improvements:
 - Decreased the number of cases where we reconfigure erroneously upon usage of `cmake.getLaunchTargetPath` [#2878](https://github.com/microsoft/vscode-cmake-tools/issues/2878)
+- Fix our checking for invalid settings when CMakeUserPresets version is different than CMakePresets [#2897](https://github.com/microsoft/vscode-cmake-tools/issues/2897)
 
 ## 1.14.33
 Bug Fixes:

--- a/src/preset.ts
+++ b/src/preset.ts
@@ -703,18 +703,6 @@ export async function expandConfigurePreset(folder: string, name: string, worksp
         }
     }
 
-    if (preset.__file && preset.__file.version <= 2) {
-        // toolchainFile and installDir added in presets v3
-        if (preset.toolchainFile) {
-            log.error(localize('property.unsupported.v2', 'Configure preset {0}: Property {1} is unsupported in presets v2', preset.name, '"toolchainFile"'));
-            return null;
-        }
-        if (preset.installDir) {
-            log.error(localize('property.unsupported.v2', 'Configure preset {0}: Property {1} is unsupported in presets v2', preset.name, '"installDir"'));
-            return null;
-        }
-    }
-
     // Expand other fields
     if (preset.binaryDir) {
         expandedPreset.binaryDir = util.lightNormalizePath(await expandString(preset.binaryDir, expansionOpts));
@@ -869,6 +857,18 @@ async function expandConfigurePresetImpl(folder: string, name: string, workspace
 async function expandConfigurePresetHelper(folder: string, preset: ConfigurePreset, workspaceFolder: string, sourceDir: string, allowUserPreset: boolean = false) {
     if (preset.__expanded) {
         return preset;
+    }
+
+    if (preset.__file && preset.__file.version <= 2) {
+        // toolchainFile and installDir added in presets v3
+        if (preset.toolchainFile) {
+            log.error(localize('property.unsupported.v2', 'Configure preset {0}: Property {1} is unsupported in presets v2', preset.name, '"toolchainFile"'));
+            return null;
+        }
+        if (preset.installDir) {
+            log.error(localize('property.unsupported.v2', 'Configure preset {0}: Property {1} is unsupported in presets v2', preset.name, '"installDir"'));
+            return null;
+        }
     }
 
     const refs = referencedConfigurePresets.get(folder)!;


### PR DESCRIPTION
<!-- Thanks for your contribution! To make things easier, please fill out the template below. -->

<!-- Please delete any unused sections. -->

<!-- Delete the following heading if there is no corresponding issue -->
## This change addresses item [#2897](https://github.com/microsoft/vscode-cmake-tools/issues/2897)

The following changes are proposed:

- Modify where we check for invalid settings in less than or equal to version 2. 

## The purpose of this change
This will fix the problem where we basically don't allow different versions in userpresets and presets.

