### PR TITLE
Fix order of CMakePresets inheritance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 Bug Fixes:
 
 - Fix an issue where we weren't able to run tests when not using Presets. [#3589](https://github.com/microsoft/vscode-cmake-tools/issues/3589)
+- Fix the order of preference for CMake Presets `inherit` field. [#3594](https://github.com/microsoft/vscode-cmake-tools/issues/3594)
 
 ## 1.17.15
 

--- a/src/preset.ts
+++ b/src/preset.ts
@@ -625,7 +625,8 @@ function getVendorForConfigurePresetHelper(folder: string, preset: ConfigurePres
         if (util.isString(preset.inherits)) {
             preset.inherits = [preset.inherits];
         }
-        for (const parent of preset.inherits) {
+        const reversedInherits = preset.inherits.slice().reverse();
+        for (const parent of reversedInherits) {
             const parentVendor = getVendorForConfigurePresetImpl(folder, parent, allowUserPreset);
             if (parentVendor) {
                 for (const key in parentVendor) {
@@ -763,6 +764,7 @@ export async function expandConfigurePreset(folder: string, name: string, worksp
     const expandedPreset: ConfigurePreset = { name };
     const expansionOpts: ExpansionOptions = await getExpansionOptions(workspaceFolder, sourceDir, preset);
 
+    preset.environment = EnvironmentUtils.mergePreserveNull([process.env, preset.environment]);
     // Expand environment vars first since other fields may refer to them
     if (preset.environment) {
         expandedPreset.environment = EnvironmentUtils.createPreserveNull();
@@ -1109,7 +1111,8 @@ async function expandConfigurePresetHelper(folder: string, preset: ConfigurePres
         if (util.isString(preset.inherits)) {
             preset.inherits = [preset.inherits];
         }
-        for (const parentName of preset.inherits) {
+        const reversedInherits = preset.inherits.slice().reverse();
+        for (const parentName of reversedInherits) {
             const parent = await expandConfigurePresetImpl(folder, parentName, workspaceFolder, sourceDir, allowUserPreset);
             if (parent) {
                 // Inherit environment
@@ -1132,7 +1135,6 @@ async function expandConfigurePresetHelper(folder: string, preset: ConfigurePres
         }
     }
 
-    inheritedEnv = EnvironmentUtils.mergePreserveNull([process.env, inheritedEnv]);
     preset.environment = EnvironmentUtils.mergePreserveNull([inheritedEnv, preset.environment]);
 
     preset.__expanded = true;
@@ -1293,7 +1295,8 @@ function getConfigurePresetForPresetHelper(folder: string, preset: BuildPreset |
         if (util.isString(preset.inherits)) {
             preset.inherits = [preset.inherits];
         }
-        for (const parent of preset.inherits) {
+        const reversedInherits = preset.inherits.slice().reverse();
+        for (const parent of reversedInherits) {
             const parentConfigurePreset = getConfigurePresetForPresetImpl(folder, parent, presetType, allowUserPreset);
             if (parentConfigurePreset) {
                 preset.configurePreset = parentConfigurePreset;
@@ -1415,7 +1418,8 @@ async function expandBuildPresetHelper(folder: string, preset: BuildPreset, work
         if (util.isString(preset.inherits)) {
             preset.inherits = [preset.inherits];
         }
-        for (const parentName of preset.inherits) {
+        const reversedInherits = preset.inherits.slice().reverse();
+        for (const parentName of reversedInherits) {
             const parent = await expandBuildPresetImpl(folder, parentName, workspaceFolder, sourceDir, parallelJobs, preferredGeneratorName, allowUserPreset);
             if (parent) {
                 // Inherit environment
@@ -1600,7 +1604,8 @@ async function expandTestPresetHelper(folder: string, preset: TestPreset, worksp
         if (util.isString(preset.inherits)) {
             preset.inherits = [preset.inherits];
         }
-        for (const parentName of preset.inherits) {
+        const reversedInherits = preset.inherits.slice().reverse();
+        for (const parentName of reversedInherits) {
             const parent = await expandTestPresetImpl(folder, parentName, workspaceFolder, sourceDir, preferredGeneratorName, allowUserPreset);
             if (parent) {
                 // Inherit environment
@@ -1728,7 +1733,8 @@ async function expandPackagePresetHelper(folder: string, preset: PackagePreset, 
         if (util.isString(preset.inherits)) {
             preset.inherits = [preset.inherits];
         }
-        for (const parentName of preset.inherits) {
+        const reversedInherits = preset.inherits.slice().reverse();
+        for (const parentName of reversedInherits) {
             const parent = await expandPackagePresetImpl(folder, parentName, workspaceFolder, sourceDir, preferredGeneratorName, allowUserPreset);
             if (parent) {
                 // Inherit environment
@@ -1862,7 +1868,8 @@ async function expandWorkflowPresetHelper(folder: string, preset: WorkflowPreset
         if (util.isString(preset.inherits)) {
             preset.inherits = [preset.inherits];
         }
-        for (const parentName of preset.inherits) {
+        const reversedInherits = preset.inherits.slice().reverse();
+        for (const parentName of reversedInherits) {
             const parent = await expandWorkflowPresetImpl(folder, parentName, workspaceFolder, sourceDir, preferredGeneratorName, allowUserPreset);
             if (parent) {
                 // Inherit environment


### PR DESCRIPTION
Fix #3594. 

Based on the [CMake Presets docs](https://cmake.org/cmake/help/latest/manual/cmake-presets.7.html), if there are multiple `inherits` presets providing conflicting values for the same field, the earlier presets in the array will be preferred. 

This PR fixes our implementation to match this. 

Additionally, it still holds the integrity of the fix from #3488 which fixed #3473. To do this, we only include the process.env at the very end, as we don't need to include it during inheritance grabbing. 
