### PR TITLE
Fix unnecessary repeating of looking for cl or ninja

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Bug Fixes:
 - Fix "Go to source" in Testing activity + test panel without function [#3362](https://github.com/microsoft/vscode-cmake-tools/issues/3362)
 - Remove an un-implemented "internal" command [#3596](https://github.com/microsoft/vscode-cmake-tools/issues/3596)
 - Fix incorrect test output [#3591](https://github.com/microsoft/vscode-cmake-tools/issues/3591)
+- Fix issue where our searching for cl and ninja was repeatedly unnecessarily, impacting performance. [#3633](https://github.com/microsoft/vscode-cmake-tools/issues/3633)
 
 Improvements:
 

--- a/src/preset.ts
+++ b/src/preset.ts
@@ -43,6 +43,7 @@ export interface Preset {
     condition?: Condition | boolean | null;
     isUserPreset?: boolean;
 
+    __vsDevEnvApplied?: boolean; // Private field to indicate if we have already applied the VS Dev Env.
     __expanded?: boolean; // Private field to indicate if we have already expanded this preset.
     __inheritedPresetCondition?: boolean; // Private field to indicate the fully evaluated inherited preset condition.
     __file?: PresetsFile; // Private field to indicate the file where this preset was defined.
@@ -851,138 +852,6 @@ export async function expandConfigurePreset(folder: string, name: string, worksp
     // Other fields can be copied by reference for simplicity
     merge(expandedPreset, preset);
 
-    let compilerEnv = EnvironmentUtils.createPreserveNull();
-    // [Windows Only] If CMAKE_CXX_COMPILER or CMAKE_C_COMPILER is set as cl, clang, clang-cl, clang-cpp and clang++,
-    // but they are not on PATH, then set the env automatically.
-    if (process.platform === 'win32') {
-        if (preset.cacheVariables) {
-            const cxxCompiler = getStringValueFromCacheVar(preset.cacheVariables['CMAKE_CXX_COMPILER'])?.toLowerCase();
-            const cCompiler = getStringValueFromCacheVar(preset.cacheVariables['CMAKE_C_COMPILER'])?.toLowerCase();
-            // The env variables for the supported compilers are the same.
-            const compilerName: string | undefined = util.isSupportedCompiler(cxxCompiler) || util.isSupportedCompiler(cCompiler);
-
-            // find where.exe using process.env since we're on windows.
-            let whereExecutable;
-            // assume in this call that it exists
-            const whereOutput = await execute('where.exe', ['where.exe'], null, {
-                environment: process.env,
-                silent: true,
-                encoding: 'utf-8',
-                shell: true
-            }).result;
-
-            // now we have a valid where.exe
-
-            if (whereOutput.stdout) {
-                const locations = whereOutput.stdout.split('\r\n');
-                if (locations.length > 0) {
-                    whereExecutable = locations[0];
-                }
-            }
-
-            if (compilerName && whereExecutable) {
-                const compilerLocation = await execute(whereExecutable, [compilerName], null, {
-                    environment: EnvironmentUtils.create(expandedPreset.environment),
-                    silent: true,
-                    encoding: 'utf8',
-                    shell: true
-                }).result;
-
-                if (!compilerLocation.stdout) {
-                    // Not on PATH, need to set env
-                    const arch = getArchitecture(preset);
-                    const toolset = getToolset(preset);
-
-                    // Get version info for all VS instances.
-                    const vsInstalls = await vsInstallations();
-
-                    // The VS installation to grab developer environment from.
-                    let vsInstall: VSInstallation | undefined;
-
-                    // VS generators starting with Visual Studio 15 2017 support CMAKE_GENERATOR_INSTANCE.
-                    // If supported, we should respect this value when defined. If not defined, we should
-                    // set it to ensure CMake chooses the same VS instance as we use here.
-                    // Note that if the user sets this in a toolchain file we won't know about it,
-                    // which could cause configuration to fail. However the user can workaround this by launching
-                    // vscode from the dev prompt of their desired instance.
-                    // https://cmake.org/cmake/help/latest/variable/CMAKE_GENERATOR_INSTANCE.html
-                    let vsGeneratorVersion: number | undefined;
-                    const matches = preset.generator?.match(/Visual Studio (?<version>\d+)/);
-                    if (matches && matches.groups?.version) {
-                        vsGeneratorVersion = parseInt(matches.groups.version);
-                        const useCMakeGeneratorInstance = !isNaN(vsGeneratorVersion) && vsGeneratorVersion >= 15;
-                        const cmakeGeneratorInstance = getStringValueFromCacheVar(preset.cacheVariables['CMAKE_GENERATOR_INSTANCE']);
-                        if (useCMakeGeneratorInstance && cmakeGeneratorInstance) {
-                            const cmakeGeneratorInstanceNormalized = path.normalize(cmakeGeneratorInstance);
-                            vsInstall = vsInstalls.find((vs) => vs.installationPath
-                                    && path.normalize(vs.installationPath) === cmakeGeneratorInstanceNormalized);
-
-                            if (!vsInstall) {
-                                log.warning(localize('specified.vs.not.found',
-                                    "Configure preset {0}: Visual Studio instance specified by {1} was not found, falling back on default instance lookup behavior.",
-                                    preset.name, `CMAKE_GENERATOR_INSTANCE="${cmakeGeneratorInstance}"`));
-                            }
-                        }
-                    }
-
-                    // If VS instance wasn't chosen using CMAKE_GENERATOR_INSTANCE, look up a matching instance
-                    // that supports the specified toolset.
-                    if (!vsInstall) {
-                        // sort VS installs in order of descending version. This ensures we choose the latest supported install first.
-                        vsInstalls.sort((a, b) => -compareVersions(a.installationVersion, b.installationVersion));
-
-                        for (const vs of vsInstalls) {
-                            // Check for existence of vcvars script to determine whether desired host/target architecture is supported.
-                            // toolset.host will be set by getToolset.
-                            if (await getVcVarsBatScript(vs, toolset.host!, arch)) {
-                                // If a toolset version is specified then check to make sure this vs instance has it installed.
-                                if (toolset.version) {
-                                    const availableToolsets = await enumerateMsvcToolsets(vs.installationPath, vs.installationVersion);
-                                    // forcing non-null due to false positive (toolset.version is checked in conditional)
-                                    if (availableToolsets?.find(t => t.startsWith(toolset.version!))) {
-                                        vsInstall = vs;
-                                        break;
-                                    }
-                                } else if (!vsGeneratorVersion || vs.installationVersion.startsWith(vsGeneratorVersion.toString())) {
-                                    // If no toolset version specified then choose the latest VS instance for the given generator
-                                    vsInstall = vs;
-                                    break;
-                                }
-                            }
-                        }
-                    }
-
-                    if (!vsInstall) {
-                        log.error(localize('specified.cl.not.found',
-                            "Configure preset {0}: Compiler {1} with toolset {2} and architecture {3} was not found, you may need to run the 'CMake: Scan for Compilers' command if this toolset exists on your computer.",
-                            preset.name, `"${compilerName}.exe"`, toolset.version ? `"${toolset.version},${toolset.host}"` : `"${toolset.host}"`, `"${arch}"`));
-                    } else {
-                        log.info(localize('using.vs.instance', "Using developer environment from Visual Studio (instance {0}, version {1}, installed at {2})", vsInstall.instanceId, vsInstall.installationVersion, `"${vsInstall.installationPath}"`));
-                        const vsEnv = await varsForVSInstallation(vsInstall, toolset.host!, arch, toolset.version);
-                        compilerEnv = vsEnv ?? EnvironmentUtils.create();
-
-                        // if ninja isn't on path, try to look for it in a VS install
-                        const ninjaLoc = await execute(whereExecutable, ['ninja'], null, {
-                            environment: EnvironmentUtils.create(expandedPreset.environment),
-                            silent: true,
-                            encoding: 'utf8',
-                            shell: true
-                        }).result;
-                        if (!ninjaLoc.stdout) {
-                            const vsCMakePaths = await paths.vsCMakePaths(vsInstall.instanceId);
-                            if (vsCMakePaths.ninja) {
-                                log.warning(localize('ninja.not.set', 'Ninja is not set on PATH, trying to use {0}', vsCMakePaths.ninja));
-                                compilerEnv['PATH'] = `${path.dirname(vsCMakePaths.ninja)};${compilerEnv['PATH']}`;
-                            }
-                        }
-
-                        expandedPreset.environment = EnvironmentUtils.mergePreserveNull([expandedPreset.environment, compilerEnv]);
-                    }
-                }
-            }
-        }
-    }
-
     return expandedPreset;
 }
 
@@ -1091,6 +960,142 @@ async function expandConfigurePresetImpl(folder: string, name: string, workspace
 
 async function expandConfigurePresetHelper(folder: string, preset: ConfigurePreset, workspaceFolder: string, sourceDir: string, allowUserPreset: boolean = false) {
     if (preset.__expanded) {
+        if (!preset.__vsDevEnvApplied) {
+            let compilerEnv = EnvironmentUtils.createPreserveNull();
+            // [Windows Only] If CMAKE_CXX_COMPILER or CMAKE_C_COMPILER is set as cl, clang, clang-cl, clang-cpp and clang++,
+            // but they are not on PATH, then set the env automatically.
+            if (process.platform === 'win32') {
+                if (preset.cacheVariables) {
+                    const cxxCompiler = getStringValueFromCacheVar(preset.cacheVariables['CMAKE_CXX_COMPILER'])?.toLowerCase();
+                    const cCompiler = getStringValueFromCacheVar(preset.cacheVariables['CMAKE_C_COMPILER'])?.toLowerCase();
+                    // The env variables for the supported compilers are the same.
+                    const compilerName: string | undefined = util.isSupportedCompiler(cxxCompiler) || util.isSupportedCompiler(cCompiler);
+
+                    // find where.exe using process.env since we're on windows.
+                    let whereExecutable;
+                    // assume in this call that it exists
+                    const whereOutput = await execute('where.exe', ['where.exe'], null, {
+                        environment: process.env,
+                        silent: true,
+                        encoding: 'utf-8',
+                        shell: true
+                    }).result;
+
+                    // now we have a valid where.exe
+
+                    if (whereOutput.stdout) {
+                        const locations = whereOutput.stdout.split('\r\n');
+                        if (locations.length > 0) {
+                            whereExecutable = locations[0];
+                        }
+                    }
+
+                    if (compilerName && whereExecutable) {
+                        const compilerLocation = await execute(whereExecutable, [compilerName], null, {
+                            environment: EnvironmentUtils.create(preset.environment),
+                            silent: true,
+                            encoding: 'utf8',
+                            shell: true
+                        }).result;
+
+                        if (!compilerLocation.stdout) {
+                            // Not on PATH, need to set env
+                            const arch = getArchitecture(preset);
+                            const toolset = getToolset(preset);
+
+                            // Get version info for all VS instances.
+                            const vsInstalls = await vsInstallations();
+
+                            // The VS installation to grab developer environment from.
+                            let vsInstall: VSInstallation | undefined;
+
+                            // VS generators starting with Visual Studio 15 2017 support CMAKE_GENERATOR_INSTANCE.
+                            // If supported, we should respect this value when defined. If not defined, we should
+                            // set it to ensure CMake chooses the same VS instance as we use here.
+                            // Note that if the user sets this in a toolchain file we won't know about it,
+                            // which could cause configuration to fail. However the user can workaround this by launching
+                            // vscode from the dev prompt of their desired instance.
+                            // https://cmake.org/cmake/help/latest/variable/CMAKE_GENERATOR_INSTANCE.html
+                            let vsGeneratorVersion: number | undefined;
+                            const matches = preset.generator?.match(/Visual Studio (?<version>\d+)/);
+                            if (matches && matches.groups?.version) {
+                                vsGeneratorVersion = parseInt(matches.groups.version);
+                                const useCMakeGeneratorInstance = !isNaN(vsGeneratorVersion) && vsGeneratorVersion >= 15;
+                                const cmakeGeneratorInstance = getStringValueFromCacheVar(preset.cacheVariables['CMAKE_GENERATOR_INSTANCE']);
+                                if (useCMakeGeneratorInstance && cmakeGeneratorInstance) {
+                                    const cmakeGeneratorInstanceNormalized = path.normalize(cmakeGeneratorInstance);
+                                    vsInstall = vsInstalls.find((vs) => vs.installationPath
+                                            && path.normalize(vs.installationPath) === cmakeGeneratorInstanceNormalized);
+
+                                    if (!vsInstall) {
+                                        log.warning(localize('specified.vs.not.found',
+                                            "Configure preset {0}: Visual Studio instance specified by {1} was not found, falling back on default instance lookup behavior.",
+                                            preset.name, `CMAKE_GENERATOR_INSTANCE="${cmakeGeneratorInstance}"`));
+                                    }
+                                }
+                            }
+
+                            // If VS instance wasn't chosen using CMAKE_GENERATOR_INSTANCE, look up a matching instance
+                            // that supports the specified toolset.
+                            if (!vsInstall) {
+                                // sort VS installs in order of descending version. This ensures we choose the latest supported install first.
+                                vsInstalls.sort((a, b) => -compareVersions(a.installationVersion, b.installationVersion));
+
+                                for (const vs of vsInstalls) {
+                                    // Check for existence of vcvars script to determine whether desired host/target architecture is supported.
+                                    // toolset.host will be set by getToolset.
+                                    if (await getVcVarsBatScript(vs, toolset.host!, arch)) {
+                                        // If a toolset version is specified then check to make sure this vs instance has it installed.
+                                        if (toolset.version) {
+                                            const availableToolsets = await enumerateMsvcToolsets(vs.installationPath, vs.installationVersion);
+                                            // forcing non-null due to false positive (toolset.version is checked in conditional)
+                                            if (availableToolsets?.find(t => t.startsWith(toolset.version!))) {
+                                                vsInstall = vs;
+                                                break;
+                                            }
+                                        } else if (!vsGeneratorVersion || vs.installationVersion.startsWith(vsGeneratorVersion.toString())) {
+                                            // If no toolset version specified then choose the latest VS instance for the given generator
+                                            vsInstall = vs;
+                                            break;
+                                        }
+                                    }
+                                }
+                            }
+
+                            if (!vsInstall) {
+                                log.error(localize('specified.cl.not.found',
+                                    "Configure preset {0}: Compiler {1} with toolset {2} and architecture {3} was not found, you may need to run the 'CMake: Scan for Compilers' command if this toolset exists on your computer.",
+                                    preset.name, `"${compilerName}.exe"`, toolset.version ? `"${toolset.version},${toolset.host}"` : `"${toolset.host}"`, `"${arch}"`));
+                            } else {
+                                log.info(localize('using.vs.instance', "Using developer environment from Visual Studio (instance {0}, version {1}, installed at {2})", vsInstall.instanceId, vsInstall.installationVersion, `"${vsInstall.installationPath}"`));
+                                const vsEnv = await varsForVSInstallation(vsInstall, toolset.host!, arch, toolset.version);
+                                compilerEnv = vsEnv ?? EnvironmentUtils.create();
+
+                                // if ninja isn't on path, try to look for it in a VS install
+                                const ninjaLoc = await execute(whereExecutable, ['ninja'], null, {
+                                    environment: EnvironmentUtils.create(preset.environment),
+                                    silent: true,
+                                    encoding: 'utf8',
+                                    shell: true
+                                }).result;
+                                if (!ninjaLoc.stdout) {
+                                    const vsCMakePaths = await paths.vsCMakePaths(vsInstall.instanceId);
+                                    if (vsCMakePaths.ninja) {
+                                        log.warning(localize('ninja.not.set', 'Ninja is not set on PATH, trying to use {0}', vsCMakePaths.ninja));
+                                        compilerEnv['PATH'] = `${path.dirname(vsCMakePaths.ninja)};${compilerEnv['PATH']}`;
+                                    }
+                                }
+
+                                preset.environment = EnvironmentUtils.mergePreserveNull([preset.environment, compilerEnv]);
+                            }
+                        }
+                    }
+                }
+            }
+
+            preset.__vsDevEnvApplied = true;
+        }
+
         return preset;
     }
 


### PR DESCRIPTION
We had done a recent refactor of this code. While it fixed other issues, it introduced perf slowdown because we looked for these extra environment locations multiple times now. 

This should fix this. 