### PR TITLE
Add ability to get a test's WORKING_DIRECTORY in launch.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.16
 Features:
 - Support different debug config for different targets. [PR #2801](https://github.com/microsoft/vscode-cmake-tools/pull/2801) [@RichardLuo0](https://github.com/RichardLuo0)
+- Add ability to get a test's `WORKING_DIRECTORY` in launch.json via `cmake.testWorkingDirectory` [PR #3336](https://github.com/microsoft/vscode-cmake-tools/pull/3336)
 
 ## 1.15
 Features:

--- a/docs/debug-launch.md
+++ b/docs/debug-launch.md
@@ -158,8 +158,8 @@ You can also construct launch.json configurations that allow you to debug tests 
 > **Note:**
 > These launch.json configurations are to be used specifically from the UI of the Test Explorer. 
 
-The easiest way to do this is to construct the debug configuration using `cmake.testProgram` for the `program` field, and `cmake.testArgs` for 
-the `args` field.
+The easiest way to do this is to construct the debug configuration using `cmake.testProgram` for the `program` field, `cmake.testArgs` for 
+the `args` field, and `cmake.testWorkingDirectory` for the `cwd` field.
 
 A couple of examples:
 
@@ -168,9 +168,9 @@ A couple of examples:
 {
     "name": "(ctest) Launch",
     "type": "cppdbg",
-    "cwd": "${workspaceFolder}",
     "request": "launch",
     // Resolved by CMake Tools:
+    "cwd": "${cmake.testWorkingDirectory}",
     "program": "${cmake.testProgram}",
     "args": [ "${cmake.testArgs}"],
 }

--- a/src/ctest.ts
+++ b/src/ctest.ts
@@ -798,6 +798,8 @@ export class CTestDriver implements vscode.Disposable {
         // Commands can't be used to replace array (i.e., args); and both test program and test args requires folder and
         // test name as parameters, which means one lauch config for each test. So replacing them here is a better way.
         chosenConfig.config = this.replaceAllInObject<vscode.DebugConfiguration>(chosenConfig.config, '${cmake.testProgram}', this.testProgram(testName));
+        chosenConfig.config = this.replaceAllInObject<vscode.DebugConfiguration>(chosenConfig.config, '${cmake.testWorkingDirectory}', this.testWorkingDirectory(testName));
+
         // Replace cmake.testArgs wrapped in quotes, like `"${command:cmake.testArgs}"`, without any spaces in between,
         // since we need to repalce the quotes as well.
         chosenConfig.config = this.replaceArrayItems(chosenConfig.config, '${cmake.testArgs}', this.testArgs(testName)) as vscode.DebugConfiguration;
@@ -851,6 +853,17 @@ export class CTestDriver implements vscode.Disposable {
                     return test.command[0];
                 }
             }
+        }
+        return '';
+    }
+
+    private testWorkingDirectory(testName: string): string {
+        const property = this.tests?.tests
+            .find(test => test.name === testName)?.properties
+            .find(prop => prop.name === 'WORKING_DIRECTORY');
+
+        if (typeof(property?.value) === 'string') {
+            return property.value;
         }
         return '';
     }


### PR DESCRIPTION
<!-- Thanks for your contribution! To make things easier, please fill out the template below. -->

<!-- Please delete any unused sections. -->

### This PR adds the option to get the correct working directory when debugging tests

The following changes are proposed:
- Support usage of ${cmake.testWorkingDirectory} in launch.json to get the WORKING_DIRECTORY property of a test dynamically

## The purpose of this change
- Make it easier to debug tests in the same environment they would normally run in

