### PR TITLE
Don't run tests from testing sidebar on build failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Bug Fixes:
 - Ensure that the output is cleared for `debugTarget` and `launchTarget` [#3489](https://github.com/microsoft/vscode-cmake-tools/issues/3489)
 - Fix the inheritance of the `environment` for CMakePresets. [#3473](https://github.com/microsoft/vscode-cmake-tools/issues/3473)
 - Removed an unnecessary `console.assert` [#3474](https://github.com/microsoft/vscode-cmake-tools/issues/3474)
-- Avoid running tests after a build failure [#3366](https://github.com/microsoft/vscode-cmake-tools/pull/3506)
+- Avoid running tests after a build failure [#3366](https://github.com/microsoft/vscode-cmake-tools/issues/3366)
 
 ## 1.16.32
 Improvements:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Bug Fixes:
 - Ensure that the output is cleared for `debugTarget` and `launchTarget` [#3489](https://github.com/microsoft/vscode-cmake-tools/issues/3489)
 - Fix the inheritance of the `environment` for CMakePresets. [#3473](https://github.com/microsoft/vscode-cmake-tools/issues/3473)
 - Removed an unnecessary `console.assert` [#3474](https://github.com/microsoft/vscode-cmake-tools/issues/3474)
+- Avoid running tests after a build failure [#3366](https://github.com/microsoft/vscode-cmake-tools/pull/3506)
 
 ## 1.16.32
 Improvements:

--- a/src/ctest.ts
+++ b/src/ctest.ts
@@ -714,8 +714,12 @@ export class CTestDriver implements vscode.Disposable {
 
         const run = testExplorer.createTestRun(request);
         this.ctestsEnqueued(tests, run);
-        await this.buildTests(tests, run);
-        await this.runCTestHelper(tests, run, undefined, undefined, undefined, cancellation);
+        const buildSucceeded = await this.buildTests(tests, run);
+        if (buildSucceeded) {
+            await this.runCTestHelper(tests, run, undefined, undefined, undefined, cancellation);
+        } else {
+            log.info(localize('test.skip.run.build.failure', "Not running tests due to build failure."));
+        }
         run.end();
     };
 
@@ -940,12 +944,16 @@ export class CTestDriver implements vscode.Disposable {
 
         const run = testExplorer.createTestRun(request);
         this.ctestsEnqueued(tests, run);
-        await this.buildTests(tests, run);
-        await this.debugCTestHelper(tests, run, cancellation);
+        const buildSucceeded = await this.buildTests(tests, run);
+        if (buildSucceeded) {
+            await this.debugCTestHelper(tests, run, cancellation);
+        } else {
+            log.info(localize('test.skip.debug.build.failure', "Not debugging tests due to build failure."));
+        }
         run.end();
     };
 
-    private async buildTests(tests: vscode.TestItem[], run: vscode.TestRun) {
+    private async buildTests(tests: vscode.TestItem[], run: vscode.TestRun): Promise<boolean> {
         // Folder => status
         const builtFolder = new Map<string, number>();
         let status: number = 0;
@@ -973,6 +981,8 @@ export class CTestDriver implements vscode.Disposable {
                 this.ctestErrored(test, run, { message: localize('build.failed', 'Build failed') });
             }
         }
+
+        return Array.from(builtFolder.values()).filter(v => v !== 0).length === 0;
     }
 
     /**


### PR DESCRIPTION
Addresses #3366 by adding a return value to the `buildTests` method and uses that return value to assess whether we should run/debug the tests in the `runTestHandler` and `debugTestHandler`. If the build fails, we output a log statement about why CTest wasn't run. 
