### PR TITLE
Update the api.ts for the getActiveFolderPath method.

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -39,6 +39,10 @@ export class CMakeToolsApiImpl implements api.CMakeToolsApi {
         return project ? new CMakeProjectWrapper(project) : undefined;
     }
 
+    getActiveFolderPath(): string {
+        return this.manager.activeFolderPath();
+    }
+
     private async setUIElementVisibility(element: api.UIElement, visible: boolean): Promise<void> {
         switch (element) {
             case api.UIElement.StatusBarDebugButton:


### PR DESCRIPTION
This will need to also update and pull down the 1.1 version of the API, so this is pending on a new version being published of https://www.npmjs.com/package/vscode-cmake-tools?activeTab=readme. 

These changes are thanks to @kemaweyan, who started this idea here: #3520. This makes the changes in our formal API. 

We add the API method implementation and we update the dependency on the public API interface. 
