### PR TITLE
Fix preset inheritance for condition field.

### DIFF
--- a/src/preset.ts
+++ b/src/preset.ts
@@ -180,11 +180,12 @@ function evaluateInheritedPresetConditions(preset: Preset, allPresets: Preset[],
 }
 
 export function evaluatePresetCondition(preset: Preset, allPresets: Preset[], references?: Set<string>): boolean | undefined {
-    if (!evaluateInheritedPresetConditions(preset, allPresets, references || new Set<string>())) {
+    const condition = preset.condition;
+
+    if (condition === undefined && !evaluateInheritedPresetConditions(preset, allPresets, references || new Set<string>())) {
         return false;
     }
 
-    const condition = preset.condition;
     if (condition === undefined || condition === null) {
         return true;
     } else if (typeof condition === 'boolean') {


### PR DESCRIPTION
The parent condition shouldn't be considered if a child preset defines its own condition. Basically, a child-defined condition overrides inherited conditions. This is based on feedback and experimentation with the cmake.exe cli.

Fixes #2802, #3340, and keeps integrity of fixing #2185. 
