### PR TITLE
Active Folder Selection as Task Argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.15
 Features:
 - Added support for the CMake Debugger. [#3093](https://github.com/microsoft/vscode-cmake-tools/issues/3093)
+- Added support for passing a folder parameter to the `cmake.selectActiveFolder` command. [#3256](https://github.com/microsoft/vscode-cmake-tools/issues/3256) [@cvanbeek](https://github.com/cvanbeek13)
 
 Bug Fixes:
 - When using CMake presets, the Project Status View now shows the build target along with the build preset. [PR #3241](https://github.com/microsoft/vscode-cmake-tools/pull/3241)

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -554,17 +554,17 @@ export class ExtensionManager implements vscode.Disposable {
                 selection = projects.find(proj => proj.folderName === project[0]);
             }
         } else if (vscode.workspace.workspaceFolders?.length) {
-                selection = await this.pickCMakeProject();
-            }
-
-            if (selection) {
-                // Ignore if user cancelled
-                await this.setActiveProject(selection);
-                telemetry.logEvent("selectactivefolder");
-                const currentActiveFolderPath = this.activeFolderPath();
-                await this.extensionContext.workspaceState.update('activeFolder', currentActiveFolderPath);
-            }
+            selection = await this.pickCMakeProject();
         }
+
+        if (selection) {
+            // Ignore if user cancelled
+            await this.setActiveProject(selection);
+            telemetry.logEvent("selectactivefolder");
+            const currentActiveFolderPath = this.activeFolderPath();
+            await this.extensionContext.workspaceState.update('activeFolder', currentActiveFolderPath);
+        }
+    }
 
     private async initActiveProject(): Promise<CMakeProject | undefined> {
         let folder: vscode.WorkspaceFolder | undefined;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -544,9 +544,21 @@ export class ExtensionManager implements vscode.Disposable {
     /**
      * Show UI to allow the user to select an active project
      */
-    async selectActiveFolder() {
+    async selectActiveFolder(project?: CMakeProject | string[]) {
+        let selection: CMakeProject | undefined;
+        if (project instanceof CMakeProject) {
+            selection = project;
+        } else if (Array.isArray(project) && project.length > 0) {
+            const projects: CMakeProject[] = this.projectController.getAllCMakeProjects();
+            if (projects.length !== 0) {
+                selection = projects.find(proj => proj.folderName === project[0]);
+            }
+        } else {
         if (vscode.workspace.workspaceFolders?.length) {
-            const selection: CMakeProject | undefined = await this.pickCMakeProject();
+                selection = await this.pickCMakeProject();
+            }
+        }
+
             if (selection) {
                 // Ignore if user cancelled
                 await this.setActiveProject(selection);
@@ -555,7 +567,6 @@ export class ExtensionManager implements vscode.Disposable {
                 await this.extensionContext.workspaceState.update('activeFolder', currentActiveFolderPath);
             }
         }
-    }
 
     private async initActiveProject(): Promise<CMakeProject | undefined> {
         let folder: vscode.WorkspaceFolder | undefined;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -548,16 +548,14 @@ export class ExtensionManager implements vscode.Disposable {
         let selection: CMakeProject | undefined;
         if (project instanceof CMakeProject) {
             selection = project;
-        } else if (Array.isArray(project) && project.length > 0) {
+        } else if (Array.isArray(project) && project.length > 0 && typeof project[0] === "string") {
             const projects: CMakeProject[] = this.projectController.getAllCMakeProjects();
             if (projects.length !== 0) {
                 selection = projects.find(proj => proj.folderName === project[0]);
             }
-        } else {
-        if (vscode.workspace.workspaceFolders?.length) {
+        } else if (vscode.workspace.workspaceFolders?.length) {
                 selection = await this.pickCMakeProject();
             }
-        }
 
             if (selection) {
                 // Ignore if user cancelled


### PR DESCRIPTION
## This change addresses item #3256

### This changes Active Folder Selection from Tasks on Multi-Root Projects

The following changes are proposed:

These updates to the `extension.ts` file allow a user to pass in a folder as an argument to the `cmake.selectActiveFolder` command.  The user may then add an argument in `tasks.json` (or the `.code-workspace` file) in order to switch the active folder as an automated task.

Here's an example `.code-workspace` file.  Note that you will need to update `tasks/inputs[switchToProject]/args[0]` to match the name of your project's root directory:

```json
{
    "folders": [
        {
            "name": "Project",
            "path": ".."
        },
        {
            "name": "Tests",
            "path": "../tests"
        }
    ],
    "tasks": {
        "version": "2.0.0",
        "tasks": [
            {
                "label": "SwitchToProject",
                "type": "process",
                "command": "${input:switchToProject}",
                "problemMatcher": []
            },
            {
                "label": "CMake Build",
                "type": "cmake",
                "command": "build",
                "dependsOn": [
                    "SwitchToProject"
                ],
                "dependsOrder": "sequence",
                "problemMatcher": [
                    "$gcc"
                ]
            },
            {
                "label": "SwitchToTests",
                "type": "process",
                "command": "${input:switchToTests}",
                "problemMatcher": []
            },
            {
                "label": "CMake Build Tests",
                "type": "cmake",
                "command": "build",
                "dependsOn": [
                    "SwitchToTests"
                ],
                "dependsOrder": "sequence",
                "problemMatcher": [
                    "$gcc"
                ]
            },
            {
                "label": "CMake Test",
                "type": "cmake",
                "command": "test",
                "options": {
                    "cwd": "${workspaceFolder}/tests"
                },
                "group": {
                    "kind": "test",
                    "isDefault": true
                },
                "problemMatcher": [
                    "$gcc"
                ],
                "dependsOn": [
                    "CMake Build Tests"
                ],
                "dependsOrder": "sequence"
            }
        ],
        "inputs": [
            {
                "id": "switchToProject",
                "type": "command",
                "command": "cmake.selectActiveFolder",
                "args": [
                    "project-folder-name"
                ]
            },
            {
                "id": "switchToTests",
                "type": "command",
                "command": "cmake.selectActiveFolder",
                "args": [
                    "tests"
                ]
            }
        ]
    }
}
```