### PR TITLE
Fixed string parameters and added clarification to the log message

### DIFF
--- a/src/kit.ts
+++ b/src/kit.ts
@@ -967,8 +967,8 @@ async function getVSInstallForKit(kit: Kit): Promise<VSInstallation | undefined>
     const inst = installs.find(match);
     if (!inst) {
         log.warning(localize('vs.instance.not.found.run.scan.kits',
-            'VS installation instance not found for kit {1}. It is recommended you re-scan the kits.',
-            kit?.visualStudio));
+            'VS installation instance not found for kit "{0}" - ({1}). It is recommended you re-scan the kits and also remove any user-local entries that are not present anymore on the system.',
+            kit.name, kit?.visualStudio));
     }
 
     return inst;


### PR DESCRIPTION
This is a follow-up to PR https://github.com/microsoft/vscode-cmake-tools/pull/3775 (bug https://github.com/microsoft/vscode-cmake-tools/issues/3644).

The {} parameter in the string to be localized was defined wrong, fixed that. Plus added an additional clarification to the message. As soon as I copied over a kits json which coincidentally had many old kit entries I started to see the message again but would not be fixed by "Scan for kits", because running that command only updates existing entries or adds new entries but does not cleanup old ones.