### PR TITLE
Ensure we clear the output channel for a build due to a test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Bug Fixes:
 - Ensure that the output is cleared for `debugTarget` and `launchTarget` [#3489](https://github.com/microsoft/vscode-cmake-tools/issues/3489)
 - Fix the inheritance of the `environment` for CMakePresets. [#3473](https://github.com/microsoft/vscode-cmake-tools/issues/3473)
 - Removed an unnecessary `console.assert` [#3474](https://github.com/microsoft/vscode-cmake-tools/issues/3474)
+- Make sure we clear the output on builds due to test when `Clear output before build` is enabled. [#1179](https://github.com/microsoft/vscode-cmake-tools/issues/1179)
 
 ## 1.16.32
 Improvements:

--- a/src/cmakeProject.ts
+++ b/src/cmakeProject.ts
@@ -37,7 +37,7 @@ import { setContextValue } from './util';
 import { VariantManager } from './variant';
 import * as nls from 'vscode-nls';
 import { ConfigurationWebview } from './cacheView';
-import { enableFullFeatureSet, updateFullFeatureSet } from './extension';
+import { enableFullFeatureSet, extensionManager, updateFullFeatureSet } from './extension';
 import { CMakeCommunicationMode, ConfigurationReader, OptionConfig, UseCMakePresets } from './config';
 import * as preset from '@cmt/preset';
 import * as util from '@cmt/util';
@@ -1902,6 +1902,7 @@ export class CMakeProject {
     }
 
     private async preTest(): Promise<CMakeDriver> {
+        extensionManager?.cleanOutputChannel();
         const buildResult = await this.build(undefined, false, false);
         if (buildResult !== 0) {
             throw new Error(localize('build.failed', 'Build failed.'));

--- a/src/cmakeProject.ts
+++ b/src/cmakeProject.ts
@@ -1902,8 +1902,8 @@ export class CMakeProject {
     }
 
     private async preTest(): Promise<CMakeDriver> {
-        if (extensionManager !== undefined) {
-            extensionManager?.cleanOutputChannel();
+        if (extensionManager !== undefined && extensionManager !== null) {
+            extensionManager.cleanOutputChannel();
         }
         const buildResult = await this.build(undefined, false, false);
         if (buildResult !== 0) {

--- a/src/cmakeProject.ts
+++ b/src/cmakeProject.ts
@@ -1902,7 +1902,9 @@ export class CMakeProject {
     }
 
     private async preTest(): Promise<CMakeDriver> {
-        extensionManager?.cleanOutputChannel();
+        if (extensionManager !== undefined) {
+            extensionManager?.cleanOutputChannel();
+        }
         const buildResult = await this.build(undefined, false, false);
         if (buildResult !== 0) {
             throw new Error(localize('build.failed', 'Build failed.'));

--- a/src/ctest.ts
+++ b/src/ctest.ts
@@ -14,6 +14,7 @@ import { testArgs, TestPreset } from './preset';
 import { expandString } from './expand';
 import * as proc from '@cmt/proc';
 import { ProjectController } from './projectController';
+import { extensionManager } from './extension';
 
 nls.config({ messageFormat: nls.MessageFormat.bundle, bundleFormat: nls.BundleFormat.standalone })();
 const localize: nls.LocalizeFunc = nls.loadMessageBundle();
@@ -957,6 +958,7 @@ export class CTestDriver implements vscode.Disposable {
                     status = 1;
                 } else {
                     try {
+                        extensionManager?.cleanOutputChannel();
                         const buildResult = await project.build(undefined, false, false);
                         if (buildResult !== 0) {
                             status = 2;

--- a/src/ctest.ts
+++ b/src/ctest.ts
@@ -958,8 +958,8 @@ export class CTestDriver implements vscode.Disposable {
                     status = 1;
                 } else {
                     try {
-                        if (extensionManager !== undefined) {
-                            extensionManager?.cleanOutputChannel();
+                        if (extensionManager !== undefined && extensionManager !== null) {
+                            extensionManager.cleanOutputChannel();
                         }
                         const buildResult = await project.build(undefined, false, false);
                         if (buildResult !== 0) {

--- a/src/ctest.ts
+++ b/src/ctest.ts
@@ -958,7 +958,9 @@ export class CTestDriver implements vscode.Disposable {
                     status = 1;
                 } else {
                     try {
-                        extensionManager?.cleanOutputChannel();
+                        if (extensionManager !== undefined) {
+                            extensionManager?.cleanOutputChannel();
+                        }
                         const buildResult = await project.build(undefined, false, false);
                         if (buildResult !== 0) {
                             status = 2;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1005,7 +1005,7 @@ export class ExtensionManager implements vscode.Disposable {
         }
     }
 
-    private cleanOutputChannel() {
+    cleanOutputChannel() {
         if (this.workspaceConfig.clearOutputBeforeBuild) {
             log.clearOutputChannel();
         }


### PR DESCRIPTION
Addresses #1179 . When the "Clear output before build" setting is turned on, it seems reasonable to ensure that this remains true during testing. If a test is started and thus a build is invoked, we should clear the output channel before the build. 
