### PR TITLE
Stale Bot Upgrades

### DIFF
--- a/.github/workflows/close-old-issues.yml
+++ b/.github/workflows/close-old-issues.yml
@@ -17,8 +17,8 @@ jobs:
     runs-on: ubuntu-latest
     env:
       stale-days: ${{ github.event.inputs.inactive-days || 720 }}
-      close-days: ${{ github.event.inputs.stale-label-days >= 14 && github.event.inputs.stale-label-days || -1 }}
-      stale-label: stale-old
+      close-days: ${{ github.event.inputs.stale-label-days >= 0 && github.event.inputs.stale-label-days || -1 }}
+      stale-label: stale-test
       stale-exempt-label: stale-exempt
     steps:
     - uses: actions/stale@v4.1.1
@@ -27,6 +27,7 @@ jobs:
         exempt-issue-labels: ${{ env.stale-exempt-label }}
         days-before-pr-stale: -1
         days-before-pr-close: -1
+        only-labels: for-stale-test
         days-before-stale: ${{ env.stale-days }}
         stale-issue-message: "This issue is now marked as '${{ env.stale-label }}' due to there being no activity on it for the past ${{ env.stale-days }} days. Unless the '${{ env.stale-label }}' label is removed or the issue is commented on, this will be remain open for at least 14 days and then it may be closed. If you would like to make this issue exempt from getting stale, please add the '${{ env.stale-exempt-label }}' label."
         days-before-close: ${{ env.close-days }}

--- a/.github/workflows/close-old-issues.yml
+++ b/.github/workflows/close-old-issues.yml
@@ -1,7 +1,7 @@
 name: Close Old Issues
 on:
   schedule:
-    - cron: "0 1 * * *"
+    - cron: "0 8 * * *"
   workflow_dispatch:
     inputs:
       inactive-days:

--- a/.github/workflows/close-old-issues.yml
+++ b/.github/workflows/close-old-issues.yml
@@ -17,8 +17,8 @@ jobs:
     runs-on: ubuntu-latest
     env:
       stale-days: ${{ github.event.inputs.inactive-days || 720 }}
-      close-days: ${{ github.event.inputs.stale-label-days >= 0 && github.event.inputs.stale-label-days || -1 }}
-      stale-label: stale-test
+      close-days: ${{ github.event.inputs.stale-label-days >= 14 && github.event.inputs.stale-label-days || -1 }}
+      stale-label: stale-old
       stale-exempt-label: stale-exempt
     steps:
     - uses: actions/stale@v4.1.1
@@ -27,7 +27,6 @@ jobs:
         exempt-issue-labels: ${{ env.stale-exempt-label }}
         days-before-pr-stale: -1
         days-before-pr-close: -1
-        only-labels: for-stale-test
         days-before-stale: ${{ env.stale-days }}
         stale-issue-message: "This issue is now marked as '${{ env.stale-label }}' due to there being no activity on it for the past ${{ env.stale-days }} days. Unless the '${{ env.stale-label }}' label is removed or the issue is commented on, this will be remain open for at least 14 days and then it may be closed. If you would like to make this issue exempt from getting stale, please add the '${{ env.stale-exempt-label }}' label."
         days-before-close: ${{ env.close-days }}

--- a/.github/workflows/close-old-issues.yml
+++ b/.github/workflows/close-old-issues.yml
@@ -1,12 +1,16 @@
 name: Close Old Issues
 on:
+  schedule:
+    - cron: "0 1 * * *"
   workflow_dispatch:
     inputs:
       inactive-days:
         description: "inactive-days: Specify how many days the issue has to have had no activity to get the 'stale-old' label."
+        type: number
         default: 720
       stale-label-days:
         description: "stale-label-days: Specify how many days the issue has to have had the 'stale-old' label to be closed. Must be >= 14 days or will default to -1 days (never)."
+        type: number
         default: -1
 jobs:
   stale:
@@ -27,4 +31,4 @@ jobs:
         stale-issue-message: "This issue is now marked as '${{ env.stale-label }}' due to there being no activity on it for the past ${{ env.stale-days }} days. Unless the '${{ env.stale-label }}' label is removed or the issue is commented on, this will be remain open for at least 14 days and then it may be closed. If you would like to make this issue exempt from getting stale, please add the '${{ env.stale-exempt-label }}' label."
         days-before-close: ${{ env.close-days }}
         close-issue-message: "This issue is now closed due to there being no activity on it for the past ${{ env.close-days }} days since being marked as '${{ env.stale-label }}'."
-        operations-per-run: 200
+        operations-per-run: 500

--- a/.github/workflows/close-stale-issues.yml
+++ b/.github/workflows/close-stale-issues.yml
@@ -1,7 +1,7 @@
 name: Close Stale Issues
 on:
   schedule:
-  - cron: "0 0 * * *"
+  - cron: "0 7 * * *"
   workflow_dispatch:
 jobs:
   stale:

--- a/.github/workflows/close-stale-issues.yml
+++ b/.github/workflows/close-stale-issues.yml
@@ -24,5 +24,5 @@ jobs:
         stale-issue-message: "This issue is now marked as '${{ env.stale-label }}' due to there being no activity on it for the past ${{ env.stale-days }} days and being labelled '${{ env.only-label }}'. Unless the '${{ env.stale-label }}' label is removed or the issue is commented on, this will be closed in ${{ env.close-days }} days. If you would like to make this issue exempt from getting stale, please remove the '${{ env.only-label }}' and '${{ env.stale-label }}' labels or add the '${{ env.stale-exempt-label }}' label"
         days-before-close: ${{ env.close-days }}
         close-issue-message: "This issue is now closed due to there being no activity on it for the past ${{ env.close-days }} days since being marked as '${{ env.stale-label }}'."
-        operations-per-run: 200
+        operations-per-run: 500
 


### PR DESCRIPTION
## The following changes are proposed:

- increased operation limits to 500
- automatically scheduled stale-old bot daily, but an hour after the stale bot
- stale-old bot can add and remove stale-old labels automatically but can never close issues automatically
- now scheduled at 12am and 1am PDT

## The purpose of this change

Currently if someone comments on an issue with a 'stale-old' label, the label will never be removed unless someone manually removes it or manually runs the stale-old bot. This fix allows the stale-old bot to run daily and remove the label if the issue is updated without fear of automatically closing the issue. I scheduled the stale-old bot one hour after the stale bot to prevent operation limit issues.
