### PR TITLE
cpptools: use default configuration with no build type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Improvements:
 
 Bug Fixes:
 - Fix Unhandled Exception if no args are specified in `cmake.getLaunchTargetFilename` inside an input context of a task. [PR #3348](https://github.com/microsoft/vscode-cmake-tools/issues/3348) [@vlavati](https://github.com/vlavati)
+- Fix incorrect IntelliSense configuration with default/empty `CMAKE_BUILD_TYPE` using CMakePresets. [PR #3363](https://github.com/microsoft/vscode-cmake-tools/pull/3363) [@deribaucourt](https://github.com/deribaucourt)
 
 ## 1.15
 Features:

--- a/src/cpptools.ts
+++ b/src/cpptools.ts
@@ -593,7 +593,7 @@ export class CppConfigurationProvider implements cpptools.CustomConfigurationPro
         }
         for (const config of opts.codeModelContent.configurations) {
             // Update only the active build type variant.
-            if (config.name === opts.activeBuildTypeVariant) {
+            if (config.name === opts.activeBuildTypeVariant || (!opts.activeBuildTypeVariant && config.name === "")) {
                 for (const project of config.projects) {
                     for (const target of project.targets) {
                         // Now some shenanigans since header files don't have config data:


### PR DESCRIPTION
See related Issue's description: #3355

Change description in the commit message:

    When configuring this extension with a CMakePresets.json, with a
    CMakeCache.txt that doesn't define a CMAKE_BUILD_TYPE, the intelliSense
    configuration was not passed to vscode-cpptools. However, this is a
    valid CMake configuration which should use the toolchain's default
    configuration.

    The codeModelContent configuration was rejected because it's name (""),
    didn't match activeBuildTypeVariant which was null.

    This patch accepts an unnamed configurations in the case where no active
    build type variant is set.

<!-- Thanks for your contribution! To make things easier, please fill out the template below. -->

<!-- Please delete any unused sections. -->

<!-- Delete the following heading if there is no corresponding issue -->
## This change addresses item #3355

### This changes visible behavior

The following changes are proposed:

- Fix IntelliSense configuration where `CMAKE_BUILD_TYPE` is empty
