### PR TITLE
Skip full configure on variant change for multi-config generators

### DIFF
--- a/src/drivers/cmakeFileApiDriver.ts
+++ b/src/drivers/cmakeFileApiDriver.ts
@@ -271,7 +271,6 @@ export class CMakeFileApiDriver extends CMakeDriver {
             return 0;
         } else if (this.isMultiConfig && trigger === ConfigureTrigger.setVariant) {
             this._needsReconfigure = false;
-            log.debug("No re-configure 'cmake' command needed to run when changing variant for a multi-config generator.");
             await this.updateCodeModel(binaryDir);
             return 0;
         } else {

--- a/src/drivers/cmakeFileApiDriver.ts
+++ b/src/drivers/cmakeFileApiDriver.ts
@@ -269,6 +269,10 @@ export class CMakeFileApiDriver extends CMakeDriver {
             log.showChannel();
             log.info(proc.buildCmdStr(this.cmake.path, args));
             return 0;
+        } else if (this.isMultiConfig && trigger === ConfigureTrigger.setVariant) {
+            this._needsReconfigure = false;
+            log.debug("No re-configure 'cmake' command needed to run when changing variant for a multi-config generator.");
+            await this.updateCodeModel(binaryDir);
         } else {
             log.debug(`Configuring using ${this.useCMakePresets ? 'preset' : 'kit'}`);
             log.debug('Invoking CMake', cmake, 'with arguments', JSON.stringify(args));

--- a/src/drivers/cmakeFileApiDriver.ts
+++ b/src/drivers/cmakeFileApiDriver.ts
@@ -273,6 +273,7 @@ export class CMakeFileApiDriver extends CMakeDriver {
             this._needsReconfigure = false;
             log.debug("No re-configure 'cmake' command needed to run when changing variant for a multi-config generator.");
             await this.updateCodeModel(binaryDir);
+            return 0;
         } else {
             log.debug(`Configuring using ${this.useCMakePresets ? 'preset' : 'kit'}`);
             log.debug('Invoking CMake', cmake, 'with arguments', JSON.stringify(args));


### PR DESCRIPTION
Fix for https://github.com/microsoft/vscode-cmake-tools/issues/2577. 
Don't fully configure after variant change for multi-config generators because such configures are generating all the build types and file-api jsons at once.
What is needed in this case is only to change the parameter for build and refresh IntelliSense via a configuration provider notification towards CppTools.

