### PR TITLE
Handle "~" in binaryDir path

### DIFF
--- a/src/drivers/cmakeFileApiDriver.ts
+++ b/src/drivers/cmakeFileApiDriver.ts
@@ -335,7 +335,7 @@ export class CMakeFileApiDriver extends CMakeDriver {
 
     private toolchainWarningProvided: boolean = false;
     private async updateCodeModel(binaryDir?: string): Promise<boolean> {
-        const reply_path = this.getCMakeReplyPath(binaryDir).replace('~', process.env.HOME || ".");
+        const reply_path = this.getCMakeReplyPath(binaryDir).replace('~', process.env.HOME || "./");
         const indexFile = await loadIndexFile(reply_path);
         if (indexFile) {
             this._generatorInformation = indexFile.cmake.generator;

--- a/src/drivers/cmakeFileApiDriver.ts
+++ b/src/drivers/cmakeFileApiDriver.ts
@@ -335,7 +335,7 @@ export class CMakeFileApiDriver extends CMakeDriver {
 
     private toolchainWarningProvided: boolean = false;
     private async updateCodeModel(binaryDir?: string): Promise<boolean> {
-        const reply_path = this.getCMakeReplyPath(binaryDir);
+        const reply_path = this.getCMakeReplyPath(binaryDir).replace('~', process.env.HOME || ".");
         const indexFile = await loadIndexFile(reply_path);
         if (indexFile) {
             this._generatorInformation = indexFile.cmake.generator;


### PR DESCRIPTION
Fix for https://github.com/microsoft/vscode-cmake-tools/issues/3541. 
File system APIs don't recognize tilda "~" in paths and because of this, when using "~" in binaryDir for example, the extension cannot properly interpret cmake file-api jsons to list targets for build, debug or run.
Replace "~" with user folder.

