### PR TITLE
allow a way to run jobs in parallel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Bug Fixes:
 - IntelliSense resolves headers coming from MacOS frameworks. CMake 3.27 or later is required. [#2324](https://github.com/microsoft/vscode-cmake-tools/issues/2324)
 - Don't ignore empty cache string variables when configuring from presets. [#1842](https://github.com/microsoft/vscode-cmake-tools/issues/1842)
 - Fix active build configuration warning coming from CppTools. [#2353](https://github.com/microsoft/vscode-cmake-tools/issues/2353)
+- Allow a way to run ctests in parallel by setting `cmake.ctest.allowParallelJobs` to `true`. []()
 
 Improvements:
 - Decreased the number of cases where we reconfigure erroneously upon usage of `cmake.getLaunchTargetPath`. [#2878](https://github.com/microsoft/vscode-cmake-tools/issues/2878)

--- a/package.json
+++ b/package.json
@@ -1656,6 +1656,12 @@
           "description": "%cmake-tools.configuration.cmake.ctest.parallelJobs.description%",
           "scope": "resource"
         },
+        "cmake.ctest.allowParallelJobs": {
+          "type": "boolean",
+          "default": false,
+          "description": "%cmake-tools.configuration.cmake.ctest.allowParallelJobs.description%",
+          "scope": "window"
+        },
         "cmake.parseBuildDiagnostics": {
           "type": "boolean",
           "default": true,

--- a/package.nls.json
+++ b/package.nls.json
@@ -86,7 +86,11 @@
     "cmake-tools.configuration.cmake.buildToolArgs.description": "Additional arguments to pass to the underlying build tool when building.",
     "cmake-tools.configuration.cmake.parallelJobs.description": "The number of parallel build jobs. Use zero to automatically detect the number of CPUs. Setting this to 1 will omit the parallelism flag (-j) from the underlying build command, which has a generator-dependent effect on build parallelism.",
     "cmake-tools.configuration.cmake.ctestPath.description": "Path to CTest executable. If null, will be inferred from cmake.cmakePath (recommended to leave null).",
-    "cmake-tools.configuration.cmake.ctest.parallelJobs.description": "The number of parallel test jobs. Use zero to use the value of cmake.parallelJobs.",
+    "cmake-tools.configuration.cmake.ctest.parallelJobs.description": {
+        "message": "The number of parallel test jobs. Use zero to use the value of cmake.parallelJobs. This only works when `#cmake.ctest.allowParallelJobs` is set to `true`.",
+        "comment": "Markdown text between `` should not be translated or localized (they represent literal text) and the capitalization, spacing, and punctuation (including the ``) should not be altered."
+    },
+    "cmake-tools.configuration.cmake.ctest.allowParallelJobs.description": "Allows ctests to be run in parallel, however the result output may be garbled as a result.",
     "cmake-tools.configuration.cmake.parseBuildDiagnostics.description": "Parse compiler output for warnings and errors.",
     "cmake-tools.configuration.cmake.enabledOutputParsers.description": {
         "message": "Output parsers to use. Supported parsers `cmake`, `gcc`, `gnuld` for GNULD-style linker output, `msvc` for Microsoft Visual C++, `ghs` for the Green Hills compiler with --no_wrap_diagnostics --brief_diagnostics, and `diab` for the Wind River Diab compiler.",

--- a/src/config.ts
+++ b/src/config.ts
@@ -107,8 +107,9 @@ export interface ExtensionConfigurationSettings {
     buildArgs: string[];
     buildToolArgs: string[];
     parallelJobs: number | undefined;
+    allowParallelJobs: boolean;
     ctestPath: string;
-    ctest: { parallelJobs: number };
+    ctest: { parallelJobs: number; allowParallelJobs: boolean };
     parseBuildDiagnostics: boolean;
     enabledOutputParsers: string[];
     debugConfig: CppDebugConfiguration;
@@ -301,6 +302,9 @@ export class ConfigurationReader implements vscode.Disposable {
     get ctestParallelJobs(): number | null {
         return this.configData.ctest.parallelJobs;
     }
+    get ctestAllowParallelJobs(): boolean {
+        return this.configData.ctest.allowParallelJobs;
+    }
     get parseBuildDiagnostics(): boolean {
         return !!this.configData.parseBuildDiagnostics;
     }
@@ -483,8 +487,9 @@ export class ConfigurationReader implements vscode.Disposable {
         buildArgs: new vscode.EventEmitter<string[]>(),
         buildToolArgs: new vscode.EventEmitter<string[]>(),
         parallelJobs: new vscode.EventEmitter<number>(),
+        allowParallelJobs: new vscode.EventEmitter<boolean>(),
         ctestPath: new vscode.EventEmitter<string>(),
-        ctest: new vscode.EventEmitter<{ parallelJobs: number }>(),
+        ctest: new vscode.EventEmitter<{ parallelJobs: number; allowParallelJobs: boolean }>(),
         parseBuildDiagnostics: new vscode.EventEmitter<boolean>(),
         enabledOutputParsers: new vscode.EventEmitter<string[]>(),
         debugConfig: new vscode.EventEmitter<CppDebugConfiguration>(),

--- a/test/unit-tests/config.test.ts
+++ b/test/unit-tests/config.test.ts
@@ -21,9 +21,11 @@ function createConfig(conf: Partial<ExtensionConfigurationSettings>): Configurat
         buildArgs: [],
         buildToolArgs: [],
         parallelJobs: 0,
+        allowParallelJobs: false,
         ctestPath: '',
         ctest: {
-            parallelJobs: 0
+            parallelJobs: 0,
+            allowParallelJobs: false
         },
         parseBuildDiagnostics: true,
         enabledOutputParsers: [],


### PR DESCRIPTION
If you set `cmake.ctest.allowParallelJobs` to `true`, then jobs can run in parallel. However, this also means that the result output may be garbled (no functional impact).