### PR TITLE
reversed order of creating workspace browse configurations

### DIFF
--- a/src/cpptools.ts
+++ b/src/cpptools.ts
@@ -594,8 +594,8 @@ export class CppConfigurationProvider implements cpptools.CustomConfigurationPro
         for (const config of opts.codeModelContent.configurations) {
             // Update only the active build type variant.
             if (config.name === opts.activeBuildTypeVariant || (!opts.activeBuildTypeVariant && config.name === "")) {
-                for (const project of config.projects.reverse()) {
-                    for (const target of project.targets.reverse()) {
+                for (const project of config.projects) {
+                    for (const target of project.targets) {
                         // Now some shenanigans since header files don't have config data:
                         // 1. Accumulate some "defaults" based on the set of all options for each file group
                         // 2. Pass these "defaults" down when rebuilding the config data

--- a/src/cpptools.ts
+++ b/src/cpptools.ts
@@ -594,12 +594,13 @@ export class CppConfigurationProvider implements cpptools.CustomConfigurationPro
         for (const config of opts.codeModelContent.configurations) {
             // Update only the active build type variant.
             if (config.name === opts.activeBuildTypeVariant || (!opts.activeBuildTypeVariant && config.name === "")) {
-                for (const project of config.projects) {
-                    for (const target of project.targets) {
+                for (const project of config.projects.reverse()) {
+                    for (const target of project.targets.reverse()) {
                         // Now some shenanigans since header files don't have config data:
                         // 1. Accumulate some "defaults" based on the set of all options for each file group
                         // 2. Pass these "defaults" down when rebuilding the config data
                         // 3. Any `fileGroup` that does not have the associated attribute will receive the `default`
+                        target.fileGroups?.reverse();
                         const grps = target.fileGroups || [];
                         const includePath = [...new Set(util.flatMap(grps, grp => grp.includePath || []))].map(item => item.path);
                         const compileCommandFragments = [...util.first(grps, grp => grp.compileCommandFragments || [])];

--- a/test/unit-tests/cpptools.test.ts
+++ b/test/unit-tests/cpptools.test.ts
@@ -235,12 +235,12 @@ suite('CppTools tests', () => {
 
         configurations = await provider.provideConfigurations([uri1]);
         expect(configurations.length).to.eq(1);
-        expect(configurations[0].configuration.defines).to.contain('FLAG1');
+        expect(configurations[0].configuration.defines).to.contain('FLAG2');
 
         provider.updateConfigurationData({ cache, codeModelContent: codeModel1, activeTarget: 'target2', activeBuildTypeVariant: 'Release', folder: here });
         configurations = await provider.provideConfigurations([uri1]);
         expect(configurations.length).to.eq(1);
-        expect(configurations[0].configuration.defines).to.contain('FLAG2');
+        expect(configurations[0].configuration.defines).to.contain('FLAG1');
         expect(configurations[0].configuration.compilerPath).to.eq('clang++');
 
         provider.updateConfigurationData({ cache, codeModelContent: codeModel1, activeTarget: 'all', activeBuildTypeVariant: 'Release', folder: here });
@@ -341,15 +341,15 @@ suite('CppTools tests', () => {
 
         configurations = await provider.provideConfigurations([uri1]);
         expect(configurations.length).to.eq(1);
-        expect(configurations[0].configuration.defines).to.contain('DEFINE1');
-        expect(configurations[0].configuration.compilerFragments).to.contain('-DFRAGMENT1');
+        expect(configurations[0].configuration.defines).to.contain('DEFINE2');
+        expect(configurations[0].configuration.compilerFragments).to.contain('-DFRAGMENT2');
         expect(configurations[0].configuration.compilerArgs).to.be.empty;
 
         provider.updateConfigurationData({ cache, codeModelContent: codeModel1, activeTarget: 'target2', activeBuildTypeVariant: 'Release', folder: here });
         configurations = await provider.provideConfigurations([uri1]);
         expect(configurations.length).to.eq(1);
-        expect(configurations[0].configuration.defines).to.contain('DEFINE2');
-        expect(configurations[0].configuration.compilerFragments).to.contain('-DFRAGMENT2');
+        expect(configurations[0].configuration.defines).to.contain('DEFINE1');
+        expect(configurations[0].configuration.compilerFragments).to.contain('-DFRAGMENT1');
         expect(configurations[0].configuration.compilerPath).to.eq('clang++');
 
         provider.updateConfigurationData({ cache, codeModelContent: codeModel1, activeTarget: 'all', activeBuildTypeVariant: 'Release', folder: here });

--- a/test/unit-tests/cpptools.test.ts
+++ b/test/unit-tests/cpptools.test.ts
@@ -235,12 +235,12 @@ suite('CppTools tests', () => {
 
         configurations = await provider.provideConfigurations([uri1]);
         expect(configurations.length).to.eq(1);
-        expect(configurations[0].configuration.defines).to.contain('FLAG2');
+        expect(configurations[0].configuration.defines).to.contain('FLAG1');
 
         provider.updateConfigurationData({ cache, codeModelContent: codeModel1, activeTarget: 'target2', activeBuildTypeVariant: 'Release', folder: here });
         configurations = await provider.provideConfigurations([uri1]);
         expect(configurations.length).to.eq(1);
-        expect(configurations[0].configuration.defines).to.contain('FLAG1');
+        expect(configurations[0].configuration.defines).to.contain('FLAG2');
         expect(configurations[0].configuration.compilerPath).to.eq('clang++');
 
         provider.updateConfigurationData({ cache, codeModelContent: codeModel1, activeTarget: 'all', activeBuildTypeVariant: 'Release', folder: here });
@@ -341,15 +341,15 @@ suite('CppTools tests', () => {
 
         configurations = await provider.provideConfigurations([uri1]);
         expect(configurations.length).to.eq(1);
-        expect(configurations[0].configuration.defines).to.contain('DEFINE2');
-        expect(configurations[0].configuration.compilerFragments).to.contain('-DFRAGMENT2');
+        expect(configurations[0].configuration.defines).to.contain('DEFINE1');
+        expect(configurations[0].configuration.compilerFragments).to.contain('-DFRAGMENT1');
         expect(configurations[0].configuration.compilerArgs).to.be.empty;
 
         provider.updateConfigurationData({ cache, codeModelContent: codeModel1, activeTarget: 'target2', activeBuildTypeVariant: 'Release', folder: here });
         configurations = await provider.provideConfigurations([uri1]);
         expect(configurations.length).to.eq(1);
-        expect(configurations[0].configuration.defines).to.contain('DEFINE1');
-        expect(configurations[0].configuration.compilerFragments).to.contain('-DFRAGMENT1');
+        expect(configurations[0].configuration.defines).to.contain('DEFINE2');
+        expect(configurations[0].configuration.compilerFragments).to.contain('-DFRAGMENT2');
         expect(configurations[0].configuration.compilerPath).to.eq('clang++');
 
         provider.updateConfigurationData({ cache, codeModelContent: codeModel1, activeTarget: 'all', activeBuildTypeVariant: 'Release', folder: here });


### PR DESCRIPTION
@gcampbell-msft I found that the more "important" target/fileGroup combos were first, so I reversed the order.