### PR TITLE
Sort CMakeLists.txt by depth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Improvements:
 - Add the ability to debug install targets [#532](https://github.com/microsoft/vscode-cmake-tools/issues/532)
 - Add a "Don't Show Again" option in the select CMakeLists.txt.
 - Log error statement if the environmentSetupScript fails. [#3566](https://github.com/microsoft/vscode-cmake-tools/issues/3566)
+- Sort CMakeLists.txt by depth during selection [#3789](https://github.com/microsoft/vscode-cmake-tools/pull/3789) [@jmigual](https://github.com/jmigual)
 - [Experiment] Improve CMake Tools experience when opening a folder [#3588](https://github.com/microsoft/vscode-cmake-tools/issues/3588)
 
 Bug Fixes:

--- a/src/cmakeProject.ts
+++ b/src/cmakeProject.ts
@@ -884,6 +884,15 @@ export class CMakeProject {
                         label: util.getRelativePath(file, this.folderPath) + "/CMakeLists.txt",
                         fullPath: file
                     })) : [];
+
+                    // Sort files by depth. In general the user may want to select the top-most CMakeLists.txt
+                    items.sort((a, b) => {
+                        const aDepth = a.fullPath.split(path.sep).length;
+                        const bDepth = b.fullPath.split(path.sep).length;
+
+                        return aDepth - bDepth;
+                    });
+
                     const browse: string = localize("browse.for.cmakelists", "[Browse for CMakeLists.txt]");
                     const dontAskAgain: string = localize("do.not.ask.again", "[Don't Show Again]");
                     items.push({ label: browse, fullPath: "", description: localize("search.for.cmakelists", "Search for CMakeLists.txt on this computer") });


### PR DESCRIPTION
<!-- Thanks for your contribution! To make things easier, please fill out the template below. -->

<!-- Please delete any unused sections. -->

<!-- Delete the following heading if there is no corresponding issue -->

### This changes visible behavior

The following changes are proposed:

- Change the sorting of the initial `CMakeLists.txt` from the default provided by the system to show top-level files first.

So, we go from this:
![Screenshot 2024-05-23 103048](https://github.com/microsoft/vscode-cmake-tools/assets/6493651/72826545-c06e-4fd1-9553-1f4df8da9de0)

To this:
![Screenshot 2024-05-23 103346](https://github.com/microsoft/vscode-cmake-tools/assets/6493651/7cbc29b3-9cdb-4955-8737-6718f23c518f)


## The purpose of this change

The motivation of this change is that usually the user wants to open the CMakeLists.txt that is the closest to the root of the repository and other files are just included via `add_subdirectory` in CMake.
