### PR TITLE
Fixes #3811 - checks for cmake.exe again if it wasnt present the previous time 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Bug Fixes:
 - Fix issue with "Test Results Not Found" when `cmake.ctest.allowParallelJobs` is disabled. [#3798](https://github.com/microsoft/vscode-cmake-tools/issues/3798)
 - Update localized strings for Project Status UI and quick pick dropdowns. [#3803](https://github.com/microsoft/vscode-cmake-tools/issues/3803), [#3802](https://github.com/microsoft/vscode-cmake-tools/issues/3802)
 - Fix issue where new presets couldn't inherit from presets in CmakeUserPresets.json. These presets are now added to CmakeUserPresets.json instead of CmakePresets.json. [#3725](https://github.com/microsoft/vscode-cmake-tools/issues/3725)
-- Fix issue where CMakeTools does not recheck CMake Path to see if user instakked CMake after launching VS Code. [3811](https://github.com/microsoft/vscode-cmake-tools/issues/3811)
+- Fix issue where CMakeTools does not recheck CMake Path to see if user installed CMake after launching VS Code. [3811](https://github.com/microsoft/vscode-cmake-tools/issues/3811)
 
 ## 1.18.42
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Bug Fixes:
 - Fix issue with "Test Results Not Found" when `cmake.ctest.allowParallelJobs` is disabled. [#3798](https://github.com/microsoft/vscode-cmake-tools/issues/3798)
 - Update localized strings for Project Status UI and quick pick dropdowns. [#3803](https://github.com/microsoft/vscode-cmake-tools/issues/3803), [#3802](https://github.com/microsoft/vscode-cmake-tools/issues/3802)
 - Fix issue where new presets couldn't inherit from presets in CmakeUserPresets.json. These presets are now added to CmakeUserPresets.json instead of CmakePresets.json. [#3725](https://github.com/microsoft/vscode-cmake-tools/issues/3725)
+- Fix issue where CMakeTools does not recheck CMake Path to see if user instakked CMake after launching VS Code. [3811](https://github.com/microsoft/vscode-cmake-tools/issues/3811)
 
 ## 1.18.42
 

--- a/src/cmake/cmakeExecutable.ts
+++ b/src/cmake/cmakeExecutable.ts
@@ -29,10 +29,12 @@ export async function getCMakeExecutableInformation(path: string): Promise<CMake
         const normalizedPath = util.platformNormalizePath(path);
         if (cmakeInfo.has(normalizedPath)) {
             const cmakeExe: CMakeExecutable = cmakeInfo.get(normalizedPath)!;
-            await setCMakeDebuggerAvailableContext(
-                cmakeExe.isDebuggerSupported?.valueOf() ?? false
-            );
-            return cmakeExe;
+            if (cmakeExe.isPresent) {
+                await setCMakeDebuggerAvailableContext(
+                    cmakeExe.isDebuggerSupported?.valueOf() ?? false
+                );
+                return cmakeExe;
+            }
         }
 
         try {


### PR DESCRIPTION
Fixes #3811.  CMakeTools now rechecks the same CMake Path to see if user installed CMake after launching VS Code, when it was previously an invalid path.