### PR TITLE
"Package.json: Change scope of cmake.additionalKits"

### DIFF
--- a/package.json
+++ b/package.json
@@ -3453,7 +3453,7 @@
           "items": {
             "type": "string"
           },
-          "scope": "resource"
+          "scope": "machine-overridable"
         },
         "cmake.revealLog": {
           "type": "string",


### PR DESCRIPTION
<!-- Thanks for your contribution! To make things easier, please fill out the template below. -->

<!-- Please delete any unused sections. -->

<!-- Delete the following heading if there is no corresponding issue -->
## This change addresses item #3607

## The purpose of this change
Since the paths it contains are machine-specific paths. It doesn't make sense to share them with others. The correct scope should be `machine-overridable` instead of `resource`.

Fixes: #3607

