### PR TITLE
Infer compiler from environment when using CMake presets

### DIFF
--- a/src/preset.ts
+++ b/src/preset.ts
@@ -864,12 +864,11 @@ export async function expandConfigurePreset(folder: string, name: string, worksp
             const compilerName: string | undefined = util.isSupportedCompiler(cxxCompiler) || util.isSupportedCompiler(cCompiler);
 
             // If CMake receives an absolute path to cl.exe it tries to perform a compiler check which is undesirable
-            if (compilerName)
-            {
-                if (cxxCompilerPath && expandedPreset.cacheVariables['CMAKE_C_COMPILER_WORKS'] === undefined) {
+            if (compilerName) {
+                if (cxxCompilerPath && path.isAbsolute(cxxCompilerPath) && expandedPreset.cacheVariables['CMAKE_C_COMPILER_WORKS'] === undefined) {
                     expandedPreset.cacheVariables['CMAKE_C_COMPILER_WORKS'] = true;
                 }
-                if (cCompilerPath && expandedPreset.cacheVariables['CMAKE_CXX_COMPILER_WORKS'] === undefined) {
+                if (cCompilerPath && path.isAbsolute(cCompilerPath) && expandedPreset.cacheVariables['CMAKE_CXX_COMPILER_WORKS'] === undefined) {
                     expandedPreset.cacheVariables['CMAKE_CXX_COMPILER_WORKS'] = true;
                 }
             }

--- a/src/preset.ts
+++ b/src/preset.ts
@@ -808,26 +808,7 @@ export async function expandConfigurePreset(folder: string, name: string, worksp
     }
 
     if (preset.cacheVariables) {
-        expandedPreset.cacheVariables = {};
-
-        // Lets infer the compiler from the environment, this might be overwritten later by a preset
-        if (preset.environment) {
-            const cxxCompiler = getStringValueFromCacheVar(preset.environment['CMAKE_CXX_COMPILER']);
-            const cCompiler = getStringValueFromCacheVar(preset.environment['CMAKE_C_COMPILER']);
-            if (cxxCompiler != null && util.isString(cxxCompiler)) {
-                const fixedPathToCompiler = util.fixPaths(cxxCompiler);
-                if (fixedPathToCompiler !== undefined) {
-                    expandedPreset.cacheVariables['CMAKE_CXX_COMPILER'] = fixedPathToCompiler;
-                }
-            }
-            if (cCompiler != null && util.isString(cCompiler)) {
-                const fixedPathToCompiler = util.fixPaths(cCompiler);
-                if (fixedPathToCompiler !== undefined) {
-                    expandedPreset.cacheVariables['CMAKE_C_COMPILER'] = fixedPathToCompiler;
-                }
-            }
-        }
-        
+        expandedPreset.cacheVariables = {};        
         for (const cacheVarName in preset.cacheVariables) {
             const cacheVar = preset.cacheVariables[cacheVarName];
             if (typeof cacheVar === 'boolean') {

--- a/src/preset.ts
+++ b/src/preset.ts
@@ -808,7 +808,7 @@ export async function expandConfigurePreset(folder: string, name: string, worksp
     }
 
     if (preset.cacheVariables) {
-        expandedPreset.cacheVariables = {};        
+        expandedPreset.cacheVariables = {};
         for (const cacheVarName in preset.cacheVariables) {
             const cacheVar = preset.cacheVariables[cacheVarName];
             if (typeof cacheVar === 'boolean') {
@@ -839,8 +839,8 @@ export async function expandConfigurePreset(folder: string, name: string, worksp
         if (preset.cacheVariables && expandedPreset.cacheVariables) {
             const cxxCompilerPath = getStringValueFromCacheVar(expandedPreset.cacheVariables['CMAKE_CXX_COMPILER']);
             const cCompilerPath = getStringValueFromCacheVar(expandedPreset.cacheVariables['CMAKE_C_COMPILER']);
-            const cxxCompiler = path.basename(cxxCompilerPath||"").toLocaleLowerCase();
-            const cCompiler = path.basename(cCompilerPath||"").toLocaleLowerCase();
+            const cxxCompiler = path.basename(cxxCompilerPath || "").toLocaleLowerCase();
+            const cCompiler = path.basename(cCompilerPath || "").toLocaleLowerCase();
             // The env variables for the supported compilers are the same.
             const compilerName: string | undefined = util.isSupportedCompiler(cxxCompiler) || util.isSupportedCompiler(cCompiler);
 


### PR DESCRIPTION
## This change addresses item

My project is targeting 2 environments [ninja, linux, gcc, x64] and [ninja, windows, msvc, x64]
I have a following preset:

```
{
    "version": 6,
    "configurePresets": [
        {
            "name": "Example",
            "binaryDir": "...",
            "architecture": {
                "value": "x64",
                "strategy": "external"
            },
            "generator": "Ninja",
            "cacheVariables": {
                ...
            }
        }
    ]
}
```

### I expect vscode-cmake-tools:
  - use compiler kit selected using "CMake: Scan For Compilers"
  - if selected compiler is MSVC - configure environment as if vcvars*.bat was executed
  - if cmake was able to find cl.exe - it should pass a cmake compiler check

### Without this change:
  - If no compiler is provided in presets - cmake configure yields error "No CMAKE_CXX_COMPILER could be found."
  - If cl.exe is manually provided though the preset as "cl" or "cl.exe" - configuring and build steps succeed
  - If cl.exe is manually provided as an absolute path - compiler check fails, if circumvented - build fails, as it cannot find standard headers

### With this change
  - When no CMAKE_CXX_COMPILER  is provided in presets selected kit is used
  - when absolute path to cl.exe is provided though environment variables - build succeeds 
  - when cl.exe is provided - build succeeds

### Potential risks
  - I did not limit generator to Ninja and platform to win32, as in my opinion selected kit should be used as a fallback on every platform and for every generator, need your input on that