### PR TITLE
Properly set up environment for MSYS toolchains

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Features:
 
 Improvements:
 
+- Properly set up environment for MSYS toolchains. [#2447](https://github.com/microsoft/vscode-cmake-tools/issues/2447) [@Steelskin](https://github.com/Steelskin)
 - Allow for users to add `--warn-unused-cli`. This will override our default `--no-warn-unused-cli`. [#1090](https://github.com/microsoft/vscode-cmake-tools/issues/1090)
 - Add option to disable kit scan by default when a kit isn't selected. [#1461](https://github.com/microsoft/vscode-cmake-tools/issues/1461)
 

--- a/src/kit.ts
+++ b/src/kit.ts
@@ -304,26 +304,48 @@ function isMingw(bin: string): boolean {
 }
 
 async function asMingwKit(bin: string, kit: Kit): Promise<Kit> {
+    // Attempt to derive the MSYS environment name from the compiler prefix.
+    // See https://www.msys2.org/docs/environments/
+    const PREFIX_TO_ENVIRONMENT = new Map<string, string>([
+        ['/usr', 'MSYS'],
+        ['/ucrt64', 'UCRT64'],
+        ['/clang64', 'CLANG64'],
+        ['/clangarm64', 'CLANGARM64'],
+        ['/clang32', 'CLANG32'],
+        ['/mingw64', 'MINGW64'],
+        ['/mingw32', 'MINGW32'],
+    ]);
+
     const binParentPath = path.dirname(bin);
+    const prefixPath = path.dirname(binParentPath);
+    const msysPrefix = '/' + path.basename(prefixPath);
+    const msysEnvironment = PREFIX_TO_ENVIRONMENT.get(msysPrefix);
     const mingwMakePath = path.join(binParentPath, 'mingw32-make.exe');
     const mingwMakeExists = await fs.exists(mingwMakePath);
 
-    // During a scan, binParentPath must be a directory already in the PATH.
-    // Therefore, we will assume that MinGW will remain in the user's PATH
-    // and do not need to record the current state of PATH (leave it to the
-    // user to rescan later or specify an explicit path to MinGW if this
-    // changes).  Additionally, caching the current state of PATH can cause
-    // complications on later invocation when using the kit environment
-    // because its PATH will take precedence.  If a user makes changes to
-    // their PATH later without rescanning for kits, then the kit's cached
-    // PATH will clobber the actual current PATH.  We will, however, record
-    // the MinGW path in case we want to use it later.
-    const ENV_PATH = `${binParentPath}`;
-    kit.environmentVariables = { CMT_MINGW_PATH: ENV_PATH };
+    // binParentPath may not already be in the PATH (for instance, scanning
+    // was done from the "additionalCompilerSearchDirs" property). In addition,
+    // in order to prevent problems during cmake configuration, we should make
+    // sure that the MSYS paths are set before the rest of the path. In
+    // particular, this can be a problem for setups with multiple MSYS
+    // installations. In order to limit the scope of the environment variable,
+    // we only override the PATH if the MSYS environment is known.
+    if (msysEnvironment === undefined) {
+        kit.environmentVariables = { CMT_MINGW_PATH: `${binParentPath}` };
+    } else {
+        const msysBasePath = path.dirname(prefixPath);
+        const msysBinPath = path.join(msysBasePath, 'usr', 'bin');
+        kit.environmentVariables = {
+            MT_MINGW_PATH: `${binParentPath}`,
+            MSYSTEM: `${msysEnvironment}`,
+            MSYSTEM_PREFIX: `${msysPrefix}`,
+            PATH: `${binParentPath}` + ';' + `${msysBinPath}` + ';${env:PATH}',
+        };
+    }
 
     if (mingwMakeExists) {
         // Check for working mingw32-make
-        const execMake = await proc.execute(mingwMakePath, ['-v'], null, { environment: { PATH: ENV_PATH }, timeout: 30000 }).result;
+        const execMake = await proc.execute(mingwMakePath, ['-v'], null, { environment: { PATH: `${binParentPath}` }, timeout: 30000 }).result;
         if (execMake.retc !== 0) {
             log.debug(localize('bad.mingw32-make.binary', 'Bad mingw32-make binary ({0} returns non-zero): {1}', "\"-v\"", bin));
         } else {

--- a/src/kit.ts
+++ b/src/kit.ts
@@ -313,7 +313,7 @@ async function asMingwKit(bin: string, kit: Kit): Promise<Kit> {
         ['/clangarm64', 'CLANGARM64'],
         ['/clang32', 'CLANG32'],
         ['/mingw64', 'MINGW64'],
-        ['/mingw32', 'MINGW32'],
+        ['/mingw32', 'MINGW32']
     ]);
 
     const binParentPath = path.dirname(bin);
@@ -336,16 +336,16 @@ async function asMingwKit(bin: string, kit: Kit): Promise<Kit> {
         const msysBasePath = path.dirname(prefixPath);
         const msysBinPath = path.join(msysBasePath, 'usr', 'bin');
         kit.environmentVariables = {
-            MT_MINGW_PATH: `${binParentPath}`,
+            CMT_MINGW_PATH: `${binParentPath}`,
             MSYSTEM: `${msysEnvironment}`,
             MSYSTEM_PREFIX: `${msysPrefix}`,
-            PATH: `${binParentPath}` + ';' + `${msysBinPath}` + ';${env:PATH}',
+            PATH: `${binParentPath}` + ';' + `${msysBinPath}` + ';${env:PATH}'
         };
     }
 
     if (mingwMakeExists) {
         // Check for working mingw32-make
-        const execMake = await proc.execute(mingwMakePath, ['-v'], null, { environment: { PATH: `${binParentPath}` }, timeout: 30000 }).result;
+        const execMake = await proc.execute(mingwMakePath, ['-v'], null, { environment: { PATH: kit.environmentVariables['CMT_MINGW_PATH'] }, timeout: 30000 }).result;
         if (execMake.retc !== 0) {
             log.debug(localize('bad.mingw32-make.binary', 'Bad mingw32-make binary ({0} returns non-zero): {1}', "\"-v\"", bin));
         } else {


### PR DESCRIPTION
## This change addresses item #2447

### This changes the environment for MSYS toolchains

The following changes are proposed:

- Set `MSYSTEM`, `MSYSTEM_PREFIX` environment variables for MSYS installations.
- Override `PATH` to prepend the MSYS paths.

## Other Notes/Information

This mimics the way MSYS sets up the environment with MSYS shells. In particular, it is necessary for the MSYS binaries to take precedence over the rest of the system or many packages may not be configured properly. For instance, if another MSYS installation is set up in `PATH`, some projects may erroneously use the wrong `sh` binary, resulting in incorrect paths during setup.
