### PR TITLE
fix parent environment inherit

### DIFF
--- a/src/preset.ts
+++ b/src/preset.ts
@@ -1031,7 +1031,7 @@ async function expandConfigurePresetHelper(folder: string, preset: ConfigurePres
             const parent = await expandConfigurePresetImpl(folder, parentName, workspaceFolder, sourceDir, allowUserPreset);
             if (parent) {
                 // Inherit environment
-                inheritedEnv = EnvironmentUtils.mergePreserveNull([parent.environment, inheritedEnv]);
+                inheritedEnv = EnvironmentUtils.mergePreserveNull([inheritedEnv, parent.environment]);
                 // Inherit cache vars
                 for (const name in parent.cacheVariables) {
                     if (preset.cacheVariables[name] === undefined) {


### PR DESCRIPTION
Fixes #3473. 

We were merging `inheritedEnv`, which is initialized in the method as an empty environment, _on top_ of the `parent.environment`, rather than the other way around. This fixes this issue. 
