### PR TITLE
Correctly parse target arch when version is included

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,8 @@ Bug Fixes:
 - Remove an un-implemented "internal" command [#3596](https://github.com/microsoft/vscode-cmake-tools/issues/3596)
 - Fix incorrect test output [#3591](https://github.com/microsoft/vscode-cmake-tools/issues/3591)
 - Fix issue where our searching for cl and ninja was repeatedly unnecessarily, impacting performance. [#3633](https://github.com/microsoft/vscode-cmake-tools/issues/3633)
-- Fix preset environment issue. [#3657](https://github.com/microsoft/vscode-cmake-tools/issues/3657) 
+- Fix preset environment issue. [#3657](https://github.com/microsoft/vscode-cmake-tools/issues/3657)
+- Fix invocation of vcvarsall.bat script argument for targetArch. [#3672](https://github.com/microsoft/vscode-cmake-tools/issues/3672)
 
 Improvements:
 

--- a/src/installs/visualStudio.ts
+++ b/src/installs/visualStudio.ts
@@ -173,7 +173,7 @@ export function getHostTargetArchString(hostArch: string, targetArch?: string, a
     }
 
     const parsedTargetArch = targetArch.split(",");
-    const version = parsedTargetArch.filter(a => a.includes("=")).map(a => a.split("=")[1]).join(" ").trimEnd();
+    const version = parsedTargetArch.filter(a => a.includes("version=")).map(a => a.split("=")[1]).join(" ").trimEnd();
     // The platform can only be first in the list: https://cmake.org/cmake/help/latest/variable/CMAKE_GENERATOR_PLATFORM.html#variable:CMAKE_GENERATOR_PLATFORM
     // If the first entry in the list includes an "=", it is the version, so we need to use the host arch.
     targetArch = parsedTargetArch[0].includes("=") ? hostArch : parsedTargetArch[0];

--- a/src/installs/visualStudio.ts
+++ b/src/installs/visualStudio.ts
@@ -168,6 +168,9 @@ export function getHostTargetArchString(hostArch: string, targetArch?: string, a
 
     if (!targetArch) {
         targetArch = hostArch;
+    } else {
+        const parsedTargetArch = targetArch.split(",")[0];
+        targetArch = parsedTargetArch.includes("=") ? hostArch : parsedTargetArch;
     }
 
     // CMake preferred generator platform requires 'win32', while vcvars are still using 'x86'.

--- a/src/installs/visualStudio.ts
+++ b/src/installs/visualStudio.ts
@@ -144,8 +144,10 @@ export function targetArchFromGeneratorPlatform(generatorPlatform?: string) {
  * @param hostArch The architecture of the host toolset
  * @param targetArch The architecture of the target
  * @param amd64Alias Whether amd64 is preferred over x64.
+ * @param includeVersion Whether to include the version. Since we use this method to get the name of the vcvars script in certain
+ *                     cases, we can't include the version in the name, only in the execution of the script when we're getting arguments.
  */
-export function getHostTargetArchString(hostArch: string, targetArch?: string, amd64Alias: boolean = false): string {
+export function getHostTargetArchString(hostArch: string, targetArch?: string, amd64Alias: boolean = false, includeVersion: boolean = false): string {
     // There are cases when we don't want to use the 'x64' alias of the 'amd64' architecture,
     // like for older VS installs, for the VS kit names (for compatibility reasons)
     // or for arm/arm64 specific vcvars scripts.
@@ -168,10 +170,13 @@ export function getHostTargetArchString(hostArch: string, targetArch?: string, a
 
     if (!targetArch) {
         targetArch = hostArch;
-    } else {
-        const parsedTargetArch = targetArch.split(",")[0];
-        targetArch = parsedTargetArch.includes("=") ? hostArch : parsedTargetArch;
     }
+
+    const parsedTargetArch = targetArch.split(",");
+    const version = parsedTargetArch.filter(a => a.includes("=")).map(a => a.split("=")[1]).join(" ").trimEnd();
+    // The platform can only be first in the list: https://cmake.org/cmake/help/latest/variable/CMAKE_GENERATOR_PLATFORM.html#variable:CMAKE_GENERATOR_PLATFORM
+    // If the first entry in the list includes an "=", it is the version, so we need to use the host arch.
+    targetArch = parsedTargetArch[0].includes("=") ? hostArch : parsedTargetArch[0];
 
     // CMake preferred generator platform requires 'win32', while vcvars are still using 'x86'.
     // This function is called only for VS generators, so it is safe to overwrite
@@ -182,7 +187,8 @@ export function getHostTargetArchString(hostArch: string, targetArch?: string, a
     // because CMake host target does not have the same name mismatch with VS.
     targetArch = targetArchFromGeneratorPlatform(targetArch);
 
-    return (hostArch === targetArch) ? hostArch : `${hostArch}_${targetArch}`;
+    const archValue = (hostArch === targetArch) ? hostArch : `${hostArch}_${targetArch}`;
+    return  includeVersion ? `${archValue} ${version}` : archValue;
 }
 
 // Gets the MSVC toolsets installed for a given VS install.
@@ -466,7 +472,7 @@ export async function varsForVSInstallation(inst: VSInstallation, hostArch: stri
         return null;
     }
 
-    const devBatArgs = [getHostTargetArchString(hostArch, targetArch, majorVersion < 15)];
+    const devBatArgs = [getHostTargetArchString(hostArch, targetArch, majorVersion < 15, true)];
     if (toolsetVersion && majorVersion >= 15) {
         devBatArgs.push(`-vcvars_ver=${toolsetVersion}`);
     }


### PR DESCRIPTION
This addresses #3672. 

The issue was that we weren't parsing the targetArch correctly when the `version` was included. See [here](https://cmake.org/cmake/help/latest/variable/CMAKE_GENERATOR_PLATFORM.html#variable:CMAKE_GENERATOR_PLATFORM).

We pass a `includeVersion` boolean that defaults to false, because we also use this method to get the name of the script to call in arm scenarios, and we shouldn't include the version then. Only when we're getting the script args should we include the version. 