### PR TITLE
fix per folder provide browse configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Features:
 
 Bug Fixes:
 - When using CMake presets, the Project Status View now shows the build target along with the build preset. [PR #3241](https://github.com/microsoft/vscode-cmake-tools/pull/3241)
+- Fix per-folder browse configurations returning incorrect information [#3155](https://github.com/microsoft/vscode-cmake-tools/issues/3155)
 
 Improvements:
 - Decreased the number of cases where we reconfigure erroneously upon usage of `cmake.getLaunchTargetPath` [#2878](https://github.com/microsoft/vscode-cmake-tools/issues/2878)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,11 @@ Features:
 
 Bug Fixes:
 - When using CMake presets, the Project Status View now shows the build target along with the build preset. [PR #3241](https://github.com/microsoft/vscode-cmake-tools/pull/3241)
-- Fix per-folder browse configurations returning incorrect information [#3155](https://github.com/microsoft/vscode-cmake-tools/issues/3155)
+- Fix per-folder browse configurations returning incorrect information. [#3155](https://github.com/microsoft/vscode-cmake-tools/issues/3155)
 
 Improvements:
-- Decreased the number of cases where we reconfigure erroneously upon usage of `cmake.getLaunchTargetPath` [#2878](https://github.com/microsoft/vscode-cmake-tools/issues/2878)
-- Fix our checking for invalid settings when CMakeUserPresets version is different than CMakePresets [#2897](https://github.com/microsoft/vscode-cmake-tools/issues/2897)
+- Decreased the number of cases where we reconfigure erroneously upon usage of `cmake.getLaunchTargetPath`. [#2878](https://github.com/microsoft/vscode-cmake-tools/issues/2878)
+- Fix our checking for invalid settings when CMakeUserPresets version is different than CMakePresets. [#2897](https://github.com/microsoft/vscode-cmake-tools/issues/2897)
 - Fix the precendence order that we evaluate the `cmake.parallelJobs` setting. [#3206](https://github.com/microsoft/vscode-cmake-tools/issues/3206)
 
 ## 1.14.33

--- a/src/cpptools.ts
+++ b/src/cpptools.ts
@@ -401,8 +401,8 @@ export class CppConfigurationProvider implements cpptools.CustomConfigurationPro
         return true;
     }
 
-    async provideFolderBrowseConfiguration(uri: vscode.Uri): Promise<cpptools.WorkspaceBrowseConfiguration> {
-        return this.workspaceBrowseConfigurations.get(util.platformNormalizePath(uri.fsPath)) ?? this.workspaceBrowseConfiguration;
+    async provideFolderBrowseConfiguration(uri: vscode.Uri): Promise<cpptools.WorkspaceBrowseConfiguration | null> {
+        return this.workspaceBrowseConfigurations.get(util.platformNormalizePath(uri.fsPath)) ?? null;
     }
 
     /** No-op */

--- a/test/unit-tests/cpptools.test.ts
+++ b/test/unit-tests/cpptools.test.ts
@@ -253,16 +253,16 @@ suite('CppTools tests', () => {
         const canProvideBrowseConfigPerFolder: boolean = await provider.canProvideBrowseConfigurationsPerFolder();
         expect(canProvideBrowseConfigPerFolder).to.eq(true);
         const browseConfig = await provider.provideFolderBrowseConfiguration(vscode.Uri.file(here));
-        expect(browseConfig.browsePath.length).to.eq(1);
-        expect(browseConfig.browsePath[0]).to.eq(util.platformNormalizePath(here));
+        expect(browseConfig?.browsePath.length).to.eq(1);
+        expect(browseConfig?.browsePath[0]).to.eq(util.platformNormalizePath(here));
 
         // Verify the browsePath with a different folder.
         const configurations2 = await provider.provideConfigurations([uri3]);
         expect(configurations2.length).to.eq(1);
         expect(configurations2[0].configuration.defines).to.contain('FLAG3');
         const browseConfig2 = await provider.provideFolderBrowseConfiguration(vscode.Uri.file(smokeFolder));
-        expect(browseConfig2.browsePath.length).to.eq(1);
-        expect(browseConfig2.browsePath[0]).to.eq(util.platformNormalizePath(smokeFolder));
+        expect(browseConfig2?.browsePath.length).to.eq(1);
+        expect(browseConfig2?.browsePath[0]).to.eq(util.platformNormalizePath(smokeFolder));
     });
 
     // Validate codeModel using cppTools API V6
@@ -362,8 +362,8 @@ suite('CppTools tests', () => {
         const canProvideBrowseConfigPerFolder: boolean = await provider.canProvideBrowseConfigurationsPerFolder();
         expect(canProvideBrowseConfigPerFolder).to.eq(true);
         const browseConfig = await provider.provideFolderBrowseConfiguration(vscode.Uri.file(here));
-        expect(browseConfig.browsePath.length).to.eq(1);
-        expect(browseConfig.browsePath[0]).to.eq(util.platformNormalizePath(here));
+        expect(browseConfig?.browsePath.length).to.eq(1);
+        expect(browseConfig?.browsePath[0]).to.eq(util.platformNormalizePath(here));
 
         // Verify the browsePath with a different folder.
         const configurations2 = await provider.provideConfigurations([uri3]);
@@ -371,7 +371,7 @@ suite('CppTools tests', () => {
         expect(configurations2[0].configuration.defines).to.be.empty;
         expect(configurations2[0].configuration.compilerFragments).to.contain('-DFRAGMENT3');
         const browseConfig2 = await provider.provideFolderBrowseConfiguration(vscode.Uri.file(smokeFolder));
-        expect(browseConfig2.browsePath.length).to.eq(1);
-        expect(browseConfig2.browsePath[0]).to.eq(util.platformNormalizePath(smokeFolder));
+        expect(browseConfig2?.browsePath.length).to.eq(1);
+        expect(browseConfig2?.browsePath[0]).to.eq(util.platformNormalizePath(smokeFolder));
     });
 });


### PR DESCRIPTION
We were returning the most recent stored browse configuration, which may be incorrect. Rather, we should return null if we don't have the browseConfiguration for the requested URI.

<!-- Thanks for your contribution! To make things easier, please fill out the template below. -->

<!-- Please delete any unused sections. -->

<!-- Delete the following heading if there is no corresponding issue -->
## This change addresses item [#3155]
### This changes the implementation of `provideFolderBrowseConfiguration`

The following changes are proposed:

- Return `null` instead of a default / last stored `workspaceBrowseConfiguration`

## The purpose of this change

We were returning what effectively was the default or last stored `workspaceBrowseConfiguration` if we didn't have stored a browseConfiguration for that URI. This is incorrect as that default or last stored has no guarantee of actually applying. We instead return `null`.

Closes #3155 
