### PR TITLE
ensure that we replace macros

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ Bug Fixes:
 - Fix issue where our searching for cl and ninja was repeatedly unnecessarily, impacting performance. [#3633](https://github.com/microsoft/vscode-cmake-tools/issues/3633)
 - Fix preset environment issue. [#3657](https://github.com/microsoft/vscode-cmake-tools/issues/3657)
 - Fix invocation of vcvarsall.bat script argument for targetArch. [#3672](https://github.com/microsoft/vscode-cmake-tools/issues/3672)
+- Ensure that we support ${workspaceFolder} when initializing cmake information. [#3658](https://github.com/microsoft/vscode-cmake-tools/issues/3658)
+
 
 ## 1.17.17
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -121,8 +121,13 @@ export class ExtensionManager implements vscode.Disposable {
         this.updateTouchBarVisibility(this.workspaceConfig.touchbar);
         this.workspaceConfig.onChange('touchbar', config => this.updateTouchBarVisibility(config));
 
+        let cmakePath = this.workspaceConfig.rawCMakePath;
+        if (vscode.workspace.workspaceFolders && vscode.workspace.workspaceFolders[0]) {
+            const workspaceContext = DirectoryContext.createForDirectory(vscode.workspace.workspaceFolders[0], new StateManager(this.extensionContext, vscode.workspace.workspaceFolders[0]));
+            cmakePath = await workspaceContext.getCMakePath() || '';
+        }
         // initialize the state of the cmake exe
-        await getCMakeExecutableInformation(this.workspaceConfig.rawCMakePath);
+        await getCMakeExecutableInformation(cmakePath);
 
         await util.setContextValue("cmake:testExplorerIntegrationEnabled", this.workspaceConfig.testExplorerIntegrationEnabled);
         this.workspaceConfig.onChange("ctest", async (value) => {


### PR DESCRIPTION
Ensure that we do macro replacement on initial cmake.exe test. 

Fixes #3658. 