### PR TITLE
Fix UI for settings override of package presets

### DIFF
--- a/package.json
+++ b/package.json
@@ -1738,7 +1738,7 @@
         },
         {
           "command": "cmake.projectStatus.selectPackagePreset",
-          "when": "view == cmake.projectStatus && cmake:enableFullFeatureSet && viewItem == 'packagePreset'",
+          "when": "view == cmake.projectStatus && cmake:enableFullFeatureSet && viewItem =~ /packagePreset/",
           "group": "inline"
         },
         {

--- a/src/drivers/cmakeDriver.ts
+++ b/src/drivers/cmakeDriver.ts
@@ -254,7 +254,7 @@ export abstract class CMakeDriver implements vscode.Disposable {
         for (const term of this._compileTerms.values()) {
             term.dispose();
         }
-        for (const sub of [this._settingsSub, this._argsSub, this._envSub, this._buildArgsSub, this._buildEnvSub, this._testArgsSub, this._testEnvSub, this._packEnvSub, this._generalEnvSub]) {
+        for (const sub of [this._settingsSub, this._argsSub, this._envSub, this._buildArgsSub, this._buildEnvSub, this._testArgsSub, this._testEnvSub, this._packEnvSub, this._packArgsSub, this._generalEnvSub]) {
             sub.dispose();
         }
         rollbar.invokeAsync(localize('async.disposing.cmake.driver', 'Async disposing CMake driver'), () => this.asyncDispose());
@@ -1827,6 +1827,9 @@ export abstract class CMakeDriver implements vscode.Disposable {
         await onTestSettingsChange();
     });
     private readonly _packEnvSub = this.config.onChange('cpackEnvironment', async () => {
+        await onPackageSettingsChange();
+    });
+    private readonly _packArgsSub = this.config.onChange('cpackArgs', async () => {
         await onPackageSettingsChange();
     });
     private readonly _generalEnvSub = this.config.onChange('environment', async () => {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1017,10 +1017,10 @@ export class ExtensionManager implements vscode.Disposable {
     viewPackageSettings(): void {
         void vscode.commands.executeCommand('workbench.action.openSettings', '@id:cmake.cpackArgs, @id:cmake.cpackEnvironment, @id:cmake.environment');
     }
-    
-     /**
-     * Show UI to allow the user to select an active kit
-     */
+
+    /**
+    * Show UI to allow the user to select an active kit
+    */
     async selectKit(folder?: vscode.WorkspaceFolder): Promise<boolean> {
         if (util.isTestMode()) {
             log.trace(localize('selecting.kit.in.test.mode', 'Running CMakeTools in test mode. selectKit is disabled.'));

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1014,7 +1014,11 @@ export class ExtensionManager implements vscode.Disposable {
         return Array.from(result);
     }
 
-    /**
+    viewPackageSettings(): void {
+        void vscode.commands.executeCommand('workbench.action.openSettings', '@id:cmake.cpackArgs, @id:cmake.cpackEnvironment, @id:cmake.environment');
+    }
+    
+     /**
      * Show UI to allow the user to select an active kit
      */
     async selectKit(folder?: vscode.WorkspaceFolder): Promise<boolean> {
@@ -2161,6 +2165,7 @@ async function setup(context: vscode.ExtensionContext, progress?: ProgressHandle
         'selectTestPreset',
         'viewTestSettings',
         'selectPackagePreset',
+        'viewPackageSettings',
         'selectWorkflowPreset',
         'selectActiveFolder',
         'editKits',

--- a/src/projectStatus.ts
+++ b/src/projectStatus.ts
@@ -673,7 +673,7 @@ class PackageNode extends Node {
 
     async refresh(): Promise<void> {
         await this.packagePreset?.refresh();
-  }
+    }
 }
 
 class WorkflowNode extends Node {

--- a/src/projectStatus.ts
+++ b/src/projectStatus.ts
@@ -92,6 +92,9 @@ export class ProjectStatus {
                 await runCommand('selectPackagePreset');
                 await this.refresh(node);
             }),
+            vscode.commands.registerCommand('cmake.projectStatus.viewPackageSettings', async (_node: Node) => {
+                await runCommand('viewPackageSettings');
+            }),
             vscode.commands.registerCommand('cmake.projectStatus.selectWorkflowPreset', async (node: Node) => {
                 await runCommand('selectWorkflowPreset');
                 await this.refresh(node);
@@ -668,6 +671,9 @@ class PackageNode extends Node {
         return this.initialize();
     }
 
+    async refresh(): Promise<void> {
+        await this.packagePreset?.refresh();
+  }
 }
 
 class WorkflowNode extends Node {

--- a/src/ui/util.ts
+++ b/src/ui/util.ts
@@ -18,5 +18,5 @@ export async function onTestSettingsChange(): Promise<void> {
 
 export async function onPackageSettingsChange(): Promise<void> {
     await treeDataProvider.refreshPackageNode();
-    // No updates necessary to status bar, package/workflow presets live in Project Status View only.
+    getStatusBar()?.updatePackagePresetButton();
 }


### PR DESCRIPTION
Fix for bug https://github.com/microsoft/vscode-cmake-tools/issues/3769. 

The "*" star used to represent settings overrides of various tools behind presets (like ctest.exe) was not working for cpack.exe. Some extra wiring needed to be done so that all cpack functionality was matching ctest and the UI to behave correctly.