### PR TITLE
Dev/gcampbell/attempt fix3318

### DIFF
--- a/src/preset.ts
+++ b/src/preset.ts
@@ -921,6 +921,8 @@ async function expandConfigurePresetHelper(folder: string, preset: ConfigurePres
     inheritedEnv = EnvironmentUtils.mergePreserveNull([process.env, inheritedEnv]);
 
     let compilerEnv = EnvironmentUtils.createPreserveNull();
+    const expansionOpts: ExpansionOptions = await getExpansionOptions(workspaceFolder, sourceDir, preset);
+    expansionOpts.envOverride = inheritedEnv;
 
     // [Windows Only] If CMAKE_CXX_COMPILER or CMAKE_C_COMPILER is set as cl, clang, clang-cl, clang-cpp and clang++,
     // but they are not on PATH, then set the env automatically.
@@ -931,6 +933,11 @@ async function expandConfigurePresetHelper(folder: string, preset: ConfigurePres
             // The env variables for the supported compilers are the same.
             const compilerName: string | undefined = util.isSupportedCompiler(cxxCompiler) || util.isSupportedCompiler(cCompiler);
             if (compilerName) {
+                for (const key in preset.environment) {
+                    if (preset.environment[key]) {
+                        preset.environment[key] = await expandString(preset.environment[key]!, expansionOpts);
+                    }
+                }
                 const compilerLocation = await execute('where.exe', [compilerName], null, {
                     environment: EnvironmentUtils.create(preset.environment),
                     silent: true,

--- a/src/preset.ts
+++ b/src/preset.ts
@@ -924,6 +924,8 @@ async function expandConfigurePresetHelper(folder: string, preset: ConfigurePres
     const expansionOpts: ExpansionOptions = await getExpansionOptions(workspaceFolder, sourceDir, preset);
     expansionOpts.envOverride = inheritedEnv;
 
+    preset.environment = EnvironmentUtils.mergePreserveNull([inheritedEnv, preset.environment]);
+
     // [Windows Only] If CMAKE_CXX_COMPILER or CMAKE_C_COMPILER is set as cl, clang, clang-cl, clang-cpp and clang++,
     // but they are not on PATH, then set the env automatically.
     if (process.platform === 'win32') {


### PR DESCRIPTION
## This change addresses item #3318 

This expands penv before `where.exe` is called so that `where.exe` can be found incase it was only found in the expanded penv path.

The original issue was that `where.exe` couldn't be called to find clang since the penv wasn't expanded by that time yet.
## Other Notes/Information
 
This is Garrett's fix. I tested with gcc as well as clang from the original issue to confirm that this works. The code seems clean enough to me because penv should be parsed at that point.
