### PR TITLE
Remove unused `getFolderContext()` function

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -308,10 +308,6 @@ export class ExtensionManager implements vscode.Disposable {
         this.extensionActiveCommandsInfo  = { contextUsed: this.contextValues ? {...this.contextValues} : {}, extensionActiveCommands: this.contextValues ? util.thisExtensionActiveCommands(this.contextValues) : [] } as ExtensionActiveCommandsInfo;
     }
 
-    public getFolderContext(folder: vscode.WorkspaceFolder): StateManager {
-        return new StateManager(this.extensionContext, folder);
-    }
-
     public showStatusBar(fullFeatureSet: boolean) {
         this.statusBar.setVisible(fullFeatureSet);
     }


### PR DESCRIPTION
<!-- Thanks for your contribution! To make things easier, please fill out the template below. -->

<!-- Please delete any unused sections. -->

<!-- Delete the following heading if there is no corresponding issue -->

* Since `ExtensionManager.getFolderContext()` is not used, it can be removed.
