### PR TITLE
Add chesscc to the allow-list of compilers.

### DIFF
--- a/src/drivers/cmakeDriver.ts
+++ b/src/drivers/cmakeDriver.ts
@@ -1085,6 +1085,12 @@ export abstract class CMakeDriver implements vscode.Disposable {
             captureGroup: 1
         },
         {
+            name: "chesscc",
+            versionSwitch: "--version",
+            versionOutputRegexp: "version ([^\\s]+)",
+            captureGroup: 1
+        },
+        {
             name: "g++",
             versionSwitch: "-v",
             versionOutputRegexp: "version ([^\\s]+)",


### PR DESCRIPTION
Fix for https://github.com/microsoft/vscode-cmake-tools/issues/3309.
Add chesscc to the allow-list of compilers. Since we couldn't find an install to test nor the customer who requested the fix didn't reply, I am using the most common and most probably regular expression for interpreting the --version output. Same as the "cc" compiler, thinking that "chesscc" would resemble the original main "cc".