### PR TITLE
fixed some inherit bugs for statusbar visibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ Bug Fixes:
 - Fixed the parsing of C and CXX compiler cache variables when adding a new configure preset from existing compilers. [#2773](https://github.com/microsoft/vscode-cmake-tools/issues/2773)
 - Avoid the pitfalls of using `RegExp.exec()` in loops, replacing their usage with `string.matchAll()`. This change is applied to the expand.ts file which deals with expansion of variables in user provided strings. It may address the failures described in issue. [#3469](https://github.com/microsoft/vscode-cmake-tools/issues/3469)
 - Fixed `compile_commands.json` file corruption with `copyCompileCommands` when value is equal to default path. [#3214](https://github.com/microsoft/vscode-cmake-tools/issues/3214) [@parniere](https://github.com/parniere)
-- Fixed status bar visibility options' `inherit` option default. []()
+- Fixed status bar visibility options' `inherit` option default. [PR #3579](https://github.com/microsoft/vscode-cmake-tools/pull/3579)
 
 ## 1.16.32
 Improvements:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,10 +24,11 @@ Bug Fixes:
 - Avoid running tests after a build failure [#3366](https://github.com/microsoft/vscode-cmake-tools/issues/3366)
 - Make sure we clear the output on builds due to test when `Clear output before build` is enabled. [#1179](https://github.com/microsoft/vscode-cmake-tools/issues/1179)
 - Ensure that, when switching between presets, the CMake executable is modified. [#2791](https://github.com/microsoft/vscode-cmake-tools/issues/2791)
-- Fixed the key to reference the correct description for the `compact` option of the `cmake.options.advanced.variant.statusBarVisibility` setting. [#3511](https://github.com/microsoft/vscode-cmake-tools/issues/3511).
+- Fixed the key to reference the correct description for the `compact` option of the `cmake.options.advanced.variant.statusBarVisibility` setting. [#3511](https://github.com/microsoft/vscode-cmake-tools/issues/3511)
 - Fixed the parsing of C and CXX compiler cache variables when adding a new configure preset from existing compilers. [#2773](https://github.com/microsoft/vscode-cmake-tools/issues/2773)
-- Avoid the pitfalls of using `RegExp.exec()` in loops, replacing their usage with `string.matchAll()`. This change is applied to the expand.ts file which deals with expansion of variables in user provided strings. It may address the failures described in issue [#3469](https://github.com/microsoft/vscode-cmake-tools/issues/3469).
+- Avoid the pitfalls of using `RegExp.exec()` in loops, replacing their usage with `string.matchAll()`. This change is applied to the expand.ts file which deals with expansion of variables in user provided strings. It may address the failures described in issue. [#3469](https://github.com/microsoft/vscode-cmake-tools/issues/3469)
 - Fixed `compile_commands.json` file corruption with `copyCompileCommands` when value is equal to default path. [#3214](https://github.com/microsoft/vscode-cmake-tools/issues/3214) [@parniere](https://github.com/parniere)
+- Fixed status bar visibility options' `inherit` option default. []()
 
 ## 1.16.32
 Improvements:

--- a/package.json
+++ b/package.json
@@ -2747,13 +2747,9 @@
         "cmake.options.advanced": {
           "type": "object",
           "default": {
-            "build": {"statusBarVisibility": "inherit"},
-            "launch": {"statusBarVisibility": "inherit"},
-            "debug": {"statusBarVisibility": "inherit"},
-            "packagePreset": {"statusBarVisibility": "hidden"},
-            "cpack": {"statusBarVisibility": "hidden"},
-            "workflowPreset": {"statusBarVisibility": "hidden"},
-            "workflow": {"statusBarVisibility": "hidden"}
+            "build": {"statusBarVisibility": "inherit", "inheritDefault": "visible"},
+            "launch": {"statusBarVisibility": "inherit", "inheritDefault": "visible"},
+            "debug": {"statusBarVisibility": "inherit", "inheritDefault": "visible"}
           },
           "markdownDescription": "%cmake-tools.configuration.cmake.options.advanced.markdownDescription%",
           "properties": {
@@ -2803,8 +2799,7 @@
                     "compact",
                     "icon",
                     "hidden"
-                  ],
-                  "default": "visible"
+                  ]
                 },
                 "statusBarLength": {
                   "description": "%cmake-tools.configuration.cmake.options.advanced.statusBarLength.description%",
@@ -2842,8 +2837,7 @@
                     "compact",
                     "icon",
                     "hidden"
-                  ],
-                  "default": "visible"
+                  ]
                 },
                 "statusBarLength": {
                   "description": "%cmake-tools.configuration.cmake.options.advanced.statusBarLength.description%",
@@ -2881,8 +2875,7 @@
                     "compact",
                     "icon",
                     "hidden"
-                  ],
-                  "default": "visible"
+                  ]
                 },
                 "statusBarLength": {
                   "description": "%cmake-tools.configuration.cmake.options.advanced.statusBarLength.description%",
@@ -2904,7 +2897,6 @@
                     "hidden",
                     "inherit"
                   ],
-                  "default": "hidden",
                   "markdownEnumDescriptions": [
                     "%cmake-tools.configuration.cmake.options.advanced.statusBarVisibility.visible.description%",
                     "%cmake-tools.configuration.cmake.options.advanced.statusBarVisibility.icon.description%",
@@ -2921,8 +2913,7 @@
                     "compact",
                     "icon",
                     "hidden"
-                  ],
-                  "default": "hidden"
+                  ]
                 },
                 "statusBarLength": {
                   "description": "%cmake-tools.configuration.cmake.options.advanced.statusBarLength.description%",
@@ -2944,7 +2935,6 @@
                     "hidden",
                     "inherit"
                   ],
-                  "default": "hidden",
                   "markdownEnumDescriptions": [
                     "%cmake-tools.configuration.cmake.options.advanced.statusBarVisibility.visible.description%",
                     "%cmake-tools.configuration.cmake.options.advanced.statusBarVisibility.icon.description%",
@@ -2961,8 +2951,7 @@
                     "compact",
                     "icon",
                     "hidden"
-                  ],
-                  "default": "hidden"
+                  ]
                 },
                 "statusBarLength": {
                   "description": "%cmake-tools.configuration.cmake.options.advanced.statusBarLength.description%",
@@ -3000,8 +2989,7 @@
                     "compact",
                     "icon",
                     "hidden"
-                  ],
-                  "default": "visible"
+                  ]
                 },
                 "statusBarLength": {
                   "description": "%cmake-tools.configuration.cmake.options.advanced.statusBarLength.description%",
@@ -3039,8 +3027,7 @@
                     "compact",
                     "icon",
                     "hidden"
-                  ],
-                  "default": "visible"
+                  ]
                 }
               }
             },
