### PR TITLE
Google Test Fix for "Go to test" and "Debug Test"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,9 @@ Bug Fixes:
 
 - Fix localization issue in package.json [#3616](https://github.com/microsoft/vscode-cmake-tools/issues/3616)
 - Remove incorrect validation which was breaking references from CMakeUserPresets to CMakePresets [#3636](https://github.com/microsoft/vscode-cmake-tools/issues/3636)
-
+- Fix 'Debug Test' from 'Test explorer' results in 'launch: property 'program' is missing or empty' [#3280]](https://github.com/microsoft/vscode-cmake-tools/issues/3280)
+- Fix "Go to source" in Testing activity + test panel without function [#3362]](https://github.com/microsoft/vscode-cmake-tools/issues/3362)
+  
 Improvements:
 
 - Allow for users to add `--warn-unused-cli`. This will override our default `--no-warn-unused-cli`. [#1090](https://github.com/microsoft/vscode-cmake-tools/issues/1090)

--- a/src/ctest.ts
+++ b/src/ctest.ts
@@ -1043,7 +1043,13 @@ export class CTestDriver implements vscode.Disposable {
             testExplorer.createRunProfile(
                 'Debug Tests',
                 vscode.TestRunProfileKind.Debug,
-                (request: vscode.TestRunRequest, cancellation: vscode.CancellationToken) => this.debugTestHandler(request, cancellation));
+                (request: vscode.TestRunRequest, cancellation: vscode.CancellationToken) => {
+                    const testProject = this.projectController!.getAllCMakeProjects().filter(
+                        project => request.include![0].uri!.fsPath.includes(project.folderPath)
+                    );
+                    return testProject![0].cTestController.debugTestHandler(request, cancellation);
+                }
+            );
         }
         return testExplorer;
     }

--- a/src/ctest.ts
+++ b/src/ctest.ts
@@ -602,13 +602,32 @@ export class CTestDriver implements vscode.Disposable {
             this.tests = JSON.parse(result.stdout) ?? undefined;
             if (this.tests && this.tests.kind === 'ctestInfo') {
                 this.tests.tests.forEach(test => {
-                    let testItem: vscode.TestItem;
+                    let testItem: vscode.TestItem | undefined;
                     if (test.backtrace !== undefined && this.tests!.backtraceGraph.nodes[test.backtrace] !== undefined) {
-                        const testDefFile = this.tests!.backtraceGraph.files[this.tests!.backtraceGraph.nodes[test.backtrace].file];
-                        const testDefLine = this.tests!.backtraceGraph.nodes[test.backtrace].line;
-                        testItem = initializedTestExplorer.createTestItem(test.name, test.name, vscode.Uri.file(testDefFile));
-                        if (testDefLine !== undefined) {
-                            testItem.range = new vscode.Range(new vscode.Position(testDefLine - 1, 0), new vscode.Position(testDefLine - 1, 0));
+                        // Use DEF_SOURCE_LINE CMake test property to find file and line number
+                        // Property must be set in the test's CMakeLists.txt file or its included modules for this to work
+                        const defSourceLineProperty = test.properties.filter(property => property.name === "DEF_SOURCE_LINE")[0];
+                        if (defSourceLineProperty && defSourceLineProperty.value && typeof defSourceLineProperty.value === 'string') {
+                            // Use RegEx to match the format "file_path:line" in value[0]
+                            const match = defSourceLineProperty.value.match(/(.*):(\d+)/);
+                            if (match && match[1] && match[2]) {
+                                const testDefFile = match[1];
+                                const testDefLine = parseInt(match[2]);
+                                if (!isNaN(testDefLine)) {
+                                    testItem = initializedTestExplorer.createTestItem(test.name, test.name, vscode.Uri.file(testDefFile));
+                                    testItem.range = new vscode.Range(new vscode.Position(testDefLine - 1, 0), new vscode.Position(testDefLine - 1, 0));
+                                }
+                            }
+                        }
+                        if (!testItem) {
+                            // Use the backtrace graph to find the file and line number
+                            // This finds the CMake module's file and line number and not the test file and line number
+                            const testDefFile = this.tests!.backtraceGraph.files[this.tests!.backtraceGraph.nodes[test.backtrace].file];
+                            const testDefLine = this.tests!.backtraceGraph.nodes[test.backtrace].line;
+                            testItem = initializedTestExplorer.createTestItem(test.name, test.name, vscode.Uri.file(testDefFile));
+                            if (testDefLine !== undefined) {
+                                testItem.range = new vscode.Range(new vscode.Position(testDefLine - 1, 0), new vscode.Position(testDefLine - 1, 0));
+                            }
                         }
                     } else {
                         testItem = initializedTestExplorer.createTestItem(test.name, test.name);


### PR DESCRIPTION
## This change addresses items #3280 and #3362

The following changes are proposed:

- Get the location of the test definition from CTest's "DEF_SOURCE_LINE" property
- Fallback to previous behaviour if DEF_SOURCE_LINE does not exist
- Route debug test request to correct CTestDriver based on folder and test URI

## Other Notes/Information

Currently, the CTest executable does not output custom properties (defined using CMake's `define_property` function).

Hence, I have made a  pull request there to address that: https://gitlab.kitware.com/cmake/cmake/-/merge_requests/9305

Note that it falls back to the old behaviour without the CMake pull request merged (which will be CMake 3.29 and above if so).

fixes #3362

Edit:
During testing with my projects, I discovered that the root cause of #3280 is how multi-root workspaces are handled. Fixing now...

Edit 2:
I have fixed #3280 by routing a debug test request to the right CTestDriver using the URI of the test and project.