### PR TITLE
Improve getLaunchTargetPath

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ Features:
 Bug Fixes:
 - When using CMake presets, the Project Status View now shows the build target along with the build preset. [PR #3241](https://github.com/microsoft/vscode-cmake-tools/pull/3241)
 
+Improvements:
+- Decreased the number of cases where we reconfigure erroneously upon usage of `cmake.getLaunchTargetPath` [#2878](https://github.com/microsoft/vscode-cmake-tools/issues/2878)
+
 ## 1.14.33
 Bug Fixes:
 - Set `Cmake: Use Project Status View` to `false` by default. This setting may be subject to A/B experimentation in 1.14 releases. To opt-out of experimentation, set the `cmake.useProjectStatusView` setting explicitly in `settings.json`. [PR #3199](https://github.com/microsoft/vscode-cmake-tools/pull/3199/)

--- a/src/drivers/cmakeDriver.ts
+++ b/src/drivers/cmakeDriver.ts
@@ -112,7 +112,7 @@ export abstract class CMakeDriver implements vscode.Disposable {
      *
      * @returns The exit code from CMake
      */
-    protected abstract doConfigure(extra_args: string[], consumer?: proc.OutputConsumer, showCommandOnly?: boolean, configurePreset?: preset.ConfigurePreset | null, options?: proc.ExecutionOptions, debuggerInformation?: DebuggerInformation): Promise<number>;
+    protected abstract doConfigure(extra_args: string[], consumer?: proc.OutputConsumer, showCommandOnly?: boolean, defaultConfigurePresetName?: string, configurePreset?: preset.ConfigurePreset | null, options?: proc.ExecutionOptions, debuggerInformation?: DebuggerInformation): Promise<number>;
     protected abstract doCacheConfigure(): Promise<number>;
 
     private _isConfiguredAtLeastOnce = false;
@@ -1325,7 +1325,9 @@ export abstract class CMakeDriver implements vscode.Disposable {
             }
 
             let expanded_flags: string[];
+            let defaultPresetName: string | undefined;
             if (this.useCMakePresets) {
+                defaultPresetName = this._configurePreset?.name;
                 const configurePreset: preset.ConfigurePreset | undefined | null = (trigger === ConfigureTrigger.taskProvider) ? presetOverride : this._configurePreset;
                 if (!configurePreset) {
                     log.debug(localize('no.config.Preset', 'No configure preset selected'));
@@ -1350,7 +1352,7 @@ export abstract class CMakeDriver implements vscode.Disposable {
                 this._isConfiguredAtLeastOnce = true;
                 return retc;
             } else {
-                retc = await this.doConfigure(expanded_flags, consumer, showCommandOnly, presetOverride, options, debuggerInformation);
+                retc = await this.doConfigure(expanded_flags, consumer, showCommandOnly, defaultPresetName, presetOverride, options, debuggerInformation);
                 this._isConfiguredAtLeastOnce = true;
             }
             const timeEnd: number = new Date().getTime();

--- a/src/drivers/cmakeFileApiDriver.ts
+++ b/src/drivers/cmakeFileApiDriver.ts
@@ -198,7 +198,7 @@ export class CMakeFileApiDriver extends CMakeDriver {
         return 0;
     }
 
-    async doConfigure(args_: string[], outputConsumer?: proc.OutputConsumer, showCommandOnly?: boolean, configurePreset?: ConfigurePreset | null, options?: proc.ExecutionOptions, debuggerInformation?: DebuggerInformation): Promise<number> {
+    async doConfigure(args_: string[], outputConsumer?: proc.OutputConsumer, showCommandOnly?: boolean, defaultConfigurePresetName?: string, configurePreset?: ConfigurePreset | null, options?: proc.ExecutionOptions, debuggerInformation?: DebuggerInformation): Promise<number> {
         const binaryDir = configurePreset?.binaryDir ?? this.binaryDir;
         const api_path = this.getCMakeFileApiPath(binaryDir);
         await createQueryFileForApi(api_path);
@@ -291,7 +291,7 @@ export class CMakeFileApiDriver extends CMakeDriver {
             log.trace(result.stderr);
             log.trace(result.stdout);
             if (result.retc === 0) {
-                if (!configurePreset) {
+                if (!configurePreset || (configurePreset && defaultConfigurePresetName && configurePreset.name === defaultConfigurePresetName)) {
                     this._needsReconfigure = false;
                 }
                 await this.updateCodeModel(binaryDir);

--- a/src/drivers/cmakeLegacyDriver.ts
+++ b/src/drivers/cmakeLegacyDriver.ts
@@ -75,7 +75,7 @@ export class CMakeLegacyDriver extends CMakeDriver {
         this._cacheWatcher.dispose();
     }
 
-    async doConfigure(args_: string[], outputConsumer?: proc.OutputConsumer, showCommandOnly?: boolean, configurePreset?: ConfigurePreset | null, options?: proc.ExecutionOptions): Promise<number> {
+    async doConfigure(args_: string[], outputConsumer?: proc.OutputConsumer, showCommandOnly?: boolean, defaultConfigurePresetName?: string, configurePreset?: ConfigurePreset | null, options?: proc.ExecutionOptions): Promise<number> {
         // Ensure the binary directory exists
         const binaryDir = configurePreset?.binaryDir ?? this.binaryDir;
         await fs.mkdir_p(binaryDir);

--- a/src/drivers/cmakeLegacyDriver.ts
+++ b/src/drivers/cmakeLegacyDriver.ts
@@ -75,7 +75,7 @@ export class CMakeLegacyDriver extends CMakeDriver {
         this._cacheWatcher.dispose();
     }
 
-    async doConfigure(args_: string[], outputConsumer?: proc.OutputConsumer, showCommandOnly?: boolean, _defaultConfigurePresetName?: string, configurePreset?: ConfigurePreset | null, options?: proc.ExecutionOptions): Promise<number> {
+    async doConfigure(args_: string[], outputConsumer?: proc.OutputConsumer, showCommandOnly?: boolean, defaultConfigurePresetName?: string, configurePreset?: ConfigurePreset | null, options?: proc.ExecutionOptions): Promise<number> {
         // Ensure the binary directory exists
         const binaryDir = configurePreset?.binaryDir ?? this.binaryDir;
         await fs.mkdir_p(binaryDir);
@@ -121,7 +121,7 @@ export class CMakeLegacyDriver extends CMakeDriver {
             this.configureProcess = null;
             log.trace(result.stderr);
             log.trace(result.stdout);
-            if (result.retc === 0 && !configurePreset) {
+            if (result.retc === 0 && (!configurePreset || (configurePreset && defaultConfigurePresetName && configurePreset.name === defaultConfigurePresetName))) {
                 this._needsReconfigure = false;
             }
             if (!configurePreset) {

--- a/src/drivers/cmakeLegacyDriver.ts
+++ b/src/drivers/cmakeLegacyDriver.ts
@@ -75,7 +75,7 @@ export class CMakeLegacyDriver extends CMakeDriver {
         this._cacheWatcher.dispose();
     }
 
-    async doConfigure(args_: string[], outputConsumer?: proc.OutputConsumer, showCommandOnly?: boolean, defaultConfigurePresetName?: string, configurePreset?: ConfigurePreset | null, options?: proc.ExecutionOptions): Promise<number> {
+    async doConfigure(args_: string[], outputConsumer?: proc.OutputConsumer, showCommandOnly?: boolean, _defaultConfigurePresetName?: string, configurePreset?: ConfigurePreset | null, options?: proc.ExecutionOptions): Promise<number> {
         // Ensure the binary directory exists
         const binaryDir = configurePreset?.binaryDir ?? this.binaryDir;
         await fs.mkdir_p(binaryDir);

--- a/src/drivers/cmakeServerDriver.ts
+++ b/src/drivers/cmakeServerDriver.ts
@@ -157,7 +157,7 @@ export class CMakeServerDriver extends CMakeDriver {
         })();
     }
 
-    protected async doConfigure(args: string[], consumer?: proc.OutputConsumer, showCommandOnly?: boolean, configurePreset?: ConfigurePreset | null, _options?: proc.ExecutionOptions) {
+    protected async doConfigure(args: string[], consumer?: proc.OutputConsumer, showCommandOnly?: boolean, _defaultConfigurePresetName?: string, configurePreset?: ConfigurePreset | null, _options?: proc.ExecutionOptions) {
         await this._clientChangeInProgress;
         const cl = await this.getClient();
         const sub = this.onMessage(msg => {


### PR DESCRIPTION
<!-- Thanks for your contribution! To make things easier, please fill out the template below. -->

<!-- Please delete any unused sections. -->

<!-- Delete the following heading if there is no corresponding issue -->
## This change addresses item [#2878](https://github.com/microsoft/vscode-cmake-tools/issues/2878)

### This decreases the number of cases where we erroneously reconfigure upon `cmake.getLaunchTargetPath`.

The following changes are proposed:

- Pass in the default current preset name (if present) in order to compare against the tasks preset name.
- In the build task, also check if we can configure using our task provider in order to make sure the `needsReconfigure` gets set correctly for any future `getLaunchTargetPath`. 

## The purpose of this change

To resolve #2878. This will improve the configure task such that it will also set the `needsReconfigure` flag to false when the requested preset matches the default. 

## Other Notes/Information

However, this  still cannot guarantee that this will always work in all cases, due to the fact that tasks can configure/build/run items from any preset, which may or may not match the default. Additionally, the build task directly invokes cmake.exe, so if the build tasks causes cmake to configure, the extension will not be aware of this, so there are still cases where the configure will happen twice. 