### PR TITLE
prevent compilation db corruption (#3214)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Bug Fixes:
 - Fixed the key to reference the correct description for the `compact` option of the `cmake.options.advanced.variant.statusBarVisibility` setting. [#3511](https://github.com/microsoft/vscode-cmake-tools/issues/3511).
 - Fixed the parsing of C and CXX compiler cache variables when adding a new configure preset from existing compilers. [#2773](https://github.com/microsoft/vscode-cmake-tools/issues/2773)
 - Avoid the pitfalls of using `RegExp.exec()` in loops, replacing their usage with `string.matchAll()`. This change is applied to the expand.ts file which deals with expansion of variables in user provided strings. It may address the failures described in issue [#3469](https://github.com/microsoft/vscode-cmake-tools/issues/3469).
+- Fixed `compile_commands.json` file corruption with `copyCompileCommands` when value is equal to default path. [#3214](https://github.com/microsoft/vscode-cmake-tools/issues/3214) [@parniere](https://github.com/parniere)
 
 ## 1.16.32
 Improvements:

--- a/src/cmakeProject.ts
+++ b/src/cmakeProject.ts
@@ -1233,20 +1233,22 @@ export class CMakeProject {
                     // Now try to copy the compdb to the user-requested path
                     const copyDest = this.workspaceContext.config.copyCompileCommands;
                     const expandedDest = await expandString(copyDest, opts);
-                    const parentDir = path.dirname(expandedDest);
-                    try {
-                        log.debug(localize('copy.compile.commands', 'Copying {2} from {0} to {1}', compdbPath, expandedDest, 'compile_commands.json'));
-                        await fs.mkdir_p(parentDir);
+                    if (compdbPath !== expandedDest) {
+                        const parentDir = path.dirname(expandedDest);
                         try {
-                            await fs.copyFile(compdbPath, expandedDest);
+                            log.debug(localize('copy.compile.commands', 'Copying {2} from {0} to {1}', compdbPath, expandedDest, 'compile_commands.json'));
+                            await fs.mkdir_p(parentDir);
+                            try {
+                                await fs.copyFile(compdbPath, expandedDest);
+                            } catch (e: any) {
+                                // Just display the error. It's the best we can do.
+                                void vscode.window.showErrorMessage(localize('failed.to.copy', 'Failed to copy {0} to {1}: {2}', `"${compdbPath}"`, `"${expandedDest}"`, e.toString()));
+                            }
                         } catch (e: any) {
-                            // Just display the error. It's the best we can do.
-                            void vscode.window.showErrorMessage(localize('failed.to.copy', 'Failed to copy {0} to {1}: {2}', `"${compdbPath}"`, `"${expandedDest}"`, e.toString()));
+                            void vscode.window.showErrorMessage(localize('failed.to.create.parent.directory.1',
+                                'Tried to copy {0} to {1}, but failed to create the parent directory {2}: {3}',
+                                `"${compdbPath}"`, `"${expandedDest}"`, `"${parentDir}"`, e.toString()));
                         }
-                    } catch (e: any) {
-                        void vscode.window.showErrorMessage(localize('failed.to.create.parent.directory.1',
-                            'Tried to copy {0} to {1}, but failed to create the parent directory {2}: {3}',
-                            `"${compdbPath}"`, `"${expandedDest}"`, `"${parentDir}"`, e.toString()));
                     }
                 }
             } else if (this.workspaceContext.config.copyCompileCommands) {


### PR DESCRIPTION
    - if copyCompileCommands is equal to default db path,
    we need to avoid the copy otherwise it would  copy on itself

<!-- Thanks for your contribution! To make things easier, please fill out the template below. -->

<!-- Please delete any unused sections. -->

<!-- Delete the following heading if there is no corresponding issue -->
## This change addresses item #3214 

