### PR TITLE
Fixes #3725 - user presets not read correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,13 @@ Features:
 
 - Add support for CMake Language Support natively in this extension. [#3559](https://github.com/microsoft/vscode-cmake-tools/issues/3559)
 
-## 1.18
+## 1.18.42
+
+Bug Fixes:
+- Fix schema validation for `$schema`. [#3809](https://github.com/microsoft/vscode-cmake-tools/pull/3809)
+- Fix tests having too long of a command-line. [#3814](https://github.com/microsoft/vscode-cmake-tools/pull/3814)
+
+## 1.18.41
 Features:
 
 - Add the possibility to open the current build directory in the Explorer [#1451](https://github.com/microsoft/vscode-cmake-tools/issues/1451)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Features:
 - Add support for CMake Language Support natively in this extension. [#3559](https://github.com/microsoft/vscode-cmake-tools/issues/3559)
 
 Bug Fixes:
-- 
+- Fixes issue where new presets couldn't `inherit` from presets in CmakeUserPresets.json, and adds these presets to CmakeUserPresets.json instead of CmakePresets.json. [#3725](https://github.com/microsoft/vscode-cmake-tools/issues/3725)
 
 ## 1.18.42
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ Features:
 
 - Add support for CMake Language Support natively in this extension. [#3559](https://github.com/microsoft/vscode-cmake-tools/issues/3559)
 
+Bug Fixes:
+- 
+
 ## 1.18.42
 
 Bug Fixes:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Features:
 - Add support for CMake Language Support natively in this extension. [#3559](https://github.com/microsoft/vscode-cmake-tools/issues/3559)
 
 Bug Fixes:
-- Fixes issue where new presets couldn't `inherit` from presets in CmakeUserPresets.json, and adds these presets to CmakeUserPresets.json instead of CmakePresets.json. [#3725](https://github.com/microsoft/vscode-cmake-tools/issues/3725)
+- Fixes issue where new presets couldn't inherit from presets in CmakeUserPresets.json. These presets are now added to CmakeUserPresets.json instead of CmakePresets.json. [#3725](https://github.com/microsoft/vscode-cmake-tools/issues/3725)
 
 ## 1.18.42
 

--- a/src/cmakeProject.ts
+++ b/src/cmakeProject.ts
@@ -582,7 +582,6 @@ export class CMakeProject {
             workflowPreset,
             lightNormalizePath(this.folderPath || '.'),
             this.sourceDir,
-            this.getPreferredGeneratorName(),
             true,
             this.configurePreset?.name);
         if (!expandedWorkflowPreset) {

--- a/src/preset.ts
+++ b/src/preset.ts
@@ -262,12 +262,12 @@ export interface ConfigurePreset extends Preset {
     installDir?: string;
 }
 
-export interface ConfigurePresetInheritPreset extends Preset {
+export interface InheritsConfigurePreset extends Preset {
     configurePreset?: string;
     inheritConfigureEnvironment?: boolean; // Defaults to true
 }
 
-export interface BuildPreset extends ConfigurePresetInheritPreset {
+export interface BuildPreset extends InheritsConfigurePreset {
     jobs?: number;
     targets?: string | string[];
     configuration?: string;
@@ -338,7 +338,7 @@ export interface ExecutionOptions {
     noTestsAction?: 'default' | 'error' | 'ignore';
 }
 
-export interface TestPreset extends ConfigurePresetInheritPreset {
+export interface TestPreset extends InheritsConfigurePreset {
     configuration?: string;
     overwriteConfigurationFile?: string[];
     output?: OutputOptions;
@@ -355,7 +355,7 @@ export interface PackageOutputOptions {
     verbose?: boolean;
 }
 
-export interface PackagePreset extends ConfigurePresetInheritPreset {
+export interface PackagePreset extends InheritsConfigurePreset {
     configurations?: string[];
     generators?: string[];
     variables?: { [key: string]: string | null | undefined };
@@ -575,8 +575,8 @@ export function inheritsFromUserPreset(preset: ConfigurePreset | BuildPreset | T
     );
 
     if ((presetType === 'buildPresets' || presetType === 'testPresets' || presetType === 'packagePresets') &&
-        ((preset as ConfigurePresetInheritPreset).configurePreset &&
-            originalUserPresetsFile.configurePresets?.find(p => p.name === (preset as ConfigurePresetInheritPreset).configurePreset))) {
+        ((preset as InheritsConfigurePreset).configurePreset &&
+            originalUserPresetsFile.configurePresets?.find(p => p.name === (preset as InheritsConfigurePreset).configurePreset))) {
         return true;
     } else if (preset.inherits && presetInherits(originalUserPresetsFile[presetType], preset.inherits)) {
         return true;

--- a/src/preset.ts
+++ b/src/preset.ts
@@ -1837,7 +1837,7 @@ async function expandPackagePresetHelper(folder: string, preset: PackagePreset, 
 // Map<fsPath, Set<referencedPresets>>
 const referencedWorkflowPresets: Map<string, Set<string>> = new Map();
 
-export async function expandWorkflowPreset(folder: string, name: string, workspaceFolder: string, sourceDir: string, preferredGeneratorName?: string, allowUserPreset: boolean = false, configurePreset?: string): Promise<WorkflowPreset | null> {
+export async function expandWorkflowPreset(folder: string, name: string, workspaceFolder: string, sourceDir: string, allowUserPreset: boolean = false, configurePreset?: string): Promise<WorkflowPreset | null> {
     const refs = referencedWorkflowPresets.get(folder);
     if (!refs) {
         referencedWorkflowPresets.set(folder, new Set());
@@ -1845,7 +1845,7 @@ export async function expandWorkflowPreset(folder: string, name: string, workspa
         refs.clear();
     }
 
-    const preset = await expandWorkflowPresetImpl(folder, name, workspaceFolder, sourceDir, preferredGeneratorName, allowUserPreset, configurePreset);
+    const preset = await expandWorkflowPresetImpl(folder, name, workspaceFolder, sourceDir, allowUserPreset, configurePreset);
     if (!preset) {
         return null;
     }
@@ -1858,16 +1858,16 @@ export async function expandWorkflowPreset(folder: string, name: string, workspa
     return expandedPreset;
 }
 
-async function expandWorkflowPresetImpl(folder: string, name: string, workspaceFolder: string, sourceDir: string, preferredGeneratorName?: string, allowUserPreset: boolean = false, configurePreset?: string): Promise<WorkflowPreset | null> {
+async function expandWorkflowPresetImpl(folder: string, name: string, workspaceFolder: string, sourceDir: string, allowUserPreset: boolean = false, configurePreset?: string): Promise<WorkflowPreset | null> {
     let preset = getPresetByName(workflowPresets(folder), name);
     if (preset) {
-        return expandWorkflowPresetHelper(folder, preset, workspaceFolder, sourceDir, preferredGeneratorName);
+        return expandWorkflowPresetHelper(folder, preset, workspaceFolder, sourceDir);
     }
 
     if (allowUserPreset) {
         preset = getPresetByName(userWorkflowPresets(folder), name);
         if (preset) {
-            return expandWorkflowPresetHelper(folder, preset, workspaceFolder, sourceDir, preferredGeneratorName, true);
+            return expandWorkflowPresetHelper(folder, preset, workspaceFolder, sourceDir, true);
         }
     }
 
@@ -1884,14 +1884,14 @@ async function expandWorkflowPresetImpl(folder: string, name: string, workspaceF
                 }
             ]
         };
-        return expandWorkflowPresetHelper(folder, preset, workspaceFolder, sourceDir, preferredGeneratorName, true);
+        return expandWorkflowPresetHelper(folder, preset, workspaceFolder, sourceDir, true);
     }
 
     log.error(localize('workflow.preset.not.found', 'Could not find workflow preset with name {0}', name));
     return null;
 }
 
-async function expandWorkflowPresetHelper(folder: string, preset: WorkflowPreset, workspaceFolder: string, sourceDir: string, preferredGeneratorName: string | undefined, allowUserPreset: boolean = false) {
+async function expandWorkflowPresetHelper(folder: string, preset: WorkflowPreset, workspaceFolder: string, sourceDir: string, allowUserPreset: boolean = false) {
     if (preset.__expanded) {
         return preset;
     }

--- a/src/preset.ts
+++ b/src/preset.ts
@@ -262,12 +262,12 @@ export interface ConfigurePreset extends Preset {
     installDir?: string;
 }
 
-export interface ConfigureInheritPreset extends Preset {
+export interface ConfigurePresetInheritPreset extends Preset {
     configurePreset?: string;
     inheritConfigureEnvironment?: boolean; // Defaults to true
 }
 
-export interface BuildPreset extends ConfigureInheritPreset {
+export interface BuildPreset extends ConfigurePresetInheritPreset {
     jobs?: number;
     targets?: string | string[];
     configuration?: string;
@@ -338,7 +338,7 @@ export interface ExecutionOptions {
     noTestsAction?: 'default' | 'error' | 'ignore';
 }
 
-export interface TestPreset extends ConfigureInheritPreset {
+export interface TestPreset extends ConfigurePresetInheritPreset {
     configuration?: string;
     overwriteConfigurationFile?: string[];
     output?: OutputOptions;
@@ -355,7 +355,7 @@ export interface PackageOutputOptions {
     verbose?: boolean;
 }
 
-export interface PackagePreset extends ConfigureInheritPreset {
+export interface PackagePreset extends ConfigurePresetInheritPreset {
     configurations?: string[];
     generators?: string[];
     variables?: { [key: string]: string | null | undefined };
@@ -575,8 +575,8 @@ export function inheritsFromUserPreset(preset: ConfigurePreset | BuildPreset | T
     );
 
     if ((presetType === 'buildPresets' || presetType === 'testPresets' || presetType === 'packagePresets') &&
-        ((preset as ConfigureInheritPreset).configurePreset &&
-            originalUserPresetsFile.configurePresets?.find(p => p.name === (preset as ConfigureInheritPreset).configurePreset))) {
+        ((preset as ConfigurePresetInheritPreset).configurePreset &&
+            originalUserPresetsFile.configurePresets?.find(p => p.name === (preset as ConfigurePresetInheritPreset).configurePreset))) {
         return true;
     } else if (preset.inherits && presetInherits(originalUserPresetsFile[presetType], preset.inherits)) {
         return true;

--- a/src/preset.ts
+++ b/src/preset.ts
@@ -10,7 +10,6 @@ import paths from '@cmt/paths';
 import { compareVersions, VSInstallation, vsInstallations, enumerateMsvcToolsets, varsForVSInstallation, getVcVarsBatScript } from '@cmt/installs/visualStudio';
 import { EnvironmentUtils, EnvironmentWithNull } from './environmentVariables';
 import { defaultNumJobs } from './config';
-import { UnevaluatedItemsError } from 'ajv/dist/vocabularies/unevaluated/unevaluatedItems';
 
 nls.config({ messageFormat: nls.MessageFormat.bundle, bundleFormat: nls.BundleFormat.standalone })();
 const localize: nls.LocalizeFunc = nls.loadMessageBundle();

--- a/src/preset.ts
+++ b/src/preset.ts
@@ -564,6 +564,31 @@ function isInheritable(key: keyof ConfigurePreset | keyof BuildPreset | keyof Te
     return key !== 'name' && key !== 'hidden' && key !== 'inherits' && key !== 'description' && key !== 'displayName';
 }
 
+export function inheritsFromUserPreset(preset: ConfigurePreset | BuildPreset | TestPreset | PackagePreset | WorkflowPreset,
+    presetType: 'configurePresets' | 'buildPresets' | 'testPresets' | 'packagePresets' | 'workflowPresets', folderPath: string): boolean {
+
+    const originalUserPresetsFile: PresetsFile = getOriginalUserPresetsFile(folderPath) || { version: 8 };
+
+    if (presetType === 'configurePresets' && preset.inherits &&
+    originalUserPresetsFile.configurePresets?.find(p =>
+        Array.isArray(preset.inherits)
+            ? preset.inherits.some(inherit => inherit === p.name)
+            : preset.inherits === p.name)) {
+        return true;
+    } else if (presetType === 'buildPresets' && (preset as BuildPreset).inheritConfigureEnvironment &&
+        originalUserPresetsFile.configurePresets?.find(p => p.name === (preset as BuildPreset).configurePreset)) {
+        return true;
+    } else if (presetType === 'testPresets' && (preset as TestPreset).inheritConfigureEnvironment &&
+        originalUserPresetsFile.configurePresets?.find(p => p.name === (preset as TestPreset).configurePreset)) {
+        return true;
+    } else if (presetType === 'packagePresets' && (preset as PackagePreset).inheritConfigureEnvironment &&
+        originalUserPresetsFile.configurePresets?.find(p => p.name === (preset as PackagePreset).configurePreset)) {
+        return true;
+    }
+
+    return false;
+}
+
 /**
  * Shallow copy if a key in base doesn't exist in target
  */

--- a/src/presetsController.ts
+++ b/src/presetsController.ts
@@ -1705,12 +1705,13 @@ export class PresetsController {
         presetType: 'configurePresets' | 'buildPresets' | 'testPresets' | 'packagePresets' | 'workflowPresets') {
         let presetsFile: preset.PresetsFile;
         // If the new preset inherits from a user preset, it should be added to the user presets file and marked as a user preset.
+        let isUserPreset = false;
         if (preset.inheritsFromUserPreset(newPreset, presetType, this.folderPath)) {
             presetsFile = preset.getOriginalUserPresetsFile(this.folderPath) || { version: 8 };
-            newPreset.isUserPreset = true;
+            isUserPreset = true;
         } else {
             presetsFile = preset.getOriginalPresetsFile(this.folderPath) || { version: 8 };
-            newPreset.isUserPreset = false;
+            isUserPreset = false;
         }
 
         if (!presetsFile[presetType]) {
@@ -1727,7 +1728,7 @@ export class PresetsController {
                 presetsFile[presetType]!.push(newPreset as preset.WorkflowPreset);
                 break;
         }
-        await this.updatePresetsFile(presetsFile, newPreset.isUserPreset);
+        await this.updatePresetsFile(presetsFile, isUserPreset);
     }
 
     private getIndentationSettings() {

--- a/src/presetsController.ts
+++ b/src/presetsController.ts
@@ -457,7 +457,7 @@ export class PresetsController {
     }
 
     async addBuildPreset(): Promise<boolean> {
-        if (preset.configurePresets(this.folderPath).length === 0) {
+        if (preset.allConfigurePresets(this.folderPath).length === 0) {
             return this.handleNoConfigurePresets();
         }
 
@@ -499,7 +499,7 @@ export class PresetsController {
             switch (chosenItem.name) {
                 case SpecialOptions.CreateFromConfigurationPreset: {
                     const placeHolder = localize('select.a.config.preset.placeholder', 'Select a configure preset');
-                    const presets = preset.configurePresets(this.folderPath);
+                    const presets = preset.allConfigurePresets(this.folderPath);
                     const configurePreset = await this.selectNonHiddenPreset(presets, presets, { placeHolder });
                     newPreset = { name: '__placeholder__', description: '', displayName: '', configurePreset };
                     break;
@@ -534,7 +534,7 @@ export class PresetsController {
     }
 
     async addTestPreset(): Promise<boolean> {
-        if (preset.configurePresets(this.folderPath).length === 0) {
+        if (preset.allConfigurePresets(this.folderPath).length === 0) {
             return this.handleNoConfigurePresets();
         }
 
@@ -576,7 +576,7 @@ export class PresetsController {
             switch (chosenItem.name) {
                 case SpecialOptions.CreateFromConfigurationPreset: {
                     const placeHolder = localize('select.a.config.preset.placeholder', 'Select a configure preset');
-                    const presets = preset.configurePresets(this.folderPath);
+                    const presets = preset.allConfigurePresets(this.folderPath);
                     const configurePreset = await this.selectNonHiddenPreset(presets, presets, { placeHolder });
                     newPreset = { name: '__placeholder__', description: '', displayName: '', configurePreset };
                     break;
@@ -610,7 +610,7 @@ export class PresetsController {
     }
 
     async addPackagePreset(): Promise<boolean> {
-        if (preset.configurePresets(this.folderPath).length === 0) {
+        if (preset.allConfigurePresets(this.folderPath).length === 0) {
             return this.handleNoConfigurePresets();
         }
 
@@ -652,7 +652,7 @@ export class PresetsController {
             switch (chosenItem.name) {
                 case SpecialOptions.CreateFromConfigurationPreset: {
                     const placeHolder = localize('select.a.config.preset.placeholder', 'Select a configure preset');
-                    const presets = preset.configurePresets(this.folderPath);
+                    const presets = preset.allConfigurePresets(this.folderPath);
                     const configurePreset = await this.selectNonHiddenPreset(presets, presets, { placeHolder });
                     newPreset = { name: '__placeholder__', description: '', displayName: '', configurePreset };
                     break;
@@ -686,7 +686,7 @@ export class PresetsController {
     }
 
     async addWorkflowPreset(): Promise<boolean> {
-        if (preset.configurePresets(this.folderPath).length === 0) {
+        if (preset.allConfigurePresets(this.folderPath).length === 0) {
             return this.handleNoConfigurePresets();
         }
 
@@ -734,7 +734,7 @@ export class PresetsController {
             switch (chosenItem.name) {
                 case SpecialOptions.CreateFromConfigurationPreset: {
                     const placeHolder = localize('select.a.config.preset.placeholder', 'Select a configure preset');
-                    const presets = preset.configurePresets(this.folderPath);
+                    const presets = preset.allConfigurePresets(this.folderPath);
                     const configurePreset = await this.selectNonHiddenPreset(presets, presets, { placeHolder });
                     if (configurePreset) {
                         newPreset = { name: '__placeholder__', description: '', displayName: '',
@@ -1703,21 +1703,16 @@ export class PresetsController {
     // Note: in case anyone want to change this, presetType must match the corresponding key in presets.json files
     async addPresetAddUpdate(newPreset: preset.ConfigurePreset | preset.BuildPreset | preset.TestPreset | preset.PackagePreset | preset.WorkflowPreset,
         presetType: 'configurePresets' | 'buildPresets' | 'testPresets' | 'packagePresets' | 'workflowPresets') {
-        const originalPresetsFile: preset.PresetsFile = preset.getOriginalPresetsFile(this.folderPath) || { version: 8 };
-        const originalUserPresetsFile: preset.PresetsFile = preset.getOriginalUserPresetsFile(this.folderPath) || { version: 8 };
         let presetsFile: preset.PresetsFile;
         let isUserPreset = false;
         // If the new configure preset inherits from a user preset, it should be added to the user presets file.
-        if (presetType === 'configurePresets' && newPreset.inherits &&
-            originalUserPresetsFile.configurePresets?.find(p =>
-                Array.isArray(newPreset.inherits)
-                    ? newPreset.inherits.some(inherit => inherit === p.name)
-                    : newPreset.inherits === p.name)) {
-            presetsFile = originalUserPresetsFile;
+        if (preset.inheritsFromUserPreset(newPreset, presetType, this.folderPath)) {
+            presetsFile = preset.getOriginalUserPresetsFile(this.folderPath) || { version: 8 };
             isUserPreset = true;
         } else {
-            presetsFile = originalPresetsFile;
+            presetsFile = preset.getOriginalPresetsFile(this.folderPath) || { version: 8 };
         }
+
         if (!presetsFile[presetType]) {
             presetsFile[presetType] = [];
         }

--- a/src/presetsController.ts
+++ b/src/presetsController.ts
@@ -476,7 +476,7 @@ export class PresetsController {
             label: localize('create.build.from.config.preset', 'Create from Configure Preset'),
             description: localize('description.create.build.from.config.preset', 'Create a new build preset')
         }];
-        if (preset.buildPresets(this.folderPath).length > 0) {
+        if (preset.allBuildPresets(this.folderPath).length > 0) {
             items.push({
                 name: SpecialOptions.InheritBuildPreset,
                 label: localize('inherit.build.preset', 'Inherit from Build Preset'),
@@ -506,7 +506,7 @@ export class PresetsController {
                 }
                 case SpecialOptions.InheritBuildPreset: {
                     const placeHolder = localize('select.one.or.more.build.preset.placeholder', 'Select one or more build presets');
-                    const presets = preset.buildPresets(this.folderPath);
+                    const presets = preset.allBuildPresets(this.folderPath);
                     const inherits = await this.selectAnyPreset(presets, presets, { placeHolder, canPickMany: true });
                     newPreset = { name: '__placeholder__', description: '', displayName: '', inherits };
                     break;
@@ -553,7 +553,7 @@ export class PresetsController {
             label: localize('create.test.from.config.preset', 'Create from Configure Preset'),
             description: localize('description.create.test.from.config.preset', 'Create a new test preset')
         }];
-        if (preset.testPresets(this.folderPath).length > 0) {
+        if (preset.allTestPresets(this.folderPath).length > 0) {
             items.push({
                 name: SpecialOptions.InheritTestPreset,
                 label: localize('inherit.test.preset', 'Inherit from Test Preset'),
@@ -583,7 +583,7 @@ export class PresetsController {
                 }
                 case SpecialOptions.InheritTestPreset: {
                     const placeHolder = localize('select.one.or.more.test.preset.placeholder', 'Select one or more test presets');
-                    const presets = preset.testPresets(this.folderPath);
+                    const presets = preset.allTestPresets(this.folderPath);
                     const inherits = await this.selectAnyPreset(presets, presets, { placeHolder, canPickMany: true });
                     newPreset = { name: '__placeholder__', description: '', displayName: '', inherits };
                     break;
@@ -711,7 +711,7 @@ export class PresetsController {
             label: localize('create.workflow.from.config.preset', 'Create from Configure Preset'),
             description: localize('description.create.workflow.from.config.preset', 'Create a new workflow preset')
         }];
-        if (preset.workflowPresets(this.folderPath).length > 0) {
+        if (preset.allWorkflowPresets(this.folderPath).length > 0) {
             items.push({
                 name: SpecialOptions.CreateFromWorkflowPreset,
                 label: localize('create.workflow.preset', 'Create from Workflow Preset'),
@@ -745,7 +745,7 @@ export class PresetsController {
                 }
                 case SpecialOptions.CreateFromWorkflowPreset: {
                     const placeHolder = localize('select.one.workflow.preset.placeholder', 'Select one workflow base preset');
-                    const presets = preset.workflowPresets(this.folderPath);
+                    const presets = preset.allWorkflowPresets(this.folderPath);
                     const workflowBasePresetName = await this.selectNonHiddenPreset(presets, presets, { placeHolder, canPickMany: false });
                     const workflowBasePreset = presets.find(pr => pr.name === workflowBasePresetName);
                     newPreset = { name: '__placeholder__', description: '', displayName: '', steps: workflowBasePreset?.steps || [{type: "configure", name: "_placeholder_"}] };
@@ -1705,7 +1705,7 @@ export class PresetsController {
         presetType: 'configurePresets' | 'buildPresets' | 'testPresets' | 'packagePresets' | 'workflowPresets') {
         let presetsFile: preset.PresetsFile;
         let isUserPreset = false;
-        // If the new configure preset inherits from a user preset, it should be added to the user presets file.
+        // If the new preset inherits from a user preset, it should be added to the user presets file.
         if (preset.inheritsFromUserPreset(newPreset, presetType, this.folderPath)) {
             presetsFile = preset.getOriginalUserPresetsFile(this.folderPath) || { version: 8 };
             isUserPreset = true;

--- a/src/presetsController.ts
+++ b/src/presetsController.ts
@@ -1703,9 +1703,10 @@ export class PresetsController {
     // Note: in case anyone want to change this, presetType must match the corresponding key in presets.json files
     async addPresetAddUpdate(newPreset: preset.ConfigurePreset | preset.BuildPreset | preset.TestPreset | preset.PackagePreset | preset.WorkflowPreset,
         presetType: 'configurePresets' | 'buildPresets' | 'testPresets' | 'packagePresets' | 'workflowPresets') {
+        // If the new preset inherits from a user preset, it should be added to the user presets file.
         let presetsFile: preset.PresetsFile;
-        // If the new preset inherits from a user preset, it should be added to the user presets file and marked as a user preset.
         let isUserPreset = false;
+
         if (preset.inheritsFromUserPreset(newPreset, presetType, this.folderPath)) {
             presetsFile = preset.getOriginalUserPresetsFile(this.folderPath) || { version: 8 };
             isUserPreset = true;

--- a/src/presetsController.ts
+++ b/src/presetsController.ts
@@ -1704,13 +1704,13 @@ export class PresetsController {
     async addPresetAddUpdate(newPreset: preset.ConfigurePreset | preset.BuildPreset | preset.TestPreset | preset.PackagePreset | preset.WorkflowPreset,
         presetType: 'configurePresets' | 'buildPresets' | 'testPresets' | 'packagePresets' | 'workflowPresets') {
         let presetsFile: preset.PresetsFile;
-        let isUserPreset = false;
-        // If the new preset inherits from a user preset, it should be added to the user presets file.
+        // If the new preset inherits from a user preset, it should be added to the user presets file and marked as a user preset.
         if (preset.inheritsFromUserPreset(newPreset, presetType, this.folderPath)) {
             presetsFile = preset.getOriginalUserPresetsFile(this.folderPath) || { version: 8 };
-            isUserPreset = true;
+            newPreset.isUserPreset = true;
         } else {
             presetsFile = preset.getOriginalPresetsFile(this.folderPath) || { version: 8 };
+            newPreset.isUserPreset = false;
         }
 
         if (!presetsFile[presetType]) {
@@ -1727,7 +1727,7 @@ export class PresetsController {
                 presetsFile[presetType]!.push(newPreset as preset.WorkflowPreset);
                 break;
         }
-        await this.updatePresetsFile(presetsFile, isUserPreset);
+        await this.updatePresetsFile(presetsFile, newPreset.isUserPreset);
     }
 
     private getIndentationSettings() {

--- a/src/presetsController.ts
+++ b/src/presetsController.ts
@@ -370,7 +370,7 @@ export class PresetsController {
                 }
                 case SpecialOptions.InheritConfigurationPreset: {
                     const placeHolder = localize('select.one.or.more.config.preset.placeholder', 'Select one or more configure presets');
-                    const presets = preset.configurePresets(this.folderPath);
+                    const presets = preset.allConfigurePresets(this.folderPath);
                     const inherits = await this.selectAnyPreset(presets, presets, { placeHolder, canPickMany: true });
                     newPreset = { name: '__placeholder__', description: '', displayName: '', inherits };
                     break;

--- a/src/presetsController.ts
+++ b/src/presetsController.ts
@@ -997,10 +997,8 @@ export class PresetsController {
             const workflowPresets = preset.allWorkflowPresets(this.folderPath);
             for (const workflowPreset of workflowPresets) {
                 // Set active workflow preset as the first valid workflow preset (matching the selected configure preset is not a requirement as for the other presets types)
-                if (!workflowPreset.hidden) {
-                    await this.setWorkflowPreset(workflowPreset.name, false/*needToCheckConfigurePreset*/, false/*checkChangingPreset*/);
-                    currentWorkflowPreset = this.project.workflowPreset?.name;
-                }
+                await this.setWorkflowPreset(workflowPreset.name, false/*needToCheckConfigurePreset*/, false/*checkChangingPreset*/);
+                currentWorkflowPreset = this.project.workflowPreset?.name;
                 if (currentWorkflowPreset) {
                     break;
                 }


### PR DESCRIPTION
Fixes #3725 

Fixes issue where new presets couldn't inherit from configure presets in CmakeUserPresets.json, and couldn't expand from other build/test/package presets. 

Presets that have a parent in CmakeUserPresets.json are now added to CmakeUserPresets.json instead of CmakePresets.json.

Updated WorkflowPreset class to not extend Preset to adhere to https://cmake.org/cmake/help/latest/manual/cmake-presets.7.html#workflow-preset

Open to suggestions on a better interface name than "ConfigurePresetInheritPreset" :)