### PR TITLE
Enable Quick Debugging in Test Explorer like in Project Outline

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -21,8 +21,8 @@ RUN apt-get update && \
     apt-get autoremove -y && \
     apt-get clean -y && \
     rm -rf /var/lib/apt/lists/*; \
-    curl -L -O https://github.com/Kitware/CMake/releases/download/v3.20.1/cmake-3.20.1-linux-x86_64.tar.gz && \
-    tar -xf cmake-3.20.1-linux-x86_64.tar.gz && \
-    rm cmake-3.20.1-linux-x86_64.tar.gz;
+    curl -L -O https://github.com/Kitware/CMake/releases/download/v3.27.8/cmake-3.27.8-linux-x86_64.tar.gz && \
+    tar -xf cmake-3.27.8-linux-x86_64.tar.gz && \
+    rm cmake-3.27.8-linux-x86_64.tar.gz;
 
-ENV PATH "$PATH:/:/cmake-3.20.1-linux-x86_64/bin"
+ENV PATH "$PATH:/:/cmake-3.27.8-linux-x86_64/bin"

--- a/src/cmakeProject.ts
+++ b/src/cmakeProject.ts
@@ -2249,7 +2249,7 @@ export class CMakeProject {
         }
 
         if (name) {
-            const found = (await this.executableTargets).find(e => e.name === name);
+            const found = (await this.executableTargets).find(e => path.parse(e.path).name === name);
             if (!found) {
                 return null;
             }

--- a/src/ctest.ts
+++ b/src/ctest.ts
@@ -758,54 +758,22 @@ export class CTestDriver implements vscode.Disposable {
 
     private async debugCTestImpl(workspaceFolder: vscode.WorkspaceFolder, testName: string, cancellation: vscode.CancellationToken): Promise<void> {
         const magicValue = sessionNum++;
-        const launchConfig = vscode.workspace.getConfiguration(
-            'launch',
-            workspaceFolder.uri
-        );
-        const workspaceLaunchConfig = vscode.workspace.workspaceFile ? vscode.workspace.getConfiguration(
-            'launch',
-            vscode.workspace.workspaceFile
-        ) : undefined;
-        const configs = launchConfig.get<vscode.DebugConfiguration[]>('configurations') ?? [];
-        const workspaceConfigs = workspaceLaunchConfig?.get<vscode.DebugConfiguration[]>('configurations') ?? [];
-        if (configs.length === 0 && workspaceConfigs.length === 0) {
+
+        const testProgram = this.testProgram(testName);
+        const basename = path.parse(testProgram).name;
+        const debugConfig = await this.projectController?.getActiveCMakeProject()?.getDebugConfiguration(basename);
+
+        if (debugConfig === null || debugConfig === undefined) {
             log.error(localize('no.launch.config', 'No launch configurations found.'));
             return;
         }
 
-        interface ConfigItem extends vscode.QuickPickItem {
-            label: string;
-            config: vscode.DebugConfiguration;
-            detail: string;
-            // Undefined for workspace launch config
-            folder?: vscode.WorkspaceFolder;
-        }
-        let allConfigItems: ConfigItem[] = configs.map(config => ({ label: config.name, config, folder: workspaceFolder, detail: workspaceFolder.uri.fsPath }));
-        allConfigItems = allConfigItems.concat(workspaceConfigs.map(config => ({ label: config.name, config, detail: vscode.workspace.workspaceFile!.fsPath })));
-        let chosenConfig: ConfigItem | undefined;
-        if (allConfigItems.length === 1) {
-            chosenConfig = allConfigItems[0];
-        } else {
-            // TODO: we can remember the last choice once the CMake side panel work is done
-            const chosen = await vscode.window.showQuickPick(allConfigItems, { placeHolder: localize('choose.launch.config', 'Choose a launch configuration to debug the test with.') });
-            if (chosen) {
-                chosenConfig = chosen;
-            } else {
-                return;
-            }
-        }
-
-        // Commands can't be used to replace array (i.e., args); and both test program and test args requires folder and
-        // test name as parameters, which means one lauch config for each test. So replacing them here is a better way.
-        chosenConfig.config = this.replaceAllInObject<vscode.DebugConfiguration>(chosenConfig.config, '${cmake.testProgram}', this.testProgram(testName));
-        chosenConfig.config = this.replaceAllInObject<vscode.DebugConfiguration>(chosenConfig.config, '${cmake.testWorkingDirectory}', this.testWorkingDirectory(testName));
-
-        // Replace cmake.testArgs wrapped in quotes, like `"${command:cmake.testArgs}"`, without any spaces in between,
-        // since we need to repalce the quotes as well.
-        chosenConfig.config = this.replaceArrayItems(chosenConfig.config, '${cmake.testArgs}', this.testArgs(testName)) as vscode.DebugConfiguration;
+        debugConfig.cwd = this.testWorkingDirectory(testName)!;
+        debugConfig.args = this.testArgs(testName)!;
 
         // Identify the session we started
-        chosenConfig.config[magicKey] = magicValue;
+        debugConfig[magicKey] = magicValue;
+
         let onDidStartDebugSession: vscode.Disposable | undefined;
         let onDidTerminateDebugSession: vscode.Disposable | undefined;
         let sessionId: string | undefined;
@@ -828,7 +796,7 @@ export class CTestDriver implements vscode.Disposable {
             log.info('debugSessionTerminated');
         });
 
-        const debugStarted = await vscode.debug.startDebugging(chosenConfig.folder, chosenConfig.config!);
+        const debugStarted = await vscode.debug.startDebugging(workspaceFolder, debugConfig!);
         if (debugStarted) {
             const session = await started;
             if (session) {
@@ -877,57 +845,6 @@ export class CTestDriver implements vscode.Disposable {
             }
         }
         return [];
-    }
-
-    private replaceAllInObject<T>(obj: any, str: string, replace: string): T {
-        const regex = new RegExp(util.escapeStringForRegex(str), 'g');
-        if (util.isString(obj)) {
-            obj = obj.replace(regex, replace);
-        } else if (util.isArray(obj)) {
-            for (let i = 0; i < obj.length; i++) {
-                obj[i] = this.replaceAllInObject(obj[i], str, replace);
-            }
-        } else if (typeof obj === 'object') {
-            for (const key of Object.keys(obj)) {
-                obj[key] = this.replaceAllInObject(obj[key], str, replace);
-            }
-        }
-        return obj;
-    }
-
-    private replaceArrayItems(obj: any, str: string, replace: string[]) {
-        if (util.isArray(obj) && obj.length !== 0) {
-            const result: any[] = [];
-            for (let i = 0; i < obj.length; i++) {
-                if (util.isArray(obj[i]) || typeof obj[i] === 'object') {
-                    result.push(this.replaceArrayItems(obj[i], str, replace));
-                } else if (util.isString(obj[i])) {
-                    const replacedItem = this.replaceArrayItemsHelper(obj[i] as string, str, replace);
-                    if (util.isArray(replacedItem)) {
-                        result.push(...replacedItem);
-                    } else {
-                        result.push(replacedItem);
-                    }
-                } else {
-                    result.push(obj[i]);
-                }
-            }
-            return result;
-        }
-        if (typeof obj === 'object') {
-            for (const key of Object.keys(obj)) {
-                obj[key] = this.replaceArrayItems(obj[key], str, replace);
-            }
-            return obj;
-        }
-        return obj;
-    }
-
-    private replaceArrayItemsHelper(orig: string, str: string, replace: string[]): string | string[] {
-        if (orig === str) {
-            return replace;
-        }
-        return orig;
     }
 
     private async debugTestHandler(request: vscode.TestRunRequest, cancellation: vscode.CancellationToken) {


### PR DESCRIPTION
## This change addresses items #3345, #3280 and #3153



The following changes are proposed:

When the user debugs a test via `TestExplorer/some-test/Debug-Icon` now the method to create a debug configuration behind the scenes is used as when the user right-clicks an executable and used "Debug" in the `PROJECT OUTLINE` of cmake.

## The purpose of this change

Harmonize Quick Debugging of executables and tests.

Simplify debugging of tests.

## Changes in current behavior

This removes behavior introduced by PR #3064. But I think this is fine, see https://github.com/microsoft/vscode-cmake-tools/issues/3345#issuecomment-1745682834 .

This may necessary to adapt the documentation at https://github.com/microsoft/vscode-cmake-tools/blob/main/docs/debug-launch.md#debugging-tests I'd add a suggestion if you guys like.

Please have a look there as well. Thx.

Remark: I used https://github.com/basejumpa/vscode-cmake-tools-testdata as testdata while coding.