### PR TITLE
allow for --warn-unused-cli

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Bug Fixes:
 
 - Fix localization issue in package.json [#3616](https://github.com/microsoft/vscode-cmake-tools/issues/3616)
 
+Improvements:
+
+- Allow for users to add `--warn-unused-cli`. This will override our default `--no-warn-unused-cli`. [#1090](https://github.com/microsoft/vscode-cmake-tools/issues/1090)
+
 ## 1.17.17
 
 Bug Fixes:

--- a/src/drivers/cmakeDriver.ts
+++ b/src/drivers/cmakeDriver.ts
@@ -1385,7 +1385,8 @@ export abstract class CMakeDriver implements vscode.Disposable {
     public async generateConfigArgsFromSettings(extra_args: string[] = [], withoutCmakeSettings: boolean = false): Promise<string[]> {
         // Cache flags will construct the command line for cmake.
         const init_cache_flags = this.generateInitCacheFlags();
-        const common_flags = ['--no-warn-unused-cli'].concat(extra_args, this.config.configureArgs);
+        const initial_common_flags = extra_args.concat(this.config.configureArgs);
+        const common_flags = initial_common_flags.includes("--warn-unused-cli") ? initial_common_flags : initial_common_flags.concat("--no-warn-unused-cli");
         const define_flags = withoutCmakeSettings ? [] : this.generateCMakeSettingsFlags();
         const final_flags = common_flags.concat(define_flags, init_cache_flags);
 


### PR DESCRIPTION
Address #1090. 

This keeps the integrity of the behavior before we took over the extension, but if a user adds the `--warn-unused-cli` argument, it will override so that users can see warnings. 
