### PR TITLE
ensure we apply our presets to local cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,10 @@ Bug Fixes:
 
 - Fixed an issue where changing an empty value to a non-empty value using the Cache Editor UI didn't work. [PR #3508](https://github.com/microsoft/vscode-cmake-tools/pull/3508)
 - Fix CMakePresets inheritance for the `condition` field. [PR #3494](https://github.com/microsoft/vscode-cmake-tools/pull/3494)
-- Ensure that the output is cleared for `debugTarget` and `launchTarget` [#3489](https://github.com/microsoft/vscode-cmake-tools/issues/3489)
+- Ensure that the output is cleared for `debugTarget` and `launchTarget`. [#3489](https://github.com/microsoft/vscode-cmake-tools/issues/3489)
 - Fix the inheritance of the `environment` for CMakePresets. [#3473](https://github.com/microsoft/vscode-cmake-tools/issues/3473)
-- Removed an unnecessary `console.assert` [#3474](https://github.com/microsoft/vscode-cmake-tools/issues/3474)
+- Removed an unnecessary `console.assert`. [#3474](https://github.com/microsoft/vscode-cmake-tools/issues/3474)
+- Make sure that we apply our presets to the local cache before also adding a build preset and erroneously overwriting our change. [#3376](https://github.com/microsoft/vscode-cmake-tools/pull/3503)
 
 ## 1.16.32
 Improvements:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Bug Fixes:
 - Ensure that the output is cleared for `debugTarget` and `launchTarget`. [#3489](https://github.com/microsoft/vscode-cmake-tools/issues/3489)
 - Fix the inheritance of the `environment` for CMakePresets. [#3473](https://github.com/microsoft/vscode-cmake-tools/issues/3473)
 - Removed an unnecessary `console.assert`. [#3474](https://github.com/microsoft/vscode-cmake-tools/issues/3474)
-- Make sure that we apply our presets to the local cache before also adding a build preset and erroneously overwriting our change. [#3376](https://github.com/microsoft/vscode-cmake-tools/pull/3503)
+- Make sure that we apply our presets to the local cache before also adding a build preset and erroneously overwriting our change. [#3376](https://github.com/microsoft/vscode-cmake-tools/issues/3376)
 
 ## 1.16.32
 Improvements:

--- a/src/presetsController.ts
+++ b/src/presetsController.ts
@@ -392,6 +392,9 @@ export class PresetsController {
                 await this.addPresetAddUpdate(newPreset, 'configurePresets');
 
                 if (isMultiConfigGenerator) {
+                    // Ensure that we update our local copies of the PresetsFile so that adding the build preset happens as expected.
+                    await this.reapplyPresets();
+
                     const buildPreset: preset.BuildPreset = {
                         name: `${newPreset.name}-debug`,
                         displayName: `${newPreset.displayName} - Debug`,


### PR DESCRIPTION
This ensures that adding the build preset doesn't overwrite the contents we wanted to write for the configure preset.

Because we can't `await` the call to `reapplyPresets` from the `chokidar` file watcher, we must call it explicitly and await it here as well to ensure that we don't have races to the file and to the cache, which causes issues. 

Fixes #3376 
