### PR TITLE
Fix output for test 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,9 @@ Bug Fixes:
 
 - Fix localization issue in package.json [#3616](https://github.com/microsoft/vscode-cmake-tools/issues/3616)
 - Remove incorrect validation which was breaking references from CMakeUserPresets to CMakePresets [#3636](https://github.com/microsoft/vscode-cmake-tools/issues/3636)
-- Fix 'Debug Test' from 'Test explorer' results in 'launch: property 'program' is missing or empty' [#3280]](https://github.com/microsoft/vscode-cmake-tools/issues/3280)
-- Fix "Go to source" in Testing activity + test panel without function [#3362]](https://github.com/microsoft/vscode-cmake-tools/issues/3362)
+- Fix 'Debug Test' from 'Test explorer' results in 'launch: property 'program' is missing or empty' [#3280](https://github.com/microsoft/vscode-cmake-tools/issues/3280)
+- Fix "Go to source" in Testing activity + test panel without function [#3362](https://github.com/microsoft/vscode-cmake-tools/issues/3362)
+- Fix incorrect test output [#3591](https://github.com/microsoft/vscode-cmake-tools/issues/3591)
 
 ## 1.17.17
 

--- a/src/ctest.ts
+++ b/src/ctest.ts
@@ -369,7 +369,7 @@ export class CTestDriver implements vscode.Disposable {
         if (test.uri && test.range) {
             message.location = new vscode.Location(test.uri, test.range);
         } else {
-            log.info(message);
+            log.info(message.message);
         }
         run.failed(test, message, duration);
     }


### PR DESCRIPTION
We weren't handling a test output correctly, we were trying to output an object rather than the message itself. 