### PR TITLE
Fixes #3140 - Test log unavailable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Features:
 
 Bug Fixes:
 
+- Fix issue "Logs are unavailable when running tests from the Test Explorer" and display properly the test output. [#3140](https://github.com/microsoft/vscode-cmake-tools/issues/3140)
 - Fix issue with "Test Results Not Found" when `cmake.ctest.allowParallelJobs` is disabled. [#3798](https://github.com/microsoft/vscode-cmake-tools/issues/3798)
 - Update localized strings for Project Status UI and quick pick dropdowns. [#3803](https://github.com/microsoft/vscode-cmake-tools/issues/3803), [#3802](https://github.com/microsoft/vscode-cmake-tools/issues/3802)
 

--- a/src/ctest.ts
+++ b/src/ctest.ts
@@ -528,7 +528,7 @@ export class CTestDriver implements vscode.Disposable {
         let output = testResult.output;
         // https://code.visualstudio.com/api/extension-guides/testing#test-output
         output = output.replace(/\r?\n/g, '\r\n');
-        run.appendOutput(output);
+        run.appendOutput(output, undefined, test);
 
         if (testResult.status !== 'passed' && !havefailures) {
             const failureDurationStr = testResult.measurements.get("Execution Time")?.value;

--- a/src/ctest.ts
+++ b/src/ctest.ts
@@ -526,9 +526,8 @@ export class CTestDriver implements vscode.Disposable {
         }
 
         let output = testResult.output;
-        if (process.platform === 'win32') {
-            output = output.replace(/\r?\n/g, '\r\n');
-        }
+        // https://code.visualstudio.com/api/extension-guides/testing#test-output
+        output = output.replace(/\r?\n/g, '\r\n');
         run.appendOutput(output);
 
         if (testResult.status !== 'passed' && !havefailures) {

--- a/src/ctest.ts
+++ b/src/ctest.ts
@@ -528,7 +528,11 @@ export class CTestDriver implements vscode.Disposable {
         let output = testResult.output;
         // https://code.visualstudio.com/api/extension-guides/testing#test-output
         output = output.replace(/\r?\n/g, '\r\n');
-        run.appendOutput(output, undefined, test);
+        if (test.uri && test.range) {
+            run.appendOutput(output, new vscode.Location(test.uri, test.range.end), test);
+        } else {
+            run.appendOutput(output, undefined, test);
+        }
 
         if (testResult.status !== 'passed' && !havefailures) {
             const failureDurationStr = testResult.measurements.get("Execution Time")?.value;
@@ -961,7 +965,7 @@ export class CTestDriver implements vscode.Disposable {
             .find(test => test.name === testName)?.properties
             .find(prop => prop.name === 'WORKING_DIRECTORY');
 
-        if (typeof(property?.value) === 'string') {
+        if (typeof (property?.value) === 'string') {
             return property.value;
         }
         return '';


### PR DESCRIPTION
<!-- Thanks for your contribution! To make things easier, please fill out the template below. -->

<!-- Please delete any unused sections. -->

<!-- Delete the following heading if there is no corresponding issue -->
## This change addresses item #3140

### This changes visible behavior

The following changes are proposed:

- Replace \n whith \r\n in the test output string just before appending it to the output. This was done for win32 systems but it shoud be done for any system.
This way the text displayed in the `Test Results` pane is correctly formatted

- Adds test item in the call to appendOutput so that the output of each test is reachable in the left part of the `Test Results` pane when clicking on the test in the right part of the same pane.

## Other Notes/Information

I did not add test yet. I'll be happy to do so but i need some help or documentation.
