### PR TITLE
Warning when VS installation instance not found

### DIFF
--- a/src/kit.ts
+++ b/src/kit.ts
@@ -964,7 +964,14 @@ async function getVSInstallForKit(kit: Kit): Promise<VSInstallation | undefined>
         // Clang for VS kit format
         (!!kit.compilers && kit.name.indexOf("Clang") >= 0 && kit.name.indexOf(vsDisplayName(inst)) >= 0);
 
-    return installs.find(match);
+    const inst = installs.find(match);
+    if (!inst) {
+        log.warning(localize('vs.instance.not.found.run.scan.kits',
+                    'VS installation instance not found for kit {1}. It is recommended you re-scan the kits.',
+                    kit?.visualStudio));
+    }
+
+    return inst;
 }
 
 export async function getVSKitEnvironment(kit: Kit): Promise<Environment | null> {

--- a/src/kit.ts
+++ b/src/kit.ts
@@ -967,8 +967,8 @@ async function getVSInstallForKit(kit: Kit): Promise<VSInstallation | undefined>
     const inst = installs.find(match);
     if (!inst) {
         log.warning(localize('vs.instance.not.found.run.scan.kits',
-                    'VS installation instance not found for kit {1}. It is recommended you re-scan the kits.',
-                    kit?.visualStudio));
+            'VS installation instance not found for kit {1}. It is recommended you re-scan the kits.',
+            kit?.visualStudio));
     }
 
     return inst;


### PR DESCRIPTION
Fix for https://github.com/microsoft/vscode-cmake-tools/issues/3644.

At the community's suggestion, add a warning when the VS installation instance is not found and recommendation to re-scan kits.
