### PR TITLE
fix inheritance for environment, cache variables, etc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # What's New?
 
+## 1.17.17
+
+Bug Fixes:
+
+- Fix the regression for inheritance of cache variables and other inheritable fields. [#3603](https://github.com/microsoft/vscode-cmake-tools/issues/3603)
+
 ## 1.17.16
 
 Bug Fixes:

--- a/src/preset.ts
+++ b/src/preset.ts
@@ -1116,7 +1116,7 @@ async function expandConfigurePresetHelper(folder: string, preset: ConfigurePres
             const parent = await expandConfigurePresetImpl(folder, parentName, workspaceFolder, sourceDir, allowUserPreset);
             if (parent) {
                 // Inherit environment
-                inheritedEnv = EnvironmentUtils.mergePreserveNull([inheritedEnv, parent.environment]);
+                inheritedEnv = EnvironmentUtils.mergePreserveNull([parent.environment, inheritedEnv]);
                 // Inherit cache vars
                 for (const name in parent.cacheVariables) {
                     if (preset.cacheVariables[name] === undefined) {

--- a/src/preset.ts
+++ b/src/preset.ts
@@ -625,8 +625,7 @@ function getVendorForConfigurePresetHelper(folder: string, preset: ConfigurePres
         if (util.isString(preset.inherits)) {
             preset.inherits = [preset.inherits];
         }
-        const reversedInherits = preset.inherits.slice().reverse();
-        for (const parent of reversedInherits) {
+        for (const parent of preset.inherits) {
             const parentVendor = getVendorForConfigurePresetImpl(folder, parent, allowUserPreset);
             if (parentVendor) {
                 for (const key in parentVendor) {
@@ -1111,8 +1110,7 @@ async function expandConfigurePresetHelper(folder: string, preset: ConfigurePres
         if (util.isString(preset.inherits)) {
             preset.inherits = [preset.inherits];
         }
-        const reversedInherits = preset.inherits.slice().reverse();
-        for (const parentName of reversedInherits) {
+        for (const parentName of preset.inherits) {
             const parent = await expandConfigurePresetImpl(folder, parentName, workspaceFolder, sourceDir, allowUserPreset);
             if (parent) {
                 // Inherit environment
@@ -1295,8 +1293,7 @@ function getConfigurePresetForPresetHelper(folder: string, preset: BuildPreset |
         if (util.isString(preset.inherits)) {
             preset.inherits = [preset.inherits];
         }
-        const reversedInherits = preset.inherits.slice().reverse();
-        for (const parent of reversedInherits) {
+        for (const parent of preset.inherits) {
             const parentConfigurePreset = getConfigurePresetForPresetImpl(folder, parent, presetType, allowUserPreset);
             if (parentConfigurePreset) {
                 preset.configurePreset = parentConfigurePreset;
@@ -1418,8 +1415,7 @@ async function expandBuildPresetHelper(folder: string, preset: BuildPreset, work
         if (util.isString(preset.inherits)) {
             preset.inherits = [preset.inherits];
         }
-        const reversedInherits = preset.inherits.slice().reverse();
-        for (const parentName of reversedInherits) {
+        for (const parentName of preset.inherits) {
             const parent = await expandBuildPresetImpl(folder, parentName, workspaceFolder, sourceDir, parallelJobs, preferredGeneratorName, allowUserPreset);
             if (parent) {
                 // Inherit environment
@@ -1604,8 +1600,7 @@ async function expandTestPresetHelper(folder: string, preset: TestPreset, worksp
         if (util.isString(preset.inherits)) {
             preset.inherits = [preset.inherits];
         }
-        const reversedInherits = preset.inherits.slice().reverse();
-        for (const parentName of reversedInherits) {
+        for (const parentName of preset.inherits) {
             const parent = await expandTestPresetImpl(folder, parentName, workspaceFolder, sourceDir, preferredGeneratorName, allowUserPreset);
             if (parent) {
                 // Inherit environment
@@ -1733,8 +1728,7 @@ async function expandPackagePresetHelper(folder: string, preset: PackagePreset, 
         if (util.isString(preset.inherits)) {
             preset.inherits = [preset.inherits];
         }
-        const reversedInherits = preset.inherits.slice().reverse();
-        for (const parentName of reversedInherits) {
+        for (const parentName of preset.inherits) {
             const parent = await expandPackagePresetImpl(folder, parentName, workspaceFolder, sourceDir, preferredGeneratorName, allowUserPreset);
             if (parent) {
                 // Inherit environment
@@ -1868,8 +1862,7 @@ async function expandWorkflowPresetHelper(folder: string, preset: WorkflowPreset
         if (util.isString(preset.inherits)) {
             preset.inherits = [preset.inherits];
         }
-        const reversedInherits = preset.inherits.slice().reverse();
-        for (const parentName of reversedInherits) {
+        for (const parentName of preset.inherits) {
             const parent = await expandWorkflowPresetImpl(folder, parentName, workspaceFolder, sourceDir, preferredGeneratorName, allowUserPreset);
             if (parent) {
                 // Inherit environment


### PR DESCRIPTION
Fixes #3603. 

The fix in #3595 fixed #3594, but regressed the inheritance for cache variables and other things that can be inherited. It only fixed it for environments but broke it for others. 

I have tested the scenarios for #3594, #3603, #3473 and confirmed that they all are fixed with this implementation change. 
