### PR TITLE
Add setting for deleting whole build dir when clean configuring

### DIFF
--- a/package.json
+++ b/package.json
@@ -2577,6 +2577,15 @@
           "description": "%cmake-tools.configuration.cmake.configureOnEdit.description%",
           "scope": "resource"
         },
+        "cmake.deleteBuildDirOnCleanConfigure": {
+          "type": "boolean",
+          "default": false,
+          "description": "%cmake-tools.configuration.cmake.deleteBuildDirOnCleanCconfigure.description%",
+          "scope": "resource",
+          "tags": [
+            "experimental"
+          ]
+        },
         "cmake.setBuildTypeOnMultiConfig": {
           "type": "boolean",
           "default": false,

--- a/package.nls.json
+++ b/package.nls.json
@@ -166,6 +166,7 @@
     "cmake-tools.configuration.cmake.copyCompileCommands.description": "Copy compile_commands.json to this location after a successful configure.",
     "cmake-tools.configuration.cmake.configureOnOpen.description": "Automatically configure CMake project directories when they are opened.",
     "cmake-tools.configuration.cmake.configureOnEdit.description": "Automatically configure CMake project directories when cmake.sourceDirectory or CMakeLists.txt content are saved.",
+    "cmake-tools.configuration.cmake.deleteBuildDirOnCleanConfigure.description": "Delete the whole build directory when a clean configure is invoked.",
     "cmake-tools.configuration.cmake.setBuildTypeOnMultiConfig.description": "Set CMAKE_BUILD_TYPE also on multi config generators.",
     "cmake-tools.configuration.cmake.skipConfigureIfCachePresent.description": "Skip over the configure process if cache is present.",
     "cmake-tools.configuration.cmake.cmakeCommunicationMode": "The protocol used to communicate between the extension and CMake.",

--- a/src/config.ts
+++ b/src/config.ts
@@ -193,6 +193,7 @@ export interface ExtensionConfigurationSettings {
     loadCompileCommands: boolean;
     configureOnOpen: boolean | null;
     configureOnEdit: boolean;
+    deleteBuildDirOnCleanConfigure: boolean | null;
     skipConfigureIfCachePresent: boolean | null;
     useCMakeServer: boolean;
     cmakeCommunicationMode: CMakeCommunicationMode;
@@ -432,6 +433,9 @@ export class ConfigurationReader implements vscode.Disposable {
     get configureOnEdit() {
         return this.configData.configureOnEdit;
     }
+    get deleteBuildDirOnCleanConfigure() {
+        return this.configData.deleteBuildDirOnCleanConfigure;
+    }
     get skipConfigureIfCachePresent() {
         return this.configData.skipConfigureIfCachePresent;
     }
@@ -592,6 +596,7 @@ export class ConfigurationReader implements vscode.Disposable {
         loadCompileCommands: new vscode.EventEmitter<boolean>(),
         configureOnOpen: new vscode.EventEmitter<boolean | null>(),
         configureOnEdit: new vscode.EventEmitter<boolean>(),
+        deleteBuildDirOnCleanConfigure: new vscode.EventEmitter<boolean | null>(),
         skipConfigureIfCachePresent: new vscode.EventEmitter<boolean | null>(),
         useCMakeServer: new vscode.EventEmitter<boolean>(),
         cmakeCommunicationMode: new vscode.EventEmitter<CMakeCommunicationMode>(),

--- a/src/drivers/cmakeDriver.ts
+++ b/src/drivers/cmakeDriver.ts
@@ -541,7 +541,7 @@ export abstract class CMakeDriver implements vscode.Disposable {
     protected async _cleanPriorConfiguration() {
         const build_dir = this.binaryDir;
         const cache = this.cachePath;
-        const cmake_files = path.join(build_dir, 'CMakeFiles');
+        const cmake_files = this.config.deleteBuildDirOnCleanConfigure ? build_dir : path.join(build_dir, 'CMakeFiles');
         if (await fs.exists(cache)) {
             log.info(localize('removing', 'Removing {0}', cache));
             try {

--- a/test/unit-tests/config.test.ts
+++ b/test/unit-tests/config.test.ts
@@ -48,6 +48,7 @@ function createConfig(conf: Partial<ExtensionConfigurationSettings>): Configurat
         loadCompileCommands: true,
         configureOnOpen: null,
         configureOnEdit: true,
+        deleteBuildDirOnCleanConfigure: false,
         skipConfigureIfCachePresent: null,
         useCMakeServer: true,
         cmakeCommunicationMode: 'automatic',


### PR DESCRIPTION
Fix for bug https://github.com/microsoft/vscode-cmake-tools/issues/3515.
At the community request, add a new boolean setting for deleting the whole build directory when configuring-clean (as opposed to deleting only the cache file and a smaller subfolder under the structure of the build dir).