### PR TITLE
fix cmake-tools-schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Bug Fixes:
 - Fix invocation of vcvarsall.bat script argument for targetArch. [#3672](https://github.com/microsoft/vscode-cmake-tools/issues/3672)
 - Ensure that we support ${workspaceFolder} when initializing cmake information. [#3658](https://github.com/microsoft/vscode-cmake-tools/issues/3658)
 - Fix issue where correcting `cmake.cmakePath` is still broken. [#3570](https://github.com/microsoft/vscode-cmake-tools/issues/3570)
+- Fix CMakePresets.json schema validation. [#3651](https://github.com/microsoft/vscode-cmake-tools/issues/3651)
 
 ## 1.17.17
 

--- a/package.json
+++ b/package.json
@@ -3646,7 +3646,7 @@
     "yamlValidation": [
       {
         "fileMatch": "cmake-variants.yaml",
-        "url": "cmake-tools-schema:./schemas/variants-schema.json"
+        "url": "cmake-tools-schema://schemas/variants-schema.json"
       }
     ],
     "jsonValidation": [

--- a/package.json
+++ b/package.json
@@ -62,7 +62,8 @@
     "workspaceContains:*/*/CMakeLists.txt",
     "workspaceContains:*/*/*/CMakeLists.txt",
     "workspaceContains:.vscode/cmake-kits.json",
-    "onLanguage:cmake"
+    "onLanguage:cmake",
+    "onFileSystem:cmake-tools-schema"
   ],
   "main": "./dist/main",
   "contributes": {
@@ -3645,29 +3646,29 @@
     "yamlValidation": [
       {
         "fileMatch": "cmake-variants.yaml",
-        "url": "cmake-tools-schema:///schemas/variants-schema.json"
+        "url": "cmake-tools-schema:./schemas/variants-schema.json"
       }
     ],
     "jsonValidation": [
       {
         "fileMatch": "cmake-variants.json",
-        "url": "cmake-tools-schema:///schemas/variants-schema.json"
+        "url": "cmake-tools-schema://schemas/variants-schema.json"
       },
       {
         "fileMatch": "cmake-variants.yaml",
-        "url": "cmake-tools-schema:///schemas/variants-schema.json"
+        "url": "cmake-tools-schema://schemas/variants-schema.json"
       },
       {
         "fileMatch": "cmake-kits.json",
-        "url": "cmake-tools-schema:///schemas/kits-schema.json"
+        "url": "cmake-tools-schema://schemas/kits-schema.json"
       },
       {
         "fileMatch": "CMakePresets.json",
-        "url": "cmake-tools-schema:///schemas/CMakePresets-v8-schema.json"
+        "url": "cmake-tools-schema://schemas/CMakePresets-v4-schema.json"
       },
       {
         "fileMatch": "CMakeUserPresets.json",
-        "url": "cmake-tools-schema:///schemas/CMakePresets-v8-schema.json"
+        "url": "cmake-tools-schema://schemas/CMakePresets-v4-schema.json"
       }
     ]
   },

--- a/package.json
+++ b/package.json
@@ -3664,11 +3664,11 @@
       },
       {
         "fileMatch": "CMakePresets.json",
-        "url": "cmake-tools-schema://schemas/CMakePresets-v4-schema.json"
+        "url": "cmake-tools-schema://schemas/CMakePresets-v8-schema.json"
       },
       {
         "fileMatch": "CMakeUserPresets.json",
-        "url": "cmake-tools-schema://schemas/CMakePresets-v4-schema.json"
+        "url": "cmake-tools-schema://schemas/CMakePresets-v8-schema.json"
       }
     ]
   },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2306,7 +2306,7 @@ class SchemaProvider implements vscode.TextDocumentContentProvider {
         let localizedFilePath: string = path.join(util.thisExtensionPath(), "dist/schema/", locale, fileName);
         const fileExists: boolean = await util.checkFileExists(localizedFilePath);
         if (!fileExists) {
-            localizedFilePath = path.join(util.thisExtensionPath(), fileName);
+            localizedFilePath = path.join(util.thisExtensionPath(), "schemas", fileName);
         }
         return fs.readFile(localizedFilePath, "utf8");
     }


### PR DESCRIPTION
<!-- Thanks for your contribution! To make things easier, please fill out the template below. -->

<!-- Please delete any unused sections. -->

<!-- Delete the following heading if there is no corresponding issue -->
## This change addresses item #3651 

### This changes our activation to help fix the issues where we weren't providing the localized schema. 

This adds the `onFileSystem:cmake-tools-schema` activation event. If any file that has that schema is opened, we activate. 

In short, because we possibly aren't activated yet when someone looks at a CMakePresets.json, the `provideTextDocumentContent` method isn't called once our extension is activated. Therefore, if we slightly fix our `url` for the presets and our activation events, this will fix the issues with the schema for CMakePresets.json