### PR TITLE
Improve when configure with debugger popup appears and allow disabling.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # What's New?
 
 ## 1.17
+
+Improvements:
+
+- Improve when the "Configure with Debugger" popup appears and allow for "Do Not Show Again". [#3343](https://github.com/microsoft/vscode-cmake-tools/issues/3343)
+
 Bug Fixes:
 
 - Fixed an issue where changing an empty value to a non-empty value using the Cache Editor UI didn't work. [PR #3508](https://github.com/microsoft/vscode-cmake-tools/pull/3508)

--- a/package.json
+++ b/package.json
@@ -2416,6 +2416,12 @@
           "description": "%cmake-tools.configuration.cmake.showOptionsMovedNotification%",
           "scope": "application"
         },
+        "cmake.showConfigureWithDebuggerNotification": {
+            "type": "boolean",
+            "default": true,
+            "description": "%cmake-tools.configuration.cmake.showConfigureWithDebuggerNotification%",
+            "scope": "application"
+        },
         "cmake.options.statusBarVisibility": {
           "type": "string",
           "default": "hidden",

--- a/package.nls.json
+++ b/package.nls.json
@@ -165,6 +165,7 @@
     "cmake-tools.configuration.cmake.touchbar.visibility.default.description": "Show Touch Bar buttons on supported systems.",
     "cmake-tools.configuration.cmake.touchbar.visibility.hidden.description": "Do not show Touch Bar buttons.",
     "cmake-tools.configuration.cmake.showOptionsMovedNotification": "Enables the notification regarding the status bar options moving to the Project Status View to show when the extension starts.",
+    "cmake-tools.configuration.cmake.showConfigureWithDebuggerNotification": "Enables the pop-up that asks the user if, upon a failed configure, they want to configure with the CMake Debugger.",
     "cmake-tools.configuration.cmake.options.advanced.statusBarVisibility.visible.description": "Show the status bar option at full size.",
     "cmake-tools.configuration.cmake.options.advanced.statusBarVisibility.icon.description": "Show the status bar option's icon only.",
     "cmake-tools.configuration.cmake.options.advanced.statusBarVisibility.compact.markdownDescription": "Show the status bar option with the text truncated to the length specified in `#cmake.status.advanced.statusBarLength#` (default is 20).",

--- a/src/api.ts
+++ b/src/api.ts
@@ -53,7 +53,7 @@ export class CMakeToolsApiImpl implements api.CMakeToolsApi {
     }
 }
 
