### PR TITLE
Remove incorrect validation - it only considers the current file when looking for referenced presets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 Bug Fixes:
 
 - Fix localization issue in package.json [#3616](https://github.com/microsoft/vscode-cmake-tools/issues/3616)
+- Remove incorrect validation which was breaking references from CMakeUserPresets to CMakePresets [#3636](https://github.com/microsoft/vscode-cmake-tools/issues/3636)
 
 Improvements:
 

--- a/src/presetsController.ts
+++ b/src/presetsController.ts
@@ -1641,26 +1641,9 @@ export class PresetsController {
             }
         }
 
-        let allBuildTestPackagePresets: (preset.BuildPreset | preset.TestPreset | preset.PackagePreset)[] = presetsFile.buildPresets || [];
-        allBuildTestPackagePresets = allBuildTestPackagePresets.concat(presetsFile.testPresets || []);
-        allBuildTestPackagePresets = allBuildTestPackagePresets.concat(presetsFile.packagePresets || []);
-        for (const pr of allBuildTestPackagePresets) {
-            const cfgPr: preset.ConfigurePreset | undefined = presetsFile.configurePresets?.find(prs => (prs.name === pr.configurePreset));
-            if (pr.configurePreset && !cfgPr) {
-                log.error(localize('referenced.configure.preset.not.found', 'Configure preset "{0}" referenced in preset "{1}" was not found.', pr.configurePreset, pr.name));
-                return undefined;
-            }
-        }
-
         for (const pr of presetsFile.workflowPresets || []) {
             if (pr.steps.length < 1 || pr.steps[0].type !== "configure") {
                 log.error(localize('workflow.does.not.start.configure.step', 'The workflow preset "{0}" does not start with a configure step.', pr.name));
-                return undefined;
-            }
-
-            const cfgPr: preset.ConfigurePreset | undefined = presetsFile.configurePresets?.find(prs => (prs.name === pr.steps[0].name));
-            if (!cfgPr) {
-                log.error(localize('referenced.configure.preset.not.found', 'Configure preset "{0}" referenced in workflow preset "{1}" was not found.', pr.steps[0].name, pr.name));
                 return undefined;
             }
 
@@ -1679,12 +1662,6 @@ export class PresetsController {
                     case "package":
                         searchInPresets = presetsFile.packagePresets;
                         break;
-                }
-
-                const refPr: any | undefined = searchInPresets?.find(prs => (prs.name === step.name));
-                if (!refPr) {
-                    log.error(localize('referenced.preset.not.resolved', 'The {0} preset "{1}" referenced in workflow preset "{2}" was not found.', step.type, step.name, pr.name));
-                    return undefined;
                 }
 
                 if (step.type === "configure" && step !== pr.steps[0]) {

--- a/src/presetsController.ts
+++ b/src/presetsController.ts
@@ -1648,22 +1648,6 @@ export class PresetsController {
             }
 
             for (const step of pr.steps) {
-                let searchInPresets: any[] | undefined;
-                switch (step.type) {
-                    case "configure":
-                        searchInPresets = presetsFile.configurePresets;
-                        break;
-                    case "build":
-                        searchInPresets = presetsFile.buildPresets;
-                        break;
-                    case "test":
-                        searchInPresets = presetsFile.testPresets;
-                        break;
-                    case "package":
-                        searchInPresets = presetsFile.packagePresets;
-                        break;
-                }
-
                 if (step.type === "configure" && step !== pr.steps[0]) {
                     log.error(localize('workflow.has.subsequent.configure.preset', 'The workflow preset "{0}" has another configure preset "{1}" besides the first step "{2}": ', pr.name, step.name, pr.steps[0].name));
                     return undefined;


### PR DESCRIPTION
This issue #3636 points out some incorrect validation that we added in #3548. This PR takes out the incorrect added validation while leaving the correct validation. 