@@ -3073,8 +3060,7 @@
                     "compact",
                     "icon",
                     "hidden"
-                  ],
-                  "default": "visible"
+                  ]
                 },
                 "statusBarLength": {
                   "description": "%cmake-tools.configuration.cmake.options.advanced.statusBarLength.description%",
@@ -3121,8 +3107,7 @@
                     "visible",
                     "compact",
                     "hidden"
-                  ],
-                  "default": "visible"
+                  ]
                 },
                 "statusBarLength": {
                   "description": "%cmake-tools.configuration.cmake.options.advanced.statusBarLength.description%",
@@ -3157,8 +3142,7 @@
                     "visible",
                     "icon",
                     "hidden"
-                  ],
-                  "default": "visible"
+                  ]
                 },
                 "projectStatusVisibility": {
                   "type": "string",
@@ -3200,8 +3184,7 @@
                     "visible",
                     "compact",
                     "hidden"
-                  ],
-                  "default": "visible"
+                  ]
                 },
                 "statusBarLength": {
                   "description": "%cmake-tools.configuration.cmake.options.advanced.statusBarLength.description%",
@@ -3236,8 +3219,7 @@
                     "visible",
                     "icon",
                     "hidden"
-                  ],
-                  "default": "visible"
+                  ]
                 },
                 "projectStatusVisibility": {
                   "type": "string",
@@ -3279,8 +3261,7 @@
                     "visible",
                     "icon",
                     "hidden"
-                  ],
-                  "default": "visible"
+                  ]
                 },
                 "projectStatusVisibility": {
                   "type": "string",
@@ -3325,8 +3306,7 @@
                     "compact",
                     "icon",
                     "hidden"
-                  ],
-                  "default": "visible"
+                  ]
                 },
                 "color": {
                   "type": "boolean",
@@ -3382,8 +3362,7 @@
                     "compact",
                     "icon",
                     "hidden"
-                  ],
-                  "default": "hidden"
+                  ]
                 },
                 "color": {
                   "type": "boolean",
@@ -3402,7 +3381,6 @@
                     "visible",
                     "hidden"
                   ],
-                  "default": "visible",
                   "enumDescriptions": [
                     "%cmake-tools.configuration.cmake.options.advanced.projectStatusVisibility.visible.description%",
                     "%cmake-tools.configuration.cmake.options.advanced.projectStatusVisibility.hidden.description%"
@@ -3440,8 +3418,7 @@
                     "compact",
                     "icon",
                     "hidden"
-                  ],
-                  "default": "hidden"
+                  ]
                 },
                 "color": {
                   "type": "boolean",
@@ -3460,7 +3437,6 @@
                     "visible",
                     "hidden"
                   ],
-                  "default": "visible",
                   "enumDescriptions": [
                     "%cmake-tools.configuration.cmake.options.advanced.projectStatusVisibility.visible.description%",
                     "%cmake-tools.configuration.cmake.options.advanced.projectStatusVisibility.hidden.description%"

--- a/src/config.ts
+++ b/src/config.ts
@@ -70,13 +70,11 @@ export interface AdvancedOptionConfig {
         statusBarLength?: number;
     };
     packagePreset?: {
-        projectStatusVisibility?: ProjectStatusOptionVisibility;
         statusBarVisibility?: StatusBarOptionVisibility;
         inheritDefault?: StatusBarInheritOptionVisibility;
         statusBarLength?: number;
     };
     workflowPreset?: {
-        projectStatusVisibility?: ProjectStatusOptionVisibility;
         statusBarVisibility?: StatusBarOptionVisibility;
         inheritDefault?: StatusBarInheritOptionVisibility;
         statusBarLength?: number;


### PR DESCRIPTION
I updated the default settings to actually get the `inheritDefault` values. Defaults in nested settings like these need to be put at the top level to be recognized. Also removed the config.ts option for project status visibility for the new presets since only the top level node on the sidebar tree should be configurable.