### PR TITLE
fix select.active.target.tooltip in i18n ru locale

### DIFF
--- a/i18n/rus/src/cmakeProject.i18n.json
+++ b/i18n/rus/src/cmakeProject.i18n.json
@@ -117,7 +117,7 @@
 	"configure.now.button": "Настроить сейчас",
 	"cache.load.failed": "Файл CMakeCache.txt не найден. Сначала настройте проект.",
 	"set.up.before.selecting.target": "Настройте проект CMake перед выбором целевого объекта.",
-	"select.active.target.tooltip": "Выобрать целевой объект сборки по умолчанию",
+	"select.active.target.tooltip": "Выбрать целевой объект сборки по умолчанию",
 	"enter.target.name": "Введите имя целевого объекта.",
 	"target.to.build.description": "Целевой объект для сборки",
 	"build.failed": "Сбой сборки.",


### PR DESCRIPTION
### This changes visible behavior

The following changes are proposed:

Fixed a typo in the ru locale of the i18b - the misspelled word "Выобрать" was replaced with "Выбрать".

## The purpose of this change

Fix a typo in a word

## Other Notes/Information

Source: https://ru.wiktionary.org/wiki/выбрать
