### PR TITLE
Dev/snehara/fix settings description keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ Bug Fixes:
 - Avoid running tests after a build failure [#3366](https://github.com/microsoft/vscode-cmake-tools/issues/3366)
 - Make sure we clear the output on builds due to test when `Clear output before build` is enabled. [#1179](https://github.com/microsoft/vscode-cmake-tools/issues/1179)
 - Ensure that, when switching between presets, the CMake executable is modified. [#2791](https://github.com/microsoft/vscode-cmake-tools/issues/2791)
-- Fixed the key to reference the correct description for the `compact` option of the `cmake.options.advanced.statusBarVisibility.variant` setting. [#3511](https://github.com/microsoft/vscode-cmake-tools/issues/3511).
+- Fixed the key to reference the correct description for the `compact` option of the `cmake.options.advanced.variant.statusBarVisibility` setting. [#3511](https://github.com/microsoft/vscode-cmake-tools/issues/3511).
 
 ## 1.16.32
 Improvements:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Bug Fixes:
 - Avoid running tests after a build failure [#3366](https://github.com/microsoft/vscode-cmake-tools/issues/3366)
 - Make sure we clear the output on builds due to test when `Clear output before build` is enabled. [#1179](https://github.com/microsoft/vscode-cmake-tools/issues/1179)
 - Ensure that, when switching between presets, the CMake executable is modified. [#2791](https://github.com/microsoft/vscode-cmake-tools/issues/2791)
+- Fixed the key to reference the correct description for the `compact` option of the `cmake.options.advanced.statusBarVisibility.variant` setting. [#3511](https://github.com/microsoft/vscode-cmake-tools/issues/3511).
 
 ## 1.16.32
 Improvements:

--- a/package.json
+++ b/package.json
@@ -2575,7 +2575,7 @@
                   "enumDescriptions": [
                     "%cmake-tools.configuration.cmake.options.advanced.statusBarVisibility.visible.description%",
                     "%cmake-tools.configuration.cmake.options.advanced.statusBarVisibility.icon.description%",
-                    "%cmake-tools.configuration.cmake.options.advanced.statusBarVisibility.variant.description%",
+                    "%cmake-tools.configuration.cmake.options.advanced.statusBarVisibility.variant.compact.description%",
                     "%cmake-tools.configuration.cmake.options.advanced.statusBarVisibility.hidden.description%"
                   ]
                 }


### PR DESCRIPTION
## This is for issue #3511 
The `cmake.options.advanced.variant.statusBarVisibility` setting's `compact` option pointed to an invalid description key. I have updated the description key to point to the correct one in this PR.