### PR TITLE
Sort pre-releases lower than releases

### DIFF
--- a/src/preset.ts
+++ b/src/preset.ts
@@ -1040,7 +1040,14 @@ async function tryApplyVsDevEnv(preset: ConfigurePreset) {
                         // that supports the specified toolset.
                         if (!vsInstall) {
                             // sort VS installs in order of descending version. This ensures we choose the latest supported install first.
-                            vsInstalls.sort((a, b) => -compareVersions(a.installationVersion, b.installationVersion));
+                            vsInstalls.sort((a, b) => {
+                                if (a.isPrerelease && !b.isPrerelease) {
+                                    return 1;
+                                } else if (!a.isPrerelease && b.isPrerelease) {
+                                    return -1;
+                                }
+                                return -compareVersions(a.installationVersion, b.installationVersion);
+                            });
 
                             for (const vs of vsInstalls) {
                                 // Check for existence of vcvars script to determine whether desired host/target architecture is supported.


### PR DESCRIPTION
### This changes behavior

**The following changes are proposed:**
When configuring with presets and using the Ninja generator on Windows with MSVC, deprioritize using any pre-releases installed when setting the environment.

## Other Notes/Information
I don't see a way currently to get CMake to use release compilers using just the Presets themselves.  This may be a development preference, so a setting may be warranted for this.  However, I didn't see an easy way to get settings evaluated during preset expansion.  I started work on that in case you would prefer that route, but am not finished and it could take a little while as there is a bit of plumbing involved.