### PR TITLE
Fix preset environment replacement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Bug Fixes:
 - Remove an un-implemented "internal" command [#3596](https://github.com/microsoft/vscode-cmake-tools/issues/3596)
 - Fix incorrect test output [#3591](https://github.com/microsoft/vscode-cmake-tools/issues/3591)
 - Fix issue where our searching for cl and ninja was repeatedly unnecessarily, impacting performance. [#3633](https://github.com/microsoft/vscode-cmake-tools/issues/3633)
+- Fix preset environment issue. [#3657](https://github.com/microsoft/vscode-cmake-tools/issues/3657) 
 
 Improvements:
 

--- a/src/preset.ts
+++ b/src/preset.ts
@@ -780,11 +780,12 @@ export async function expandConfigurePreset(folder: string, name: string, worksp
         return null;
     }
 
+    preset.environment = EnvironmentUtils.mergePreserveNull([process.env, preset.environment]);
+
     // Expand strings under the context of current preset
     const expandedPreset: ConfigurePreset = { name };
     const expansionOpts: ExpansionOptions = await getExpansionOptions(workspaceFolder, sourceDir, preset);
 
-    preset.environment = EnvironmentUtils.mergePreserveNull([process.env, preset.environment]);
     // Expand environment vars first since other fields may refer to them
     if (preset.environment) {
         expandedPreset.environment = EnvironmentUtils.createPreserveNull();


### PR DESCRIPTION
We weren't using the preset.environment AND the process.environment when trying to expand our strings. This fixes that and should fix #3657 