### PR TITLE
Update kits-variants doc with unsupported commands that are specific for presets

### DIFF
--- a/docs/kits.md
+++ b/docs/kits.md
@@ -122,6 +122,21 @@ Keys:
 > **Note:**
 > To use Visual C++, both `visualStudio` and `visualStudioArchitecture` must be specified. Omitting either one won't work.
 
+## Unsupported commands
+
+The following commands are not supported when kits and variants are active:
+- **CMake: Scan for Compilers**
+- **CMake: Add Configure Preset**
+- **CMake: Add Build Preset**
+- **CMake: Add Test Preset**
+- **CMake: Add Package Preset**
+- **CMake: Add Workflow Preset**
+- **CMake: Select Configure Preset**
+- **CMake: Select Build Preset**
+- **CMake: Select Test Preset**
+- **CMake: Select Package Preset**
+- **CMake: Select Workflow Preset**
+
 ### General options
 
 The following additional options may be specified:


### PR DESCRIPTION
Fix for request https://github.com/microsoft/vscode-cmake-tools/issues/3574.

The kits-variants doc mentions "Scan for Kits" command which indeed is supported when kits/variants are ON (and not presets).
The user mentions that the command "Scan for Compilers" is available in the commands palette which probably happens when presets are ON (and not kits/variants).

Following the model of presets doc, which mentions all the kits-variants commands that are not available with presets on, this PR adds a paragraph enumerating all commands not available with kits-variants on. This should clear any confusion around "Scan for Kits" and "Scan for Compilers" commands.