### PR TITLE
Don't write sourceDir in the build log when builds are out of source

### DIFF
--- a/src/cmakeProject.ts
+++ b/src/cmakeProject.ts
@@ -1897,7 +1897,7 @@ export class CMakeProject {
      */
     async runBuild(targets?: string[], showCommandOnly?: boolean, taskConsumer?: proc.OutputConsumer, isBuildCommand?: boolean): Promise<number> {
         if (!showCommandOnly) {
-            log.info(localize('run.build', 'Building folder: {0}', this.folderName), (targets && targets.length > 0) ? targets.join(', ') : '');
+            log.info(localize('run.build', 'Building folder: {0}', await this.binaryDir || this.folderName), (targets && targets.length > 0) ? targets.join(', ') : '');
         }
         let drv: CMakeDriver | null;
         if (showCommandOnly) {


### PR DESCRIPTION
Fix for bug https://github.com/microsoft/vscode-cmake-tools/issues/3308.
Add clarity in the build log when builds are out of source and mention the correct binaryDir instead of sourceDir.