### PR TITLE
Add an option to use a custom compile commands filename

### DIFF
--- a/docs/cmake-settings.md
+++ b/docs/cmake-settings.md
@@ -18,6 +18,7 @@ Options that support substitution, in the table below, allow variable references
 | `cmake.cmakePath`| Specify location of the cmake executable. | `cmake` (causes CMake Tools to search the `PATH` environment variable, as well as some hard-coded locations.) | Supports substitution for `workspaceRoot`, `workspaceFolder`, `workspaceRootFolderName`, `userHome`, `${command:...}` and `${env:...}`. Other substitutions result in an empty string. |
 | `cmake.cmakeCommunicationMode` | Specifies the protocol for communicating between the extension and CMake | `automatic` | no |
 | `cmake.configureArgs` | Arguments to CMake that will be passed during the configure process. Prefer to use `cmake.configureSettings` or [CMake variants](variants.md).</br> It is not recommended to pass `-D` arguments using this setting. | `[]` (empty array-no arguments) | yes |
+| `cmake.compileCommandsFilename`| The filename of the compile commands database. | `compile_commands.json` | no |
 | `cmake.configureEnvironment` | An object containing `key:value` pairs of environment variables, which will be passed to CMake only when configuring.| `null` (no environment variable pairs) | yes |
 | `cmake.configureOnEdit` | Automatically configure CMake project directories when the path in the `cmake.sourceDirectory` setting is updated or when `CMakeLists.txt` or `*.cmake` files are saved. | `true` | no |
 | `cmake.configureOnOpen` | Automatically configure CMake project directories when they are opened. | `null` (prompt for configure) | no |

--- a/package.json
+++ b/package.json
@@ -1997,6 +1997,12 @@
           "description": "%cmake-tools.configuration.cmake.copyCompileCommands.description%",
           "scope": "resource"
         },
+        "cmake.compileCommandsFilename": {
+          "type": "string",
+          "default": "compile_commands.json",
+          "description": "%cmake-tools.configuration.cmake.compileCommandsFilename.description%",
+          "scope": "resource"
+        },
         "cmake.configureOnOpen": {
           "type": "boolean",
           "default": null,

--- a/src/config.ts
+++ b/src/config.ts
@@ -124,6 +124,7 @@ export interface ExtensionConfigurationSettings {
     emscriptenSearchDirs: string[];
     mergedCompileCommands: string | null;
     copyCompileCommands: string | null;
+    compileCommandsFilename: string;
     loadCompileCommands: boolean;
     configureOnOpen: boolean | null;
     configureOnEdit: boolean;
@@ -415,6 +416,9 @@ export class ConfigurationReader implements vscode.Disposable {
     get emscriptenSearchDirs(): string[] {
         return this.configData.emscriptenSearchDirs;
     }
+    get compileCommandsFilename(): string {
+        return this.configData.compileCommandsFilename;
+    }
     get mergedCompileCommands(): string | null {
         return this.configData.mergedCompileCommands;
     }
@@ -501,6 +505,7 @@ export class ConfigurationReader implements vscode.Disposable {
         mingwSearchDirs: new vscode.EventEmitter<string[]>(), // Deprecated in 1.14, replaced by additionalCompilerSearchDirs, but kept for backwards compatibility
         additionalCompilerSearchDirs: new vscode.EventEmitter<string[]>(),
         emscriptenSearchDirs: new vscode.EventEmitter<string[]>(),
+        compileCommandsFilename: new vscode.EventEmitter<string>(),
         mergedCompileCommands: new vscode.EventEmitter<string | null>(),
         copyCompileCommands: new vscode.EventEmitter<string | null>(),
         loadCompileCommands: new vscode.EventEmitter<boolean>(),

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -181,6 +181,12 @@ export class ExtensionManager implements vscode.Disposable {
         this.workspaceConfig.onChange('mingwSearchDirs', async _ => { // Deprecated in 1.14, replaced by additionalCompilerSearchDirs, but kept for backwards compatibility
             KitsController.additionalCompilerSearchDirs = await this.getAdditionalCompilerDirs();
         });
+        this.workspaceConfig.onChange('compileCommandsFilename', async _ => {
+            const projects = this.projectController.getAllCMakeProjects();
+            for (const project of projects) {
+                await project.refreshCompileDatabaseWithDefaultOptions();
+            }
+        });
         KitsController.additionalCompilerSearchDirs = await this.getAdditionalCompilerDirs();
 
         let isMultiProject = false;

--- a/test/unit-tests/config.test.ts
+++ b/test/unit-tests/config.test.ts
@@ -39,6 +39,7 @@ function createConfig(conf: Partial<ExtensionConfigurationSettings>): Configurat
         mingwSearchDirs: [], // Deprecated in 1.14, replaced by additionalCompilerSearchDirs, but kept for backwards compatibility
         additionalCompilerSearchDirs: [],
         emscriptenSearchDirs: [],
+        compileCommandsFilename: 'compile_commands.json',
         mergedCompileCommands: null,
         copyCompileCommands: null,
         loadCompileCommands: true,


### PR DESCRIPTION
### This changes [[visible behavior/performance/documentation/etc.]]

The following changes are proposed:

- Add a `compileCommandsFilename` config option.

## The purpose of this change

I use a project that generates a custom compile commands database so this allows
this extension to load that file.

## Other Notes/Information

Tested on a real project including changing the value at runtime.
