### PR TITLE
log fs.stat() errors in dirty.ts:checkOutOfDate()

### DIFF
--- a/src/dirty.ts
+++ b/src/dirty.ts
@@ -7,6 +7,9 @@ import { fs } from '@cmt/pr';
 import * as util from '@cmt/util';
 import { Stats } from 'fs';
 import * as path from 'path';
+import { createLogger } from '@cmt/logging';
+
+const logger = createLogger('dirty');
 
 export class InputFile {
     constructor(readonly filePath: string, readonly mtime: Date | null) {}
@@ -18,7 +21,8 @@ export class InputFile {
         let stat: Stats;
         try {
             stat = await fs.stat(this.filePath);
-        } catch (_) {
+        } catch (error: any) {
+            logger.debug(error as Error);
             // Failed to stat: Treat the file as out-of-date
             return true;
         }


### PR DESCRIPTION
## This change helps understanding #588 

The CMake configuration process is started in unexpected conditions, such as when opening a folder containing a CMake project, and `"cmake.configureOnOpen": false`. By looking to the code, there is a code path that is assuming out-of-date-ness when `fs.stat()` fails.

### This changes how the errors are reported for the outOfDate checks of `CMakeLists.txt/.cmake` files

The following changes are proposed:
- Ensure all failures are logged in the code path that checks for out-of-date-ness. 