### PR TITLE
Bump dev container Dockerfile to node 16, from 14

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -5,7 +5,7 @@
 
 # To fully customize the contents of this image, use the following Dockerfile instead:
 # https://github.com/microsoft/vscode-dev-containers/tree/v0.128.0/containers/typescript-node-10/.devcontainer/Dockerfile
-FROM mcr.microsoft.com/vscode/devcontainers/typescript-node:14
+FROM mcr.microsoft.com/vscode/devcontainers/typescript-node:16
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \


### PR DESCRIPTION
This extension doesn't build with node 14 anymore:

"""
error @vscode/test-electron@2.3.8: The engine "node" is incompatible with this module. Expected version ">=16". Got "14.21.3"
"""

