### PR TITLE
Support $penv{} in include paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Improvements:
 - In multi-root workspace, the Project Outline View now shows all configured projects. [PR #3270](https://github.com/microsoft/vscode-cmake-tools/pull/3270) [@vlavati](https://github.com/vlavati)
 - Added script mode and ability to connect to externally launched CMake processes. [PR #3277](https://github.com/microsoft/vscode-cmake-tools/pull/3277)
 - Added buttons to the project nodes in the Project Outline View. [PR #3354](https://github.com/microsoft/vscode-cmake-tools/pull/3354) [@vlavati](https://github.com/vlavati)
+- `$penv{}` macros are expanded in `include` paths in CMakePresets.json as long as `version` is 7 or higher. [#3310](https://github.com/microsoft/vscode-cmake-tools/issues/3310)
 
 Bug Fixes:
 - Fix Unhandled Exception if no args are specified in `cmake.getLaunchTargetFilename` inside an input context of a task. [PR #3348](https://github.com/microsoft/vscode-cmake-tools/issues/3348) [@vlavati](https://github.com/vlavati)

--- a/src/presetsController.ts
+++ b/src/presetsController.ts
@@ -1029,7 +1029,7 @@ export class PresetsController {
             const includePath = presetsFile.version >= 7 ?
                 // Version 7 and later support $penv{} expansions in include paths
                 substituteAll(rawInclude, getParentEnvSubstitutions(rawInclude, new Map<string, string>())).result :
-                presetsFile.include[i];
+                rawInclude;
             const fullIncludePath = path.normalize(path.resolve(path.dirname(file), includePath));
 
             // Do not include files more than once

--- a/src/presetsController.ts
+++ b/src/presetsController.ts
@@ -9,7 +9,7 @@ import { fs } from '@cmt/pr';
 import * as preset from '@cmt/preset';
 import * as util from '@cmt/util';
 import rollbar from '@cmt/rollbar';
-import { ExpansionOptions } from '@cmt/expand';
+import { ExpansionOptions, getParentEnvSubstitutions, substituteAll } from '@cmt/expand';
 import paths from '@cmt/paths';
 import { KitsController } from '@cmt/kitsController';
 import { descriptionForKit, Kit, SpecialKits } from '@cmt/kit';
@@ -1025,7 +1025,12 @@ export class PresetsController {
 
         // Merge the includes in reverse order so that the final presets order is correct
         for (let i = presetsFile.include.length - 1; i >= 0; i--) {
-            const fullIncludePath = path.normalize(path.resolve(path.dirname(file), presetsFile.include[i]));
+            const rawInclude = presetsFile.include[i];
+            const includePath = presetsFile.version >= 7 ?
+                // Version 7 and later support $penv{} expansions in include paths
+                substituteAll(rawInclude, getParentEnvSubstitutions(rawInclude, new Map<string, string>())).result :
+                presetsFile.include[i];
+            const fullIncludePath = path.normalize(path.resolve(path.dirname(file), includePath));
 
             // Do not include files more than once
             if (referencedFiles.has(fullIncludePath)) {


### PR DESCRIPTION
Addresses #3310

This ended up as more of a new feature than a bug fix. We don't formally support all of CMakePresets v6 or v7 right now, but this is a simple change to enable the include path part of the v7 changes.