### PR TITLE
Fix doubling of cpack args passed by package preset

### DIFF
--- a/src/cpack.ts
+++ b/src/cpack.ts
@@ -89,13 +89,6 @@ export class CPackDriver implements vscode.Disposable {
             }
         }
 
-        const opts = driver.expansionOptions;
-        const args = [];
-        for (const value of this.ws.config.cpackArgs) {
-            args.push(await expandString(value, opts));
-        }
-
-        cpackArgs = cpackArgs.concat(args);
         return cpackArgs;
     }
 


### PR DESCRIPTION
Fix for https://github.com/microsoft/vscode-cmake-tools/issues/3765. 
