### PR TITLE
support vscode variable in debugConfig environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Improvements:
 - Improve various settings scopes [#3601](https://github.com/microsoft/vscode-cmake-tools/issues/3601)
 - Refactor the Project Outline view to show a flat list of targets [#491](https://github.com/microsoft/vscode-cmake-tools/issues/491), [#3684](https://github.com/microsoft/vscode-cmake-tools/issues/3684)
 - Add the ability to pin CMake Commands to the sidebar [#2984](https://github.com/microsoft/vscode-cmake-tools/issues/2984) & [#3296](https://github.com/microsoft/vscode-cmake-tools/issues/3296)
+- Add support for variable expansion in `debugConfig.environment` [#3711](https://github.com/microsoft/vscode-cmake-tools/issues/3711)
 
 Bug Fixes:
 

--- a/src/cmakeProject.ts
+++ b/src/cmakeProject.ts
@@ -2659,6 +2659,14 @@ export class CMakeProject {
         // Add debug configuration from settings.
         const userConfig = this.workspaceContext.config.debugConfig;
         Object.assign(debugConfig, userConfig);
+
+        const options = await this.getExpansionOptions();
+        if (debugConfig.environment) {
+            for (const env of debugConfig.environment) {
+                env.value = await expandString(env.value, options);
+            }
+        }
+
         const launchEnv = await this.getTargetLaunchEnvironment(drv, debugConfig.environment);
         debugConfig.environment = util.makeDebuggerEnvironmentVars(launchEnv);
         log.debug(localize('starting.debugger.with', 'Starting debugger with following configuration.'), JSON.stringify({


### PR DESCRIPTION
<!-- Delete the following heading if there is no corresponding issue -->
## This change addresses item #3711 

### This changes src\cmakeProject.ts

The following changes are proposed:
``` TypeScript
if (debugConfig.environment) {
    for (const env of debugConfig.environment) {
        env.value = await expandString(env.value, await this.getExpansionOptions());
    }
}
```

## The purpose of this change
resolve the vscode variable in debugConfig environment