-async function withErrorCheck(name: string, action: () => Thenable<number>): Promise<void> {
+async function withErrorCheck(name: string, action: () => Promise<number>): Promise<void> {
     const code = await action();
     if (code !== 0) {
         throw new Error(`${name} failed with code ${code}`);
@@ -72,7 +72,7 @@ class CMakeProjectWrapper implements api.Project {
     }
 
     configure(): Promise<void> {
-        return withErrorCheck('configure', () => this.project.configure());
+        return withErrorCheck('configure', async () => (await this.project.configure()).result);
     }
 
     build(targets?: string[]): Promise<void> {
@@ -88,7 +88,7 @@ class CMakeProjectWrapper implements api.Project {
     }
 
     reconfigure(): Promise<void> {
-        return withErrorCheck('reconfigure', () => this.project.cleanConfigure());
+        return withErrorCheck('reconfigure', async () => (await this.project.cleanConfigure()).result);
     }
 
     async getBuildDirectory(): Promise<string | undefined> {

--- a/src/cmakeTaskProvider.ts
+++ b/src/cmakeTaskProvider.ts
@@ -420,8 +420,8 @@ export class CustomBuildTaskTerminal implements vscode.Pseudoterminal, proc.Outp
                 this.writeEmitter.fire(localize('configure.terminated', 'Configure was terminated') + endOfLine);
                 this.closeEmitter.fire(-1);
             } else {
-                this.writeEmitter.fire(localize('configure.finished.with.code', 'Configure finished with return code {0}', result) + endOfLine);
-                this.closeEmitter.fire(result);
+                this.writeEmitter.fire(localize('configure.finished.with.code', 'Configure finished with return code {0}', result.result) + endOfLine);
+                this.closeEmitter.fire(result.result);
             }
         } else {
             log.debug(localize("cmake.driver.not.found", 'CMake driver not found.'));

--- a/src/drivers/cmakeDriver.ts
+++ b/src/drivers/cmakeDriver.ts
@@ -56,6 +56,21 @@ interface CompilerInfo {
     version: string;
 }
 
+export enum ConfigureResultType {
+    NormalOperation,
+    ForcedCancel,
+    ConfigureInProgress,
+    BuildInProgress,
+    NoCache,
+    NoConfigurePreset,
+    Other
+}
+
+export interface ConfigureResult {
+    result: number;
+    resultType: ConfigureResultType;
+}
+
 export type CMakePreconditionProblemSolver = (e: CMakePreconditionProblems, config?: ConfigurationReader) => Promise<void>;
 
 function nullableValueToString(arg: any | null | undefined): string {
@@ -911,14 +926,14 @@ export abstract class CMakeDriver implements vscode.Disposable {
      * Perform a clean configure. Deletes cached files before running the config
      * @param consumer The output consumer
      */
-    public async cleanConfigure(trigger: ConfigureTrigger, extra_args: string[], consumer?: proc.OutputConsumer, debuggerInformation?: DebuggerInformation): Promise<number> {
+    public async cleanConfigure(trigger: ConfigureTrigger, extra_args: string[], consumer?: proc.OutputConsumer, debuggerInformation?: DebuggerInformation): Promise<ConfigureResult> {
         if (this.isConfigInProgress) {
             await this.preconditionHandler(CMakePreconditionProblems.ConfigureIsAlreadyRunning);
-            return -1;
+            return { result: -1, resultType: ConfigureResultType.ForcedCancel };
         }
         if (this.cmakeBuildRunner.isBuildInProgress()) {
             await this.preconditionHandler(CMakePreconditionProblems.BuildIsAlreadyRunning);
-            return -1;
+            return { result: -1, resultType: ConfigureResultType.ConfigureInProgress };
         }
         this.isConfigInProgress = true;
         await this.doPreCleanConfigure();
@@ -1290,21 +1305,21 @@ export abstract class CMakeDriver implements vscode.Disposable {
         return Promise.all(expanded_flags_promises);
     }
 
-    async configure(trigger: ConfigureTrigger, extra_args: string[], consumer?: proc.OutputConsumer, debuggerInformation?: DebuggerInformation, withoutCmakeSettings: boolean = false, showCommandOnly?: boolean, presetOverride?: preset.ConfigurePreset, options?: proc.ExecutionOptions): Promise<number> {
+    async configure(trigger: ConfigureTrigger, extra_args: string[], consumer?: proc.OutputConsumer, debuggerInformation?: DebuggerInformation, withoutCmakeSettings: boolean = false, showCommandOnly?: boolean, presetOverride?: preset.ConfigurePreset, options?: proc.ExecutionOptions): Promise<ConfigureResult> {
         // Check if the configuration is using cache in the first configuration and adjust the logging messages based on that.
         const shouldUseCachedConfiguration: boolean = this.shouldUseCachedConfiguration(trigger);
 
         if (trigger === ConfigureTrigger.configureWithCache && !shouldUseCachedConfiguration) {
             log.debug(localize('no.cached.config', "No cached config could be used for IntelliSense"));
-            return -2;
+            return { result: -2, resultType: ConfigureResultType.NoCache };
         }
         if (this.isConfigInProgress) {
             await this.preconditionHandler(CMakePreconditionProblems.ConfigureIsAlreadyRunning);
-            return -1;
+            return { result: -1, resultType: ConfigureResultType.ConfigureInProgress };
         }
         if (this.cmakeBuildRunner.isBuildInProgress()) {
             await this.preconditionHandler(CMakePreconditionProblems.BuildIsAlreadyRunning);
-            return -1;
+            return { result: -1, resultType: ConfigureResultType.BuildInProgress };
         }
         this.isConfigInProgress = true;
         try {
@@ -1321,7 +1336,7 @@ export abstract class CMakeDriver implements vscode.Disposable {
 
             const pre_check_ok = await this._beforeConfigureOrBuild(showCommandOnly);
             if (!pre_check_ok) {
-                return -2;
+                return { result: -2, resultType: ConfigureResultType.Other };
             }
 
             let expanded_flags: string[];
@@ -1331,7 +1346,7 @@ export abstract class CMakeDriver implements vscode.Disposable {
                 const configurePreset: preset.ConfigurePreset | undefined | null = (trigger === ConfigureTrigger.taskProvider) ? presetOverride : this._configurePreset;
                 if (!configurePreset) {
                     log.debug(localize('no.config.Preset', 'No configure preset selected'));
-                    return -3;
+                    return { result: -3, resultType: ConfigureResultType.NoConfigurePreset };
                 }
                 // For now, fields in presets are expanded when the preset is selected
                 expanded_flags = this.generateConfigArgsFromPreset(configurePreset);
@@ -1350,7 +1365,7 @@ export abstract class CMakeDriver implements vscode.Disposable {
             if (shouldUseCachedConfiguration) {
                 retc = await this.doCacheConfigure();
                 this._isConfiguredAtLeastOnce = true;
-                return retc;
+                return { result: retc, resultType: ConfigureResultType.NormalOperation };
             } else {
                 retc = await this.doConfigure(expanded_flags, trigger, consumer, showCommandOnly, defaultPresetName, presetOverride, options, debuggerInformation);
                 this._isConfiguredAtLeastOnce = true;
@@ -1469,10 +1484,10 @@ export abstract class CMakeDriver implements vscode.Disposable {
 
             telemetry.logEvent('configure', telemetryProperties, telemetryMeasures);
 
-            return retc;
+            return { result: retc, resultType: ConfigureResultType.NormalOperation };
         } catch {
             log.info(localize('configure.failed', 'Failed to configure project'));
-            return -1;
+            return { result: -1, resultType: ConfigureResultType.NormalOperation };
         } finally {
             this.isConfigInProgress = false;
         }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1124,7 +1124,7 @@ export class ExtensionManager implements vscode.Disposable {
     configure(folder?: vscode.WorkspaceFolder, showCommandOnly?: boolean, sourceDir?: string) {
         telemetry.logEvent("configure", { all: "false", debug: "false"});
         return this.runCMakeCommand(
-            cmakeProject => cmakeProject.configureInternal(ConfigureTrigger.commandConfigure, [], showCommandOnly ? ConfigureType.ShowCommandOnly : ConfigureType.Normal),
+            async cmakeProject => (await cmakeProject.configureInternal(ConfigureTrigger.commandConfigure, [], showCommandOnly ? ConfigureType.ShowCommandOnly : ConfigureType.Normal)).result,
             folder, undefined, true, sourceDir);
     }
 
@@ -1135,7 +1135,7 @@ export class ExtensionManager implements vscode.Disposable {
     configureWithDebuggerInternal(debuggerInformation: DebuggerInformation, folder?: vscode.WorkspaceFolder, showCommandOnly?: boolean, sourceDir?: string, trigger?: ConfigureTrigger) {
         telemetry.logEvent("configure", { all: "false", debug: "true"});
         return this.runCMakeCommand(
-            cmakeProject => cmakeProject.configureInternal(trigger ?? ConfigureTrigger.commandConfigureWithDebugger, [], showCommandOnly ? ConfigureType.ShowCommandOnly : ConfigureType.NormalWithDebugger, debuggerInformation),
+            async cmakeProject => (await cmakeProject.configureInternal(trigger ?? ConfigureTrigger.commandConfigureWithDebugger, [], showCommandOnly ? ConfigureType.ShowCommandOnly : ConfigureType.NormalWithDebugger, debuggerInformation)).result,
             folder, undefined, true, sourceDir);
     }
 
@@ -1145,7 +1145,7 @@ export class ExtensionManager implements vscode.Disposable {
 
     configureAll() {
         telemetry.logEvent("configure", { all: "true", debug: "false"});
-        return this.runCMakeCommandForAll(cmakeProject => cmakeProject.configureInternal(ConfigureTrigger.commandCleanConfigureAll, [], ConfigureType.Normal), undefined, true);
+        return this.runCMakeCommandForAll(async cmakeProject => ((await cmakeProject.configureInternal(ConfigureTrigger.commandCleanConfigureAll, [], ConfigureType.Normal)).result), undefined, true);
     }
 
     configureAllWithDebugger(trigger?: ConfigureTrigger) {
@@ -1155,7 +1155,7 @@ export class ExtensionManager implements vscode.Disposable {
     configureAllWithDebuggerInternal(debuggerInformation: DebuggerInformation, trigger?: ConfigureTrigger) {
         // I need to add ConfigureTriggers that account for coming from the project status view or project outline.
         telemetry.logEvent("configure", { all: "true", debug: "true"});
-        return this.runCMakeCommandForAll(cmakeProject => cmakeProject.configureInternal(trigger ?? ConfigureTrigger.commandConfigureAllWithDebugger, [], ConfigureType.NormalWithDebugger, debuggerInformation), undefined, true);
+        return this.runCMakeCommandForAll(async cmakeProject => (await cmakeProject.configureInternal(trigger ?? ConfigureTrigger.commandConfigureAllWithDebugger, [], ConfigureType.NormalWithDebugger, debuggerInformation)).result, undefined, true);
     }
 
     editCacheUI() {

--- a/test/extension-tests/single-root-UI/test/configure-and-build-kits.test.ts
+++ b/test/extension-tests/single-root-UI/test/configure-and-build-kits.test.ts
@@ -58,7 +58,7 @@ suite('Build using Kits and Variants', () => {
 
     test('Configure', async () => {
         expect(await vscode.commands.executeCommand('cmake.useCMakePresets', vscode.workspace.workspaceFolders![0])).to.be.eq(false);
-        expect(await vscode.commands.executeCommand('cmake.configure')).to.be.eql({ result: 0, resultType: ConfigureResultType.NormalOperation });
+        expect(await vscode.commands.executeCommand('cmake.configure')).to.be.deep.equal({ result: 0, resultType: ConfigureResultType.NormalOperation });
 
         expect(testEnv.projectFolder.buildDirectory.isCMakeCachePresent).to.eql(true, 'no expected cache present');
     }).timeout(100000);

--- a/test/extension-tests/single-root-UI/test/configure-and-build-kits.test.ts
+++ b/test/extension-tests/single-root-UI/test/configure-and-build-kits.test.ts
@@ -1,3 +1,4 @@
+import { ConfigureResultType } from '@cmt/drivers/cmakeDriver';
 import { fs } from '@cmt/pr';
 import { TestProgramResult } from '@test/helpers/testprogram/test-program-result';
 import {
@@ -57,7 +58,7 @@ suite('Build using Kits and Variants', () => {
 
     test('Configure', async () => {
         expect(await vscode.commands.executeCommand('cmake.useCMakePresets', vscode.workspace.workspaceFolders![0])).to.be.eq(false);
-        expect(await vscode.commands.executeCommand('cmake.configure')).to.be.eq(0);
+        expect(await vscode.commands.executeCommand('cmake.configure')).to.be.eql({ result: 0, resultType: ConfigureResultType.NormalOperation });
 
         expect(testEnv.projectFolder.buildDirectory.isCMakeCachePresent).to.eql(true, 'no expected cache present');
     }).timeout(100000);

--- a/test/extension-tests/single-root-UI/test/configure-and-build-kits.test.ts
+++ b/test/extension-tests/single-root-UI/test/configure-and-build-kits.test.ts
@@ -58,7 +58,7 @@ suite('Build using Kits and Variants', () => {
 
     test('Configure', async () => {
         expect(await vscode.commands.executeCommand('cmake.useCMakePresets', vscode.workspace.workspaceFolders![0])).to.be.eq(false);
-        expect(await vscode.commands.executeCommand('cmake.configure')).to.be.deep.equal({ result: 0, resultType: ConfigureResultType.NormalOperation });
+        expect(await vscode.commands.executeCommand('cmake.configure')).to.be.eq({result: 0, resultType: ConfigureResultType.NormalOperation});
 
         expect(testEnv.projectFolder.buildDirectory.isCMakeCachePresent).to.eql(true, 'no expected cache present');
     }).timeout(100000);

--- a/test/extension-tests/single-root-UI/test/configure-and-build-kits.test.ts
+++ b/test/extension-tests/single-root-UI/test/configure-and-build-kits.test.ts
@@ -1,4 +1,3 @@
-import { ConfigureResultType } from '@cmt/drivers/cmakeDriver';
 import { fs } from '@cmt/pr';
 import { TestProgramResult } from '@test/helpers/testprogram/test-program-result';
 import {
@@ -58,7 +57,7 @@ suite('Build using Kits and Variants', () => {
 
     test('Configure', async () => {
         expect(await vscode.commands.executeCommand('cmake.useCMakePresets', vscode.workspace.workspaceFolders![0])).to.be.eq(false);
-        expect(await vscode.commands.executeCommand('cmake.configure')).to.be.eq({result: 0, resultType: ConfigureResultType.NormalOperation});
+        expect(await vscode.commands.executeCommand('cmake.configure')).to.be.eq(0);
 
         expect(testEnv.projectFolder.buildDirectory.isCMakeCachePresent).to.eql(true, 'no expected cache present');
     }).timeout(100000);

--- a/test/extension-tests/successful-build/test/configure-and-build.test.ts
+++ b/test/extension-tests/successful-build/test/configure-and-build.test.ts
@@ -61,7 +61,7 @@ suite('Build', () => {
 
     test('Configure with cache-initializer', async () => {
         testEnv.config.updatePartial({ cacheInit: 'TestCacheInit.cmake' });
-        expect(await cmakeProject.configureInternal(ConfigureTrigger.runTests)).to.be.eq(0);
+        expect((await cmakeProject.configureInternal(ConfigureTrigger.runTests)).result).to.be.eq(0);
         await cmakeProject.setDefaultTarget('runTestTarget');
         expect(await cmakeProject.build()).to.be.eq(0);
         const resultFile = new TestProgramResult(testEnv.projectFolder.buildDirectory.location, 'output_target.txt');
@@ -198,12 +198,12 @@ suite('Build', () => {
             newSettings.generator = 'Ninja';  // VS generators don't create compile_commands.json
             testEnv.config.updatePartial(newSettings);
         }
-        let retc = await cmakeProject.cleanConfigure(ConfigureTrigger.runTests);
+        let retc = (await cmakeProject.cleanConfigure(ConfigureTrigger.runTests)).result;
         expect(retc).to.eq(0);
         expect(await fs.exists(compdb_cp_path), 'File still shouldn\'t be there').to.be.false;
         newSettings.copyCompileCommands = compdb_cp_path;
         testEnv.config.updatePartial(newSettings);
-        retc = await cmakeProject.configureInternal(ConfigureTrigger.runTests);
+        retc = (await cmakeProject.configureInternal(ConfigureTrigger.runTests)).result;
         expect(retc).to.eq(0);
         expect(await fs.exists(compdb_cp_path), 'File wasn\'t copied').to.be.true;
     }).timeout(100000);

--- a/test/extension-tests/successful-build/test/environment.test.ts
+++ b/test/extension-tests/successful-build/test/environment.test.ts
@@ -37,7 +37,7 @@ suite('Environment', () => {
         });
 
         // Configure
-        expect(await cmakeProject.configure()).to.be.eq(0, '[configureEnvironment] configure failed');
+        expect((await cmakeProject.configure()).result).to.be.eq(0, '[configureEnvironment] configure failed');
         expect(testEnv.projectFolder.buildDirectory.isCMakeCachePresent).to.eql(true, 'expected cache not present');
         const cache = await CMakeCache.fromPath(await cmakeProject.cachePath);
 
@@ -59,7 +59,7 @@ suite('Environment', () => {
         testEnv.config.updatePartial({ buildEnvironment: { _BUILD_ENV: '${workspaceRootFolderName}' } });
 
         // Configure
-        expect(await cmakeProject.configure()).to.be.eq(0, '[buildEnvironment] configure failed');
+        expect((await cmakeProject.configure()).result).to.be.eq(0, '[buildEnvironment] configure failed');
         expect(testEnv.projectFolder.buildDirectory.isCMakeCachePresent).to.eql(true, 'expected cache not present');
         const cache = await CMakeCache.fromPath(await cmakeProject.cachePath);
 
@@ -81,7 +81,7 @@ suite('Environment', () => {
         testEnv.config.updatePartial({ environment: { _ENV: '${workspaceRootFolderName}' } });
 
         // Configure
-        expect(await cmakeProject.configure()).to.be.eq(0, '[environment] configure failed');
+        expect((await cmakeProject.configure()).result).to.be.eq(0, '[environment] configure failed');
         expect(testEnv.projectFolder.buildDirectory.isCMakeCachePresent).to.eql(true, 'expected cache not present');
         const cache = await CMakeCache.fromPath(await cmakeProject.cachePath);
 

--- a/test/extension-tests/successful-build/test/toolchain.test.ts
+++ b/test/extension-tests/successful-build/test/toolchain.test.ts
@@ -47,7 +47,7 @@ suite('Toolchain Substitution', () => {
 
     test('Check substitution within toolchain kits', async () => {
         // Configure
-        expect(await cmakeProject.configureInternal(ConfigureTrigger.runTests)).to.be.eq(0, '[toolchain] configure failed');
+        expect((await cmakeProject.configureInternal(ConfigureTrigger.runTests)).result).to.be.eq(0, '[toolchain] configure failed');
         expect(testEnv.projectFolder.buildDirectory.isCMakeCachePresent).to.eql(true, 'expected cache not present');
         const cache = await CMakeCache.fromPath(await cmakeProject.cachePath);
 

--- a/test/extension-tests/successful-build/test/variable-substitution.test.ts
+++ b/test/extension-tests/successful-build/test/variable-substitution.test.ts
@@ -165,7 +165,7 @@ suite('Variable Substitution', () => {
         testEnv.config.updatePartial({ configureSettings: configSettings });
 
         // Configure and retrieve generated cache
-        expect(await cmakeProject.configureInternal(ConfigureTrigger.runTests)).to.be.eq(0, '[variant] configure failed');
+        expect((await cmakeProject.configureInternal(ConfigureTrigger.runTests)).result).to.be.eq(0, '[variant] configure failed');
         expect(testEnv.projectFolder.buildDirectory.isCMakeCachePresent).to.eql(true, '[variant] cache not found');
         const cache = await CMakeCache.fromPath(await cmakeProject.cachePath);
 

--- a/test/extension-tests/successful-build/test/variant-envs.test.ts
+++ b/test/extension-tests/successful-build/test/variant-envs.test.ts
@@ -72,7 +72,7 @@ suite('Environment Variables in Variants', () => {
 
         try {
             // Configure
-            expect(await cmakeProject.configure()).to.be.eq(0, '[variantEnv] configure failed');
+            expect((await cmakeProject.configure()).result).to.be.eq(0, '[variantEnv] configure failed');
             expect(testEnv.projectFolder.buildDirectory.isCMakeCachePresent).to.eql(true, 'expected cache not present');
             const cache = await CMakeCache.fromPath(await cmakeProject.cachePath);
 

--- a/test/smoke/badProject/badProject.test.ts
+++ b/test/smoke/badProject/badProject.test.ts
@@ -10,7 +10,7 @@ suite('Smoke test: bad project', () => {
                 kit: await smokeTestDefaultKit(),
                 async run(cmakeProject) {
                     expect((await cmakeProject.getCMakeExecutable()).isFileApiModeSupported).to.be.equal(true);
-                    const retc = await cmakeProject.configureInternal(ConfigureTrigger.runTests);
+                    const retc = (await cmakeProject.configureInternal(ConfigureTrigger.runTests)).result;
                     // Test will fail because of a bad command:
                     expect(retc, 'Configure should have failed').to.eq(1);
                 }

--- a/test/smoke/goodProject/goodProject.test.ts
+++ b/test/smoke/goodProject/goodProject.test.ts
@@ -18,7 +18,7 @@ suite('Smoke test: good project', () => {
                 }
             });
             suite.smokeTest('Successful configure', async () => {
-                expect(await cmakeProject.configure()).to.eq(0);
+                expect((await cmakeProject.configure()).result).to.eq(0);
             });
         });
     });

--- a/test/smoke/noCtest/noCtest.test.ts
+++ b/test/smoke/noCtest/noCtest.test.ts
@@ -19,7 +19,7 @@ suite('Smoke test: No ctest in bin dir', () => {
                     cmakeProject.workspaceContext.config.updatePartial({
                         cmakePath: path.join(ctx.projectDir.uri.fsPath, 'bin', cmake_filename)
                     });
-                    expect(await cmakeProject.configureInternal(ConfigureTrigger.runTests)).to.eq(0);
+                    expect((await cmakeProject.configureInternal(ConfigureTrigger.runTests)).result).to.eq(0);
                     expect(await cmakeProject.build()).to.eq(0);
                     expect(await cmakeProject.ctest()).to.eq(0);
                 }

--- a/test/unit-tests/driver/driver-codemodel-tests.ts
+++ b/test/unit-tests/driver/driver-codemodel-tests.ts
@@ -87,7 +87,7 @@ export function makeCodeModelDriverTestsuite(driverName: string, driver_generato
                     code_model = cm;
                 });
             }
-            expect(await driver.configure(ConfigureTrigger.runTests, args)).to.be.eq(0);
+            expect((await driver.configure(ConfigureTrigger.runTests, args)).result).to.be.eq(0);
             return code_model;
         }
 

--- a/test/unit-tests/driver/driver-test.ts
+++ b/test/unit-tests/driver/driver-test.ts
@@ -13,7 +13,7 @@ import { CMakeServerDriver } from '@cmt/drivers/cmakeServerDriver';
 chai.use(chaiString);
 
 import { Kit, CMakeGenerator } from '@cmt/kit';
-import { CMakePreconditionProblems, CMakeDriver, CMakePreconditionProblemSolver, NoGeneratorError } from '@cmt/drivers/cmakeDriver';
+import { CMakePreconditionProblems, CMakeDriver, CMakePreconditionProblemSolver, NoGeneratorError, ConfigureResultType } from '@cmt/drivers/cmakeDriver';
 
 const here = __dirname;
 function getTestRootFilePath(filename: string): string {
@@ -275,8 +275,7 @@ export function makeDriverTestsuite(driverName: string, driver_generator: (cmake
             const configure = driver.configure(ConfigureTrigger.runTests, []);
             const build = driver.build([driver.allTargetName]);
 
-            await configure;
-            //expect(await configure).to.be.equal(0);
+            expect(await configure).to.be.deep.equal({ result: 0, resultType: ConfigureResultType.NormalOperation });
             expect(await build).to.be.equal(-1);
             expect(called).to.be.true;
         }).timeout(90000);
@@ -317,8 +316,7 @@ export function makeDriverTestsuite(driverName: string, driver_generator: (cmake
             const configure = driver.cleanConfigure(ConfigureTrigger.runTests, []);
             const build = driver.build([driver.allTargetName]);
 
-            await configure;
-            //expect(await configure).to.be.equal(0);
+            expect(await configure).to.be.deep.equal({ result: 0, resultType: ConfigureResultType.NormalOperation });
             expect(await build).to.be.equal(-1);
             expect(called).to.be.true;
         }).timeout(90000);

--- a/test/unit-tests/driver/driver-test.ts
+++ b/test/unit-tests/driver/driver-test.ts
@@ -272,11 +272,11 @@ export function makeDriverTestsuite(driverName: string, driver_generator: (cmake
             driver
                 = await driver_generator(executable, config, ninjaKitDefault, defaultWorkspaceFolder, checkPreconditionHelper, []);
             expect((await driver.configure(ConfigureTrigger.runTests, [])).result).to.be.equal(0);
-            const configure = await driver.configure(ConfigureTrigger.runTests, []);
-            const build = await driver.build([driver.allTargetName]);
+            const configure = driver.configure(ConfigureTrigger.runTests, []);
+            const build = driver.build([driver.allTargetName]);
 
-            expect(configure.result).to.be.equal(0);
-            expect(build).to.be.equal(-1);
+            expect(await configure).to.be.equal(0);
+            expect(await build).to.be.equal(-1);
             expect(called).to.be.true;
         }).timeout(90000);
 
@@ -313,11 +313,11 @@ export function makeDriverTestsuite(driverName: string, driver_generator: (cmake
             };
             driver
                 = await driver_generator(executable, config, ninjaKitDefault, defaultWorkspaceFolder, checkPreconditionHelper, []);
-            const configure = await driver.cleanConfigure(ConfigureTrigger.runTests, []);
-            const build = await driver.build([driver.allTargetName]);
+            const configure = driver.cleanConfigure(ConfigureTrigger.runTests, []);
+            const build = driver.build([driver.allTargetName]);
 
-            expect(configure.result).to.be.equal(0);
-            expect(build).to.be.equal(-1);
+            expect(await configure).to.be.equal(0);
+            expect(await build).to.be.equal(-1);
             expect(called).to.be.true;
         }).timeout(90000);
 

--- a/test/unit-tests/driver/driver-test.ts
+++ b/test/unit-tests/driver/driver-test.ts
@@ -13,7 +13,7 @@ import { CMakeServerDriver } from '@cmt/drivers/cmakeServerDriver';
 chai.use(chaiString);
 
 import { Kit, CMakeGenerator } from '@cmt/kit';
-import { CMakePreconditionProblems, CMakeDriver, CMakePreconditionProblemSolver, NoGeneratorError } from '@cmt/drivers/cmakeDriver';
+import { CMakePreconditionProblems, CMakeDriver, CMakePreconditionProblemSolver, NoGeneratorError, ConfigureResultType } from '@cmt/drivers/cmakeDriver';
 
 const here = __dirname;
 function getTestRootFilePath(filename: string): string {
@@ -272,10 +272,10 @@ export function makeDriverTestsuite(driverName: string, driver_generator: (cmake
             driver
                 = await driver_generator(executable, config, ninjaKitDefault, defaultWorkspaceFolder, checkPreconditionHelper, []);
             expect((await driver.configure(ConfigureTrigger.runTests, [])).result).to.be.equal(0);
-            const configure = (await driver.configure(ConfigureTrigger.runTests, [])).result;
+            const configure = driver.configure(ConfigureTrigger.runTests, []);
             const build = driver.build([driver.allTargetName]);
 
-            expect(configure).to.be.equal(0);
+            expect(await configure).to.be.equal({ result: 0, resultType: ConfigureResultType.NormalOperation});
             expect(await build).to.be.equal(-1);
             expect(called).to.be.true;
         }).timeout(90000);
@@ -313,10 +313,10 @@ export function makeDriverTestsuite(driverName: string, driver_generator: (cmake
             };
             driver
                 = await driver_generator(executable, config, ninjaKitDefault, defaultWorkspaceFolder, checkPreconditionHelper, []);
-            const configure = (await driver.cleanConfigure(ConfigureTrigger.runTests, [])).result;
+            const configure = driver.cleanConfigure(ConfigureTrigger.runTests, []);
             const build = driver.build([driver.allTargetName]);
 
-            expect(configure).to.be.equal(0);
+            expect(await configure).to.be.equal({ result: 0, resultType: ConfigureResultType.NormalOperation });
             expect(await build).to.be.equal(-1);
             expect(called).to.be.true;
         }).timeout(90000);

--- a/test/unit-tests/driver/driver-test.ts
+++ b/test/unit-tests/driver/driver-test.ts
@@ -13,7 +13,7 @@ import { CMakeServerDriver } from '@cmt/drivers/cmakeServerDriver';
 chai.use(chaiString);
 
 import { Kit, CMakeGenerator } from '@cmt/kit';
-import { CMakePreconditionProblems, CMakeDriver, CMakePreconditionProblemSolver, NoGeneratorError, ConfigureResultType } from '@cmt/drivers/cmakeDriver';
+import { CMakePreconditionProblems, CMakeDriver, CMakePreconditionProblemSolver, NoGeneratorError } from '@cmt/drivers/cmakeDriver';
 
 const here = __dirname;
 function getTestRootFilePath(filename: string): string {

--- a/test/unit-tests/driver/driver-test.ts
+++ b/test/unit-tests/driver/driver-test.ts
@@ -272,11 +272,11 @@ export function makeDriverTestsuite(driverName: string, driver_generator: (cmake
             driver
                 = await driver_generator(executable, config, ninjaKitDefault, defaultWorkspaceFolder, checkPreconditionHelper, []);
             expect((await driver.configure(ConfigureTrigger.runTests, [])).result).to.be.equal(0);
-            const configure = driver.configure(ConfigureTrigger.runTests, []);
-            const build = driver.build([driver.allTargetName]);
+            const configure = await driver.configure(ConfigureTrigger.runTests, []);
+            const build = await driver.build([driver.allTargetName]);
 
-            expect(await configure).to.be.equal({ result: 0, resultType: ConfigureResultType.NormalOperation});
-            expect(await build).to.be.equal(-1);
+            expect(configure.result).to.be.equal(0);
+            expect(build).to.be.equal(-1);
             expect(called).to.be.true;
         }).timeout(90000);
 
@@ -313,11 +313,11 @@ export function makeDriverTestsuite(driverName: string, driver_generator: (cmake
             };
             driver
                 = await driver_generator(executable, config, ninjaKitDefault, defaultWorkspaceFolder, checkPreconditionHelper, []);
-            const configure = driver.cleanConfigure(ConfigureTrigger.runTests, []);
-            const build = driver.build([driver.allTargetName]);
+            const configure = await driver.cleanConfigure(ConfigureTrigger.runTests, []);
+            const build = await driver.build([driver.allTargetName]);
 
-            expect(await configure).to.be.equal({ result: 0, resultType: ConfigureResultType.NormalOperation });
-            expect(await build).to.be.equal(-1);
+            expect(configure.result).to.be.equal(0);
+            expect(build).to.be.equal(-1);
             expect(called).to.be.true;
         }).timeout(90000);
 

--- a/test/unit-tests/driver/driver-test.ts
+++ b/test/unit-tests/driver/driver-test.ts
@@ -275,7 +275,8 @@ export function makeDriverTestsuite(driverName: string, driver_generator: (cmake
             const configure = driver.configure(ConfigureTrigger.runTests, []);
             const build = driver.build([driver.allTargetName]);
 
-            expect(await configure).to.be.equal(0);
+            await configure;
+            //expect(await configure).to.be.equal(0);
             expect(await build).to.be.equal(-1);
             expect(called).to.be.true;
         }).timeout(90000);
@@ -316,7 +317,8 @@ export function makeDriverTestsuite(driverName: string, driver_generator: (cmake
             const configure = driver.cleanConfigure(ConfigureTrigger.runTests, []);
             const build = driver.build([driver.allTargetName]);
 
-            expect(await configure).to.be.equal(0);
+            await configure;
+            //expect(await configure).to.be.equal(0);
             expect(await build).to.be.equal(-1);
             expect(called).to.be.true;
         }).timeout(90000);

--- a/test/unit-tests/driver/driver-test.ts
+++ b/test/unit-tests/driver/driver-test.ts
@@ -211,11 +211,11 @@ export function makeDriverTestsuite(driverName: string, driver_generator: (cmake
                 called = true;
             };
             driver = await driver_generator(executable, config, ninjaKitDefault, defaultWorkspaceFolder, checkPreconditionHelper, []);
-            const configure1 = (await driver.configure(ConfigureTrigger.runTests, [])).result;
-            const configure2 = (await driver.configure(ConfigureTrigger.runTests, [])).result;
+            const configure1 = driver.configure(ConfigureTrigger.runTests, []);
+            const configure2 = driver.configure(ConfigureTrigger.runTests, []);
 
-            expect(configure1).to.be.equal(0);
-            expect(configure2).to.be.equal(-1);
+            expect((await configure1).result).to.be.equal(0);
+            expect((await configure2).result).to.be.equal(-1);
             expect(called).to.be.true;
         }).timeout(90000);
 
@@ -230,11 +230,11 @@ export function makeDriverTestsuite(driverName: string, driver_generator: (cmake
             };
             driver
                 = await driver_generator(executable, config, ninjaKitDefault, defaultWorkspaceFolder, checkPreconditionHelper, []);
-            const configure1 = (await driver.cleanConfigure(ConfigureTrigger.runTests, [])).result;
-            const configure2 = (await driver.cleanConfigure(ConfigureTrigger.runTests, [])).result;
+            const configure1 = driver.cleanConfigure(ConfigureTrigger.runTests, []);
+            const configure2 = driver.cleanConfigure(ConfigureTrigger.runTests, []);
 
-            expect(configure1).to.be.equal(0);
-            expect(configure2).to.be.equal(-1);
+            expect((await configure1).result).to.be.equal(0);
+            expect((await configure2).result).to.be.equal(-1);
             expect(called).to.be.true;
         }).timeout(90000);
 
@@ -297,7 +297,7 @@ export function makeDriverTestsuite(driverName: string, driver_generator: (cmake
             const configure = driver.configure(ConfigureTrigger.runTests, []);
 
             expect(await build).to.be.equal(0);
-            expect(await configure).to.be.equal(-1);
+            expect((await configure).result).to.be.equal(-1);
             expect(called).to.be.true;
         }).timeout(90000);
 

--- a/test/unit-tests/driver/driver-test.ts
+++ b/test/unit-tests/driver/driver-test.ts
@@ -105,7 +105,7 @@ export function makeDriverTestsuite(driverName: string, driver_generator: (cmake
             const executable = await getCMakeExecutableInformation(cmakePath);
 
             driver = await driver_generator(executable, config, ninjaKitDefault, badCommandWorkspaceFolder, async () => {}, []);
-            expect(await driver.cleanConfigure(ConfigureTrigger.runTests, [])).to.be.eq(1);
+            expect((await driver.cleanConfigure(ConfigureTrigger.runTests, [])).result).to.be.eq(1);
         }).timeout(90000);
 
         test('Build', async () => {
@@ -113,7 +113,7 @@ export function makeDriverTestsuite(driverName: string, driver_generator: (cmake
             const executable = await getCMakeExecutableInformation(cmakePath);
 
             driver = await driver_generator(executable, config, ninjaKitDefault, defaultWorkspaceFolder, async () => {}, []);
-            expect(await driver.cleanConfigure(ConfigureTrigger.runTests, [])).to.be.eq(0);
+            expect((await driver.cleanConfigure(ConfigureTrigger.runTests, [])).result).to.be.eq(0);
             expect(await driver.build([driver.allTargetName])).to.be.eq(0);
 
             expect(driver.executableTargets.length).to.be.eq(2);
@@ -176,12 +176,12 @@ export function makeDriverTestsuite(driverName: string, driver_generator: (cmake
 
             // Set kit without a preferred generator
             await driver.setKit({ name: 'GCC', isTrusted: true }, []);
-            expect(await driver.cleanConfigure(ConfigureTrigger.runTests, [])).to.be.eq(0);
+            expect((await driver.cleanConfigure(ConfigureTrigger.runTests, [])).result).to.be.eq(0);
             const kit1 = driver.cmakeCacheEntries?.get('CMAKE_GENERATOR')!.value;
 
             // Set kit with a list of two default preferred generators, for comparison
             await driver.setKit({ name: 'GCC', isTrusted: true }, [{ name: 'Ninja' }, { name: 'Unix Makefiles' }]);
-            expect(await driver.configure(ConfigureTrigger.runTests, [])).to.be.eq(0);
+            expect((await driver.configure(ConfigureTrigger.runTests, [])).result).to.be.eq(0);
             const kit2 = driver.cmakeCacheEntries?.get('CMAKE_GENERATOR')!.value;
 
             expect(kit1).to.be.equal(kit2);
@@ -197,7 +197,7 @@ export function makeDriverTestsuite(driverName: string, driver_generator: (cmake
                 called = true;
             };
             driver = await driver_generator(executable, config, ninjaKitDefault, emptyWorkspaceFolder, checkPreconditionHelper, []);
-            expect(await driver.cleanConfigure(ConfigureTrigger.runTests, [])).to.be.eq(-2);
+            expect((await driver.cleanConfigure(ConfigureTrigger.runTests, [])).result).to.be.eq(-2);
             expect(called).to.be.true;
         }).timeout(60000);
 
@@ -211,11 +211,11 @@ export function makeDriverTestsuite(driverName: string, driver_generator: (cmake
                 called = true;
             };
             driver = await driver_generator(executable, config, ninjaKitDefault, defaultWorkspaceFolder, checkPreconditionHelper, []);
-            const configure1 = driver.configure(ConfigureTrigger.runTests, []);
-            const configure2 = driver.configure(ConfigureTrigger.runTests, []);
+            const configure1 = (await driver.configure(ConfigureTrigger.runTests, [])).result;
+            const configure2 = (await driver.configure(ConfigureTrigger.runTests, [])).result;
 
-            expect(await configure1).to.be.equal(0);
-            expect(await configure2).to.be.equal(-1);
+            expect(configure1).to.be.equal(0);
+            expect(configure2).to.be.equal(-1);
             expect(called).to.be.true;
         }).timeout(90000);
 
@@ -230,11 +230,11 @@ export function makeDriverTestsuite(driverName: string, driver_generator: (cmake
             };
             driver
                 = await driver_generator(executable, config, ninjaKitDefault, defaultWorkspaceFolder, checkPreconditionHelper, []);
-            const configure1 = driver.cleanConfigure(ConfigureTrigger.runTests, []);
-            const configure2 = driver.cleanConfigure(ConfigureTrigger.runTests, []);
+            const configure1 = (await driver.cleanConfigure(ConfigureTrigger.runTests, [])).result;
+            const configure2 = (await driver.cleanConfigure(ConfigureTrigger.runTests, [])).result;
 
-            expect(await configure1).to.be.equal(0);
-            expect(await configure2).to.be.equal(-1);
+            expect(configure1).to.be.equal(0);
+            expect(configure2).to.be.equal(-1);
             expect(called).to.be.true;
         }).timeout(90000);
 
@@ -250,7 +250,7 @@ export function makeDriverTestsuite(driverName: string, driver_generator: (cmake
             };
             driver
                 = await driver_generator(executable, config, ninjaKitDefault, defaultWorkspaceFolder, checkPreconditionHelper, []);
-            expect(await driver.configure(ConfigureTrigger.runTests, [])).to.be.equal(0);
+            expect((await driver.configure(ConfigureTrigger.runTests, [])).result).to.be.equal(0);
             const build1 = driver.build([driver.allTargetName]);
             const build2 = driver.build([driver.allTargetName]);
 
@@ -271,11 +271,11 @@ export function makeDriverTestsuite(driverName: string, driver_generator: (cmake
             };
             driver
                 = await driver_generator(executable, config, ninjaKitDefault, defaultWorkspaceFolder, checkPreconditionHelper, []);
-            expect(await driver.configure(ConfigureTrigger.runTests, [])).to.be.equal(0);
-            const configure = driver.configure(ConfigureTrigger.runTests, []);
+            expect((await driver.configure(ConfigureTrigger.runTests, [])).result).to.be.equal(0);
+            const configure = (await driver.configure(ConfigureTrigger.runTests, [])).result;
             const build = driver.build([driver.allTargetName]);
 
-            expect(await configure).to.be.equal(0);
+            expect(configure).to.be.equal(0);
             expect(await build).to.be.equal(-1);
             expect(called).to.be.true;
         }).timeout(90000);
@@ -292,7 +292,7 @@ export function makeDriverTestsuite(driverName: string, driver_generator: (cmake
             };
             driver
                 = await driver_generator(executable, config, ninjaKitDefault, defaultWorkspaceFolder, checkPreconditionHelper, []);
-            expect(await driver.configure(ConfigureTrigger.runTests, [])).to.be.equal(0);
+            expect((await driver.configure(ConfigureTrigger.runTests, [])).result).to.be.equal(0);
             const build = driver.build([driver.allTargetName]);
             const configure = driver.configure(ConfigureTrigger.runTests, []);
 
@@ -313,10 +313,10 @@ export function makeDriverTestsuite(driverName: string, driver_generator: (cmake
             };
             driver
                 = await driver_generator(executable, config, ninjaKitDefault, defaultWorkspaceFolder, checkPreconditionHelper, []);
-            const configure = driver.cleanConfigure(ConfigureTrigger.runTests, []);
+            const configure = (await driver.cleanConfigure(ConfigureTrigger.runTests, [])).result;
             const build = driver.build([driver.allTargetName]);
 
-            expect(await configure).to.be.equal(0);
+            expect(configure).to.be.equal(0);
             expect(await build).to.be.equal(-1);
             expect(called).to.be.true;
         }).timeout(90000);
@@ -332,12 +332,12 @@ export function makeDriverTestsuite(driverName: string, driver_generator: (cmake
                 }
             };
             driver = await driver_generator(executable, config, ninjaKitDefault, defaultWorkspaceFolder, checkPreconditionHelper, []);
-            expect(await driver.configure(ConfigureTrigger.runTests, [])).to.be.equal(0);
+            expect((await driver.configure(ConfigureTrigger.runTests, [])).result).to.be.equal(0);
             const build = driver.build([driver.allTargetName]);
-            const configure = driver.cleanConfigure(ConfigureTrigger.runTests, []);
+            const configure = (await driver.cleanConfigure(ConfigureTrigger.runTests, [])).result;
 
             expect(await build).to.be.equal(0);
-            expect(await configure).to.be.equal(-1);
+            expect(configure).to.be.equal(-1);
             expect(called).to.be.true;
         }).timeout(90000);
 
@@ -351,7 +351,7 @@ export function makeDriverTestsuite(driverName: string, driver_generator: (cmake
 
             driver = null;
             driver = await driver_generator(executable, config, ninjaKitDefault, defaultWorkspaceFolder, async () => {}, []);
-            expect(await driver.configure(ConfigureTrigger.runTests, [])).to.be.eq(0);
+            expect((await driver.configure(ConfigureTrigger.runTests, [])).result).to.be.eq(0);
 
             const expFileApi = driver instanceof CMakeFileApiDriver;
             const expSrv = driver instanceof CMakeServerDriver;
@@ -379,7 +379,7 @@ export function makeDriverTestsuite(driverName: string, driver_generator: (cmake
                 await driver.setKit(secondaryKit, [{ name: 'Unix Makefiles' }]);
             }
 
-            expect(await driver.configure(ConfigureTrigger.runTests, [])).to.be.eq(0);
+            expect((await driver.configure(ConfigureTrigger.runTests, [])).result).to.be.eq(0);
             expect(driver.cmakeCacheEntries.get('CMAKE_GENERATOR')!.value).to.be.not.eq('Ninja');
 
             if (process.platform === 'win32') {


### PR DESCRIPTION
<!-- Thanks for your contribution! To make things easier, please fill out the template below. -->

<!-- Please delete any unused sections. -->

<!-- Delete the following heading if there is no corresponding issue -->
## This change addresses item #3343 

### This changes when the notification to configure with the CMake Debugger appears. 

The following changes are proposed:

- I modified the return value of the configure method, such that we can also return not only an exit code, but also a contextual `returnType`, was this forcibly stopped? Was it normal operation? Etc. 
- I also added a setting that controls whether this popup will appear. This can be modified through the popup by pressing the "Do Not Show Again" button. 

## Other Notes/Information

![image](https://github.com/microsoft/vscode-cmake-tools/assets/86264750/2ac219e0-69d9-4e93-b94b-6749cb7e77ff)
![image](https://github.com/microsoft/vscode-cmake-tools/assets/86264750/1c68b22b-575b-4556-aa31-586ee652440d)
