### PR TITLE
remove un-implemented command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,9 @@ Bug Fixes:
 
 - Fix localization issue in package.json [#3616](https://github.com/microsoft/vscode-cmake-tools/issues/3616)
 - Remove incorrect validation which was breaking references from CMakeUserPresets to CMakePresets [#3636](https://github.com/microsoft/vscode-cmake-tools/issues/3636)
-- Fix 'Debug Test' from 'Test explorer' results in 'launch: property 'program' is missing or empty' [#3280]](https://github.com/microsoft/vscode-cmake-tools/issues/3280)
-- Fix "Go to source" in Testing activity + test panel without function [#3362]](https://github.com/microsoft/vscode-cmake-tools/issues/3362)
+- Fix 'Debug Test' from 'Test explorer' results in 'launch: property 'program' is missing or empty' [#3280](https://github.com/microsoft/vscode-cmake-tools/issues/3280)
+- Fix "Go to source" in Testing activity + test panel without function [#3362](https://github.com/microsoft/vscode-cmake-tools/issues/3362)
+- Remove an un-implemented "internal" command [#3596](https://github.com/microsoft/vscode-cmake-tools/issues/3596)
 
 ## 1.17.17
 

--- a/package.json
+++ b/package.json
@@ -401,11 +401,6 @@
         }
       },
       {
-        "command": "cmake.buildNamedTarget",
-        "when": "cmake:enableFullFeatureSet",
-        "title": "%cmake-tools.command.cmake.buildNamedTarget.title%"
-      },
-      {
         "command": "cmake.compileFile",
         "title": "%cmake-tools.command.cmake.compileFile.title%",
         "category": "CMake",

--- a/package.nls.json
+++ b/package.nls.json
@@ -30,7 +30,6 @@
     "cmake-tools.command.cmake.build.title": "Build",
     "cmake-tools.command.cmake.buildAll.title": "Build All Projects",
     "cmake-tools.command.cmake.showBuildCommand.title": "Show Build Command",
-    "cmake-tools.command.cmake.buildNamedTarget.title": "(Internal) Build a Target by Name",
     "cmake-tools.command.cmake.compileFile.title": "Compile Active File",
     "cmake-tools.command.cmake.outline.compileFile.title": "Compile File",
     "cmake-tools.command.cmake.install.title": "Install",


### PR DESCRIPTION
We still exposed a command called `cmake.buildNamedTarget` even though the description had it marked as internal and we didn't have an implementation for it. 

Removing it. 

Fixes #3596 3596