### PR TITLE
Tree view for tests using test suite delimiter

### DIFF
--- a/package.json
+++ b/package.json
@@ -2244,7 +2244,7 @@
         "cmake.ctest.testSuiteDelimiter": {
           "type": "string",
           "default": null,
-          "description": "%cmake-tools.configuration.cmake.ctest.testSuiteDelimiter.description%",
+          "markdownDescription": "%cmake-tools.configuration.cmake.ctest.testSuiteDelimiter.markdownDescription%",
           "scope": "machine-overridable"
         },
         "cmake.parseBuildDiagnostics": {
@@ -3729,7 +3729,6 @@
     "chai-string": "^1.5.0",
     "eslint": "^8.15.0",
     "eslint-plugin-import": "^2.26.0",
-    "eslint-plugin-jsdoc": "^39.6.4",
     "event-stream": "^4.0.1",
     "fs-extra": "^9.1.0",
     "glob": "^7.1.6",

--- a/package.json
+++ b/package.json
@@ -3729,6 +3729,7 @@
     "chai-string": "^1.5.0",
     "eslint": "^8.15.0",
     "eslint-plugin-import": "^2.26.0",
+    "eslint-plugin-jsdoc": "^39.6.4",
     "event-stream": "^4.0.1",
     "fs-extra": "^9.1.0",
     "glob": "^7.1.6",

--- a/package.json
+++ b/package.json
@@ -2241,6 +2241,12 @@
           "description": "%cmake-tools.configuration.cmake.ctest.testExplorerIntegrationEnabled.description%",
           "scope": "machine-overridable"
         },
+        "cmake.ctest.testSuiteDelimiter": {
+          "type": "string",
+          "default": null,
+          "description": "%cmake-tools.configuration.cmake.ctest.testSuiteDelimiter.description%",
+          "scope": "machine-overridable"
+        },
         "cmake.parseBuildDiagnostics": {
           "type": "boolean",
           "default": true,

--- a/package.nls.json
+++ b/package.nls.json
@@ -106,7 +106,12 @@
     },
     "cmake-tools.configuration.cmake.ctest.allowParallelJobs.description": "Allows ctests to be run in parallel, however the result output may be garbled as a result and the Test Explorer may not accurately reflect test progress.",
     "cmake-tools.configuration.cmake.ctest.testExplorerIntegrationEnabled.description": "Whether or not the integration with the test explorer is enabled. This is helpful to disable if you prefer using a different extension for test integration.",
-    "cmake-tools.configuration.cmake.ctest.testSuiteDelimiter.description": "Optional delimiter used to separate test suite names in the Test Explorer. This is used to group tests in a hierarchical view. A TypeScript String split()'s Regular Expression can be used to specify multiple delimiters.",
+    "cmake-tools.configuration.cmake.ctest.testSuiteDelimiter.markdownDescription": {
+        "message": "Optional delimiter used to separate test suite names and group tests hierarchically in the Test Explorer. This string is used in TypeScript's String.split() method with Regular Expressions, so some delimiters may need escaping. Examples: `-` ( One delimiter: `-`), `\\.|::` (Two delimiters: `.` or `::`. Note that `.` needs to be escaped.)",
+        "comment": [
+            "Markdown text between `` should not be translated or localized (they represent literal text) and the capitalization, spacing, and punctuation (including the ``) should not be altered."
+        ]
+    }, 
     "cmake-tools.configuration.cmake.parseBuildDiagnostics.description": "Parse compiler output for warnings and errors.",
     "cmake-tools.configuration.cmake.enabledOutputParsers.description": {
         "message": "Output parsers to use. Supported parsers `cmake`, `gcc`, `gnuld` for GNULD-style linker output, `msvc` for Microsoft Visual C++, `ghs` for the Green Hills compiler with --no_wrap_diagnostics --brief_diagnostics, and `diab` for the Wind River Diab compiler.",

--- a/package.nls.json
+++ b/package.nls.json
@@ -106,7 +106,7 @@
     },
     "cmake-tools.configuration.cmake.ctest.allowParallelJobs.description": "Allows ctests to be run in parallel, however the result output may be garbled as a result and the Test Explorer may not accurately reflect test progress.",
     "cmake-tools.configuration.cmake.ctest.testExplorerIntegrationEnabled.description": "Whether or not the integration with the test explorer is enabled. This is helpful to disable if you prefer using a different extension for test integration.",
-    "cmake-tools.configuration.cmake.ctest.testSuiteDelimiter.description": "Optional delimiter used to separate test suite names in the Test Explorer. This is used to group tests in a hierarchical view.",
+    "cmake-tools.configuration.cmake.ctest.testSuiteDelimiter.description": "Optional delimiter used to separate test suite names in the Test Explorer. This is used to group tests in a hierarchical view. A TypeScript String split()'s Regular Expression can be used to specify multiple delimiters.",
     "cmake-tools.configuration.cmake.parseBuildDiagnostics.description": "Parse compiler output for warnings and errors.",
     "cmake-tools.configuration.cmake.enabledOutputParsers.description": {
         "message": "Output parsers to use. Supported parsers `cmake`, `gcc`, `gnuld` for GNULD-style linker output, `msvc` for Microsoft Visual C++, `ghs` for the Green Hills compiler with --no_wrap_diagnostics --brief_diagnostics, and `diab` for the Wind River Diab compiler.",

--- a/package.nls.json
+++ b/package.nls.json
@@ -106,6 +106,7 @@
     },
     "cmake-tools.configuration.cmake.ctest.allowParallelJobs.description": "Allows ctests to be run in parallel, however the result output may be garbled as a result and the Test Explorer may not accurately reflect test progress.",
     "cmake-tools.configuration.cmake.ctest.testExplorerIntegrationEnabled.description": "Whether or not the integration with the test explorer is enabled. This is helpful to disable if you prefer using a different extension for test integration.",
+    "cmake-tools.configuration.cmake.ctest.testSuiteDelimiter.description": "Optional delimiter used to separate test suite names in the Test Explorer. This is used to group tests in a hierarchical view.",
     "cmake-tools.configuration.cmake.parseBuildDiagnostics.description": "Parse compiler output for warnings and errors.",
     "cmake-tools.configuration.cmake.enabledOutputParsers.description": {
         "message": "Output parsers to use. Supported parsers `cmake`, `gcc`, `gnuld` for GNULD-style linker output, `msvc` for Microsoft Visual C++, `ghs` for the Green Hills compiler with --no_wrap_diagnostics --brief_diagnostics, and `diab` for the Wind River Diab compiler.",

--- a/package.nls.json
+++ b/package.nls.json
@@ -107,7 +107,7 @@
     "cmake-tools.configuration.cmake.ctest.allowParallelJobs.description": "Allows ctests to be run in parallel, however the result output may be garbled as a result and the Test Explorer may not accurately reflect test progress.",
     "cmake-tools.configuration.cmake.ctest.testExplorerIntegrationEnabled.description": "Whether or not the integration with the test explorer is enabled. This is helpful to disable if you prefer using a different extension for test integration.",
     "cmake-tools.configuration.cmake.ctest.testSuiteDelimiter.markdownDescription": {
-        "message": "Optional delimiter used to separate test suite names and group tests hierarchically in the Test Explorer. This string is used in TypeScript's String.split() method with Regular Expressions, so some delimiters may need escaping. Examples: `-` ( One delimiter: `-`), `\\.|::` (Two delimiters: `.` or `::`. Note that `.` needs to be escaped.)",
+        "message": "Optional delimiter used to separate test suite names and group tests hierarchically in the Test Explorer. This string is used in a Regular Expression, so some delimiters may need escaping. Examples: `-` ( One delimiter: `-`), `\\.|::` (Two delimiters: `.` or `::`. Note that `.` needs to be escaped.)",
         "comment": [
             "Markdown text between `` should not be translated or localized (they represent literal text) and the capitalization, spacing, and punctuation (including the ``) should not be altered."
         ]

--- a/src/config.ts
+++ b/src/config.ts
@@ -171,7 +171,7 @@ export interface ExtensionConfigurationSettings {
     buildToolArgs: string[];
     parallelJobs: number | undefined;
     ctestPath: string;
-    ctest: { parallelJobs: number; allowParallelJobs: boolean; testExplorerIntegrationEnabled: boolean };
+    ctest: { parallelJobs: number; allowParallelJobs: boolean; testExplorerIntegrationEnabled: boolean; testSuiteDelimiter: string };
     parseBuildDiagnostics: boolean;
     enabledOutputParsers: string[];
     debugConfig: CppDebugConfiguration;
@@ -375,6 +375,9 @@ export class ConfigurationReader implements vscode.Disposable {
     get testExplorerIntegrationEnabled(): boolean {
         return this.configData.ctest.testExplorerIntegrationEnabled;
     }
+    get testSuiteDelimiter(): string {
+        return this.configData.ctest.testSuiteDelimiter;
+    }
     get parseBuildDiagnostics(): boolean {
         return !!this.configData.parseBuildDiagnostics;
     }
@@ -571,7 +574,7 @@ export class ConfigurationReader implements vscode.Disposable {
         parallelJobs: new vscode.EventEmitter<number>(),
         ctestPath: new vscode.EventEmitter<string>(),
         cpackPath: new vscode.EventEmitter<string>(),
-        ctest: new vscode.EventEmitter<{ parallelJobs: number; allowParallelJobs: boolean; testExplorerIntegrationEnabled: boolean }>(),
+        ctest: new vscode.EventEmitter<{ parallelJobs: number; allowParallelJobs: boolean; testExplorerIntegrationEnabled: boolean; testSuiteDelimiter: string }>(),
         parseBuildDiagnostics: new vscode.EventEmitter<boolean>(),
         enabledOutputParsers: new vscode.EventEmitter<string[]>(),
         debugConfig: new vscode.EventEmitter<CppDebugConfiguration>(),

--- a/src/ctest.ts
+++ b/src/ctest.ts
@@ -390,7 +390,7 @@ export class CTestDriver implements vscode.Disposable {
             if (driver) {
                 _driver = driver;
             } else {
-                const folder = test.parent ? test.parent.id : test.id;
+                const folder = this.getTestRootFolder(test);
                 const project = await this.projectController?.getProjectForFolder(folder);
                 if (!project) {
                     this.ctestErrored(test, run, { message: localize('no.project.found', 'No project found for folder {0}', folder) });
@@ -599,6 +599,29 @@ export class CTestDriver implements vscode.Disposable {
         return undefined;
     }
 
+    private createTestItemAndSuiteTree(testName: string, testExplorerRoot: vscode.TestItem, initializedTestExplorer: vscode.TestController, uri?: vscode.Uri) {
+        let parentSuiteItem = testExplorerRoot;
+        let testLabel = testName;
+
+        // If a suite delimiter is set, create a suite tree
+        if (this.ws.config.testSuiteDelimiter ) {
+            const parts = testName.split(this.ws.config.testSuiteDelimiter);
+            testLabel = parts.pop() || testName; // The last part is the test label
+
+            // Create a suite item for each suite ID part if it doesn't exist yet at that tree level
+            for (const suiteId of parts) {
+                let suiteItem = parentSuiteItem.children.get(suiteId);
+                if (!suiteItem) {
+                    suiteItem = initializedTestExplorer.createTestItem(suiteId, suiteId);
+                    parentSuiteItem.children.add(suiteItem);
+                }
+                parentSuiteItem = suiteItem;
+            }
+        }
+        const testItem = initializedTestExplorer.createTestItem(testName, testLabel, uri);
+        return { testItem, parentSuiteItem };
+    }
+
     /**
      * @brief Refresh the list of CTest tests
      * @returns 0 when successful
@@ -675,7 +698,9 @@ export class CTestDriver implements vscode.Disposable {
             this.tests = JSON.parse(result.stdout) ?? undefined;
             if (this.tests && this.tests.kind === 'ctestInfo') {
                 this.tests.tests.forEach(test => {
-                    let testItem: vscode.TestItem | undefined;
+                    let testDefFile: string | undefined;
+                    let testDefLine: number | undefined;
+
                     if (test.backtrace !== undefined && this.tests!.backtraceGraph.nodes[test.backtrace] !== undefined) {
                         // Use DEF_SOURCE_LINE CMake test property to find file and line number
                         // Property must be set in the test's CMakeLists.txt file or its included modules for this to work
@@ -684,26 +709,27 @@ export class CTestDriver implements vscode.Disposable {
                             // Use RegEx to match the format "file_path:line" in value[0]
                             const match = defSourceLineProperty.value.match(/(.*):(\d+)/);
                             if (match && match[1] && match[2]) {
-                                const testDefFile = match[1];
-                                const testDefLine = parseInt(match[2]);
-                                if (!isNaN(testDefLine)) {
-                                    testItem = initializedTestExplorer.createTestItem(test.name, test.name, vscode.Uri.file(testDefFile));
-                                    testItem.range = new vscode.Range(new vscode.Position(testDefLine - 1, 0), new vscode.Position(testDefLine - 1, 0));
+                                testDefFile = match[1];
+                                testDefLine = parseInt(match[2]);
+                                if (isNaN(testDefLine)) {
+                                    testDefLine = undefined;
+                                    testDefFile = undefined
                                 }
                             }
                         }
-                        if (!testItem) {
+
+                        if (!testDefFile) {
                             // Use the backtrace graph to find the file and line number
                             // This finds the CMake module's file and line number and not the test file and line number
-                            const testDefFile = this.tests!.backtraceGraph.files[this.tests!.backtraceGraph.nodes[test.backtrace].file];
-                            const testDefLine = this.tests!.backtraceGraph.nodes[test.backtrace].line;
-                            testItem = initializedTestExplorer.createTestItem(test.name, test.name, vscode.Uri.file(testDefFile));
-                            if (testDefLine !== undefined) {
-                                testItem.range = new vscode.Range(new vscode.Position(testDefLine - 1, 0), new vscode.Position(testDefLine - 1, 0));
-                            }
+                            testDefFile = this.tests!.backtraceGraph.files[this.tests!.backtraceGraph.nodes[test.backtrace].file];
+                            testDefLine = this.tests!.backtraceGraph.nodes[test.backtrace].line;
                         }
-                    } else {
-                        testItem = initializedTestExplorer.createTestItem(test.name, test.name);
+                    }
+
+                    const { testItem, parentSuiteItem } = this.createTestItemAndSuiteTree(test.name, testExplorerRoot, initializedTestExplorer,  testDefFile ? vscode.Uri.file(testDefFile) : undefined);
+
+                    if (testDefLine !== undefined) {
+                        testItem.range = new vscode.Range(new vscode.Position(testDefLine - 1, 0), new vscode.Position(testDefLine - 1, 0));
                     }
 
                     const testTags: vscode.TestTag[] = [];
@@ -723,7 +749,7 @@ export class CTestDriver implements vscode.Disposable {
                         testItem.tags = [...testItem.tags, ...testTags];
                     }
 
-                    testExplorerRoot.children.add(testItem);
+                    parentSuiteItem.children.add(testItem);
                 });
             };
         }
@@ -778,7 +804,7 @@ export class CTestDriver implements vscode.Disposable {
         let presetMayChange = false;
         for (const test of tests) {
             if (test.id === testPresetRequired) {
-                const folder = test.parent ? test.parent.id : test.id;
+                const folder = this.getTestRootFolder(test);
                 const project = await this.projectController?.getProjectForFolder(folder);
                 if (!project) {
                     log.error(localize('no.project.found', 'No project found for folder {0}', folder));
@@ -832,7 +858,7 @@ export class CTestDriver implements vscode.Disposable {
                 continue;
             }
 
-            const folder = test.parent ? test.parent.id : test.id;
+            const folder = this.getTestRootFolder(test);
             const project = await this.projectController?.getProjectForFolder(folder);
             if (!project) {
                 this.ctestErrored(test, run, { message: localize('no.project.found', 'No project found for folder {0}', folder) });
@@ -1050,12 +1076,20 @@ export class CTestDriver implements vscode.Disposable {
         run.end();
     };
 
+    private getTestRootFolder(test: vscode.TestItem): string {
+        let currentTestItem = test;
+        while (currentTestItem.parent !== undefined) {
+            currentTestItem = currentTestItem.parent;
+        }
+        return currentTestItem.id;
+    }
+
     private async buildTests(tests: vscode.TestItem[], run: vscode.TestRun): Promise<boolean> {
         // Folder => status
         const builtFolder = new Map<string, number>();
         let status: number = 0;
         for (const test of tests) {
-            const folder = test.parent ? test.parent.id : test.id;
+            const folder = this.getTestRootFolder(test);
             if (!builtFolder.has(folder)) {
                 const project = await this.projectController?.getProjectForFolder(folder);
                 if (!project) {

--- a/src/ctest.ts
+++ b/src/ctest.ts
@@ -605,7 +605,7 @@ export class CTestDriver implements vscode.Disposable {
         return undefined;
     }
 
-    private createTestItemAndSuiteTree(testName: string, testExplorerRoot: vscode.TestItem, initializedTestExplorer: vscode.TestController, uri?: vscode.Uri) : TestAndParentSuite {
+    private createTestItemAndSuiteTree(testName: string, testExplorerRoot: vscode.TestItem, initializedTestExplorer: vscode.TestController, uri?: vscode.Uri): TestAndParentSuite {
         let parentSuiteItem = testExplorerRoot;
         let testLabel = testName;
 

--- a/src/ctest.ts
+++ b/src/ctest.ts
@@ -435,7 +435,7 @@ export class CTestDriver implements vscode.Disposable {
             if (test.children.size > 0) {
                 // Shouldn't reach here now, but not hard to write so keeping it in case we want to have more complicated test hierarchies
                 const children = this.testItemCollectionToArray(test.children);
-                if (await this.runCTestHelper(children, run, _driver, _ctestPath, _ctestArgs, cancellation, customizedTask, consumer)) {
+                if (await this.runCTestHelper(children, run, _driver, _ctestPath, _ctestArgs, cancellation, customizedTask, consumer, entryPoint)) {
                     returnCode = -1;
                 }
                 return returnCode;

--- a/src/ctest.ts
+++ b/src/ctest.ts
@@ -599,13 +599,14 @@ export class CTestDriver implements vscode.Disposable {
         return undefined;
     }
 
-    private createTestItemAndSuiteTree(testName: string, testExplorerRoot: vscode.TestItem, initializedTestExplorer: vscode.TestController, uri?: vscode.Uri) {
+    private createTestItemAndSuiteTree(testName: string, testExplorerRoot: vscode.TestItem, initializedTestExplorer: vscode.TestController, uri?: vscode.Uri) : { testItem: vscode.TestItem, parentSuiteItem: vscode.TestItem } {
         let parentSuiteItem = testExplorerRoot;
         let testLabel = testName;
 
         // If a suite delimiter is set, create a suite tree
-        if (this.ws.config.testSuiteDelimiter ) {
-            const parts = testName.split(this.ws.config.testSuiteDelimiter);
+        if (this.ws.config.testSuiteDelimiter) {
+            let delimiterRegExp = new RegExp(this.ws.config.testSuiteDelimiter);
+            const parts = testName.split(delimiterRegExp);
             testLabel = parts.pop() || testName; // The last part is the test label
 
             // Create a suite item for each suite ID part if it doesn't exist yet at that tree level

--- a/test/unit-tests/config.test.ts
+++ b/test/unit-tests/config.test.ts
@@ -24,9 +24,10 @@ function createConfig(conf: Partial<ExtensionConfigurationSettings>): Configurat
         ctestPath: '',
         cpackPath: '',
         ctest: {
-            parallelJobs: 0,
+        parallelJobs: 0,
             allowParallelJobs: false,
-            testExplorerIntegrationEnabled: true
+            testExplorerIntegrationEnabled: true,
+            testSuiteDelimiter: ''
         },
         parseBuildDiagnostics: true,
         enabledOutputParsers: [],

--- a/test/unit-tests/config.test.ts
+++ b/test/unit-tests/config.test.ts
@@ -24,7 +24,7 @@ function createConfig(conf: Partial<ExtensionConfigurationSettings>): Configurat
         ctestPath: '',
         cpackPath: '',
         ctest: {
-        parallelJobs: 0,
+            parallelJobs: 0,
             allowParallelJobs: false,
             testExplorerIntegrationEnabled: true,
             testSuiteDelimiter: ''


### PR DESCRIPTION
## This change addresses item #3156 

### This changes visible behavior

The following changes are proposed:

- Currently, tests are displayed in a flat list. Allow users to specify a test suite delimiter string and split the suite and test names using that delimiter to create a tree view of suites and tests.
  - The extension's CTest settings have been extended to add an optional Test Suite Delimiter string:
     ![image](https://github.com/microsoft/vscode-cmake-tools/assets/160914867/864935fc-ac87-4c6f-9717-51c831c3d675)
  - `refreshTests `has been modified to split test names using the suite delimiter, if present, and create suite tree items if necessary, using `createTestItemAndSuiteTree`.
  - If a test suite delimiter is not provided, tests are displayed in a flat list, as before.
  - `getTestRootFolder `has been introduced to get the root folder for a test.