### PR TITLE
Disable bots for now

### DIFF
--- a/.github/workflows/locker.yml
+++ b/.github/workflows/locker.yml
@@ -1,7 +1,5 @@
 name: Locker
 on:
-  schedule:
-    - cron: 30 11 * * * # Run at 11:30 AM UTC (3:30 AM PST, 4:30 AM PDT)
   workflow_dispatch:
    inputs:
      readonly:

--- a/.github/workflows/more-info-needed-closer.yml
+++ b/.github/workflows/more-info-needed-closer.yml
@@ -1,7 +1,5 @@
 name: More Info Needed Closer
 on:
-  schedule:
-    - cron: 10 11 * * * # Run at 11:10 AM UTC (3:10 AM PST, 4:10 AM PDT)
   workflow_dispatch:
    inputs:
      readonly:

--- a/.github/workflows/question-closer.yml
+++ b/.github/workflows/question-closer.yml
@@ -1,7 +1,5 @@
 name: Question Closer
 on:
-  schedule:
-    - cron: 20 11 * * * # Run at 11:20 AM UTC (3:20 AM PST, 4:20 AM PDT)
   workflow_dispatch:
    inputs:
      readonly:


### PR DESCRIPTION
The bots do not run on the latest CI images.  I'm disabling them for now to reduce the daily failure spam email I'm getting.