### PR TITLE
Show cmake output when version probe fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Improvements:
 - Properly set up environment for MSYS toolchains. [#2447](https://github.com/microsoft/vscode-cmake-tools/issues/2447) [@Steelskin](https://github.com/Steelskin)
 - Allow for users to add `--warn-unused-cli`. This will override our default `--no-warn-unused-cli`. [#1090](https://github.com/microsoft/vscode-cmake-tools/issues/1090)
 - Add option to disable kit scan by default when a kit isn't selected. [#1461](https://github.com/microsoft/vscode-cmake-tools/issues/1461)
+- Show cmake output when version probe fails. [#3650](https://github.com/microsoft/vscode-cmake-tools/issues/3650)
 
 Bug Fixes:
 

--- a/src/cmake/cmakeExecutable.ts
+++ b/src/cmake/cmakeExecutable.ts
@@ -36,7 +36,8 @@ export async function getCMakeExecutableInformation(path: string): Promise<CMake
         }
 
         try {
-            const execVersion = await proc.execute(path, ['--version']).result;
+            const execOpt: proc.ExecutionOptions = { showOutputOnError: true };
+            const execVersion = await proc.execute(path, ['--version'], null, execOpt).result;
             if (execVersion.retc === 0 && execVersion.stdout) {
                 console.assert(execVersion.stdout);
                 const regexVersion = /cmake.* version (.*?)\r?\n/;
@@ -50,7 +51,7 @@ export async function getCMakeExecutableInformation(path: string): Promise<CMake
                 cmake.isFileApiModeSupported = util.versionGreaterOrEquals(cmake.version, cmake.minimalFileApiModeVersion);
                 cmake.isPresent = true;
             }
-            const debuggerPresent = await proc.execute(path, ['-E', 'capabilities']).result;
+            const debuggerPresent = await proc.execute(path, ['-E', 'capabilities'], null, execOpt).result;
             if (debuggerPresent.retc === 0 && debuggerPresent.stdout) {
                 console.assert(debuggerPresent.stdout);
                 const stdoutJson = JSON.parse(debuggerPresent.stdout);

--- a/src/proc.ts
+++ b/src/proc.ts
@@ -102,6 +102,7 @@ export interface ExecutionOptions {
     outputEncoding?: string;
     overrideLocale?: boolean;
     timeout?: number;
+    showOutputOnError?: boolean;
 }
 
 export function buildCmdStr(command: string, args?: string[]): string {
@@ -206,6 +207,16 @@ export function execute(command: string, args?: string[], outputConsumer?: Outpu
                     log.warning(localize({key: 'process.exit.with.signal', comment: ['The space before and after all placeholders should be preserved.']}, 'The command: {0} exited with code: {1} and signal: {2}', `${cmdstr}`, `${code}`, `${signal}`));
                 } else {
                     log.warning(localize({key: 'process.exit', comment: ['The space before and after all placeholders should be preserved.']}, 'The command: {0} exited with code: {1}', `${cmdstr}`, `${code}`));
+                }
+                if (options?.showOutputOnError) {
+                    if (stdout_acc) {
+                        const output = stdout_acc.trimEnd().replace(/\n/g, '\n\t');
+                        log.warning(localize('process.exit.stdout', 'Command output on standard out: {0}', `${output}`));
+                    }
+                    if (stderr_acc) {
+                        const output = stderr_acc.trimEnd().replace(/\n/g, '\n\t');
+                        log.warning(localize('process.exit.stderr', 'Command output on standard error: {0}', `${output}`));
+                    }
                 }
             }
         });


### PR DESCRIPTION
## This change addresses item #3650

### This improves debuggability for users when the cmake version probe fails.

The following changes are proposed:

- When CMake Tools starts up, it tries to get information about the installed cmake version by executing the `cmake` binary. If the cmake invocation fails with a non-zero exit status, this change logs any standard output and standard error output.