### PR TITLE
add lldb to debug-launch.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ Features:
 - Support different debug config for different targets. [PR #2801](https://github.com/microsoft/vscode-cmake-tools/pull/2801) [@RichardLuo0](https://github.com/RichardLuo0)
 - Add ability to get a test's `WORKING_DIRECTORY` in launch.json via `cmake.testWorkingDirectory` [PR #3336](https://github.com/microsoft/vscode-cmake-tools/pull/3336)
 
+Improvements:
+- Updated debugging documentation to add the LLDB configuration needed for macOS. [PR #3332](https://github.com/microsoft/vscode-cmake-tools/pull/3332) [@slhck](https://github.com/slhck)
+
 ## 1.15
 Features:
 - Added support for the CMake Debugger. [#3093](https://github.com/microsoft/vscode-cmake-tools/issues/3093)

--- a/docs/debug-launch.md
+++ b/docs/debug-launch.md
@@ -81,6 +81,38 @@ Here are minimal examples of a `launch.json` file that uses `cmake.launchTargetP
     ]
 }
 ```
+### lldb
+```jsonc
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "(lldb) Launch",
+            "type": "cppdbg",
+            "request": "launch",
+            // Resolved by CMake Tools:
+            "program": "${command:cmake.launchTargetPath}",
+            "args": [],
+            "stopAtEntry": false,
+            "cwd": "${workspaceFolder}",
+            "environment": [
+                {
+                    // add the directory where our target was built to the PATHs
+                    // it gets resolved by CMake Tools:
+                    "name": "PATH",
+                    "value": "${env:PATH}:${command:cmake.getLaunchTargetDirectory}"
+                },
+                {
+                    "name": "OTHER_VALUE",
+                    "value": "Something something"
+                }
+            ],
+            "console": "externalTerminal",
+            "MIMode": "lldb"
+        }
+    ]
+}
+```
 ### msvc
 ```jsonc
 {


### PR DESCRIPTION
### This changes documentation

The following changes are proposed:

This adds the lldb configuration needed for macOS.

## The purpose of this change

Previously, there was no simple way to obtain a config for macOS with lldb, and gdb is not available.
