### PR TITLE
Custom visualStudio kit PATH setting is ineffective  fix #3849

### DIFF
--- a/src/kit.ts
+++ b/src/kit.ts
@@ -1010,7 +1010,11 @@ export async function effectiveKitEnvironment(kit: Kit, opts?: expand.ExpansionO
     if (process.platform === 'win32') {
         if (kit.visualStudio && kit.visualStudioArchitecture) {
             const vs_vars = await getVSKitEnvironment(kit);
+            const kitPath = env['PATH'];
             env = EnvironmentUtils.merge([env, vs_vars]);
+            if (kitPath) {
+                env['PATH'] = [kitPath, env['PATH']].join(';');
+            }
         } else {
             const path_list: string[] = [];
             const cCompiler = kit.compilers?.C;


### PR DESCRIPTION
https://github.com/microsoft/vscode-cmake-tools/blob/39f372b90469fa15a18c0fad5d5f871abac9ec8e/src/kit.ts#L1011-L1014

PATH variable in `vs_vars` overwrite PATH variable in `env` after merge

please check #3849 for details