### PR TITLE
Set useCMakePresets context after quick start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Bug Fixes:
 - Fix issue where new presets couldn't inherit from presets in CmakeUserPresets.json. These presets are now added to CmakeUserPresets.json instead of CmakePresets.json. [#3725](https://github.com/microsoft/vscode-cmake-tools/issues/3725)
 - Fix issue where CMakeTools does not recheck CMake Path to see if user installed CMake after launching VS Code. [3811](https://github.com/microsoft/vscode-cmake-tools/issues/3811)
 - Fix issue where `cmake.buildToolArgs` was sometimes applied incorrectly when presets are used [#3754](https://github.com/microsoft/vscode-cmake-tools/issues/3754)
+- Ensure `useCMakePresets` context is set after making a CMakePreset.json with `Quick Start`. [#3734](https://github.com/microsoft/vscode-cmake-tools/issues/3734)
 
 ## 1.18.42
 

--- a/src/cmakeProject.ts
+++ b/src/cmakeProject.ts
@@ -2847,9 +2847,7 @@ export class CMakeProject {
         if (await fs.exists(mainPresetsFile)) {
             log.info(localize('cmakepresets.already.configured', '[Quick Start] A CMakePresets.json is already configured.'));
         } else {
-            await this.setUseCMakePresets(true);
             if (!await this.presetsController.selectConfigurePreset(true)) {
-            //if (!await extensionManager?.selectConfigurePreset(true)) {
                 await this.kitsController.setKitByName(SpecialKits.Unspecified);
                 log.info(localize('cmakepresets.not.created', '[Quick Start] CMakePresets.json not created.'));
             } else {
@@ -2857,8 +2855,7 @@ export class CMakeProject {
             }
         }
 
-        //await this.projectController?.updateActiveProject(this.workspaceFolder);
-        await this.projectController?.setActiveProject(this);
+        await this.projectController?.updateActiveProject(this.workspaceFolder);
 
         // Regardless of the following configure return code,
         // we want full feature set view for the whole workspace.

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -418,7 +418,7 @@ export class ExtensionManager implements vscode.Disposable {
             if (cmakeProject.configurePreset) {
                 return true;
             }
-            const didChoosePreset = await this.selectConfigurePreset(false, cmakeProject.workspaceFolder);
+            const didChoosePreset = await this.selectConfigurePreset(cmakeProject.workspaceFolder);
             if (!didChoosePreset && !cmakeProject.configurePreset) {
                 return false;
             }
@@ -1935,7 +1935,7 @@ export class ExtensionManager implements vscode.Disposable {
     /**
      * Show UI to allow the user to select an active configure preset
      */
-    async selectConfigurePreset(quickstart?: boolean, folder?: vscode.WorkspaceFolder): Promise<boolean> {
+    async selectConfigurePreset(folder?: vscode.WorkspaceFolder): Promise<boolean> {
         if (util.isTestMode()) {
             log.trace(localize('selecting.config.preset.in.test.mode', 'Running CMakeTools in test mode. selectConfigurePreset is disabled.'));
             return false;
@@ -1951,7 +1951,7 @@ export class ExtensionManager implements vscode.Disposable {
             return false;
         }
 
-        const presetSelected = await project.presetsController.selectConfigurePreset(quickstart);
+        const presetSelected = await project.presetsController.selectConfigurePreset();
         const configurePreset = project.configurePreset;
         this.statusBar.setConfigurePresetName(configurePreset?.displayName || configurePreset?.name || '');
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -418,7 +418,7 @@ export class ExtensionManager implements vscode.Disposable {
             if (cmakeProject.configurePreset) {
                 return true;
             }
-            const didChoosePreset = await this.selectConfigurePreset(cmakeProject.workspaceFolder);
+            const didChoosePreset = await this.selectConfigurePreset(false, cmakeProject.workspaceFolder);
             if (!didChoosePreset && !cmakeProject.configurePreset) {
                 return false;
             }
@@ -1935,7 +1935,7 @@ export class ExtensionManager implements vscode.Disposable {
     /**
      * Show UI to allow the user to select an active configure preset
      */
-    async selectConfigurePreset(folder?: vscode.WorkspaceFolder): Promise<boolean> {
+    async selectConfigurePreset(quickstart?: boolean, folder?: vscode.WorkspaceFolder): Promise<boolean> {
         if (util.isTestMode()) {
             log.trace(localize('selecting.config.preset.in.test.mode', 'Running CMakeTools in test mode. selectConfigurePreset is disabled.'));
             return false;
@@ -1951,7 +1951,7 @@ export class ExtensionManager implements vscode.Disposable {
             return false;
         }
 
-        const presetSelected = await project.presetsController.selectConfigurePreset();
+        const presetSelected = await project.presetsController.selectConfigurePreset(quickstart);
         const configurePreset = project.configurePreset;
         this.statusBar.setConfigurePresetName(configurePreset?.displayName || configurePreset?.name || '');
 


### PR DESCRIPTION
Ensure `useCMakePresets` context is set after making a CMakePreset.json with Quick Start, so the `Select Configure Preset` and `Add Configure Preset` options are available in the command pallete.

This works by updating the active project after the new project files are made, which in turn updates the use presets context.

In the future, it would be good to set up a file watcher to call this function to cover other use cases.

Fixes #3734.