### PR TITLE
The cmake.getActiveWorkspace command to reuse it by another extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # What's New?
 
 ## 1.17
+Features:
+- Added the `cmake.getActiveWorkspace` command to share current active project path to reuse by another extensions
+
 Bug Fixes:
 
 - Fixed an issue where changing an empty value to a non-empty value using the Cache Editor UI didn't work. [PR #3508](https://github.com/microsoft/vscode-cmake-tools/pull/3508)

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1959,7 +1959,9 @@ async function setup(context: vscode.ExtensionContext, progress?: ProgressHandle
         // vscode.commands.registerCommand('cmake.outline.selectWorkspace', (what: WorkspaceFolderNode) => runCommand('selectWorkspace', what.wsFolder))
         vscode.commands.registerCommand('cmake.outline.selectWorkspace', (what: WorkspaceFolderNode) => runCommand('selectWorkspace', what.wsFolder)),
         // Notification of active project change (e.g. when cmake.sourceDirectory changes)
-        vscode.commands.registerCommand('cmake.statusbar.update', () => extensionManager?.updateStatusBarForActiveProjectChange())
+        vscode.commands.registerCommand('cmake.statusbar.update', () => extensionManager?.updateStatusBarForActiveProjectChange()),
+        // Share the Active Workspace setting to reuse by another extensions
+        vscode.commands.registerCommand('cmake.getActiveWorkspace', () => extensionManager?.activeFolderPath())
     ]);
 
     return { getApi: (_version) => ext.api };


### PR DESCRIPTION
Added the `cmake.getActiveWorkspace` command to share current active project path to reuse by another extensions