### PR TITLE
clean configures when platform differs between old and new selected kit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ Bug Fixes:
 - Fix issue where new presets couldn't inherit from presets in CmakeUserPresets.json. These presets are now added to CmakeUserPresets.json instead of CmakePresets.json. [#3725](https://github.com/microsoft/vscode-cmake-tools/issues/3725)
 - Fix issue where CMakeTools does not recheck CMake Path to see if user installed CMake after launching VS Code. [3811](https://github.com/microsoft/vscode-cmake-tools/issues/3811)
 - Fix issue where `cmake.buildToolArgs` was sometimes applied incorrectly when presets are used [#3754](https://github.com/microsoft/vscode-cmake-tools/issues/3754)
-- Fix issue where `preferredGenerator.platform` wasn't being compared between the old and new kit to trigger a clean configure on a kit selection change. [#2699](https://github.com/microsoft/vscode-cmake-tools/issues/2699)
+- Fix issue where `preferredGenerator.platform` and `preferredGenerator.toolset` wasn't being compared between the old and new kit to trigger a clean configure on a kit selection change. [#2699](https://github.com/microsoft/vscode-cmake-tools/issues/2699)
 - Still allow for users to add `--warn-unused-cli`. Now instead of overriding, it will remove our default `--no-warn-unused-cli`. [#1090](https://github.com/microsoft/vscode-cmake-tools/issues/1090)
 
 ## 1.18.42

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Bug Fixes:
 - Fix issue where new presets couldn't inherit from presets in CmakeUserPresets.json. These presets are now added to CmakeUserPresets.json instead of CmakePresets.json. [#3725](https://github.com/microsoft/vscode-cmake-tools/issues/3725)
 - Fix issue where CMakeTools does not recheck CMake Path to see if user installed CMake after launching VS Code. [3811](https://github.com/microsoft/vscode-cmake-tools/issues/3811)
 - Fix issue where `cmake.buildToolArgs` was sometimes applied incorrectly when presets are used [#3754](https://github.com/microsoft/vscode-cmake-tools/issues/3754)
+- Fix issue where `preferredGenerator.platform` wasn't being compared between the old and new kit to trigger a clean configure on a kit selection change. [#2699](https://github.com/microsoft/vscode-cmake-tools/issues/2699)
 
 ## 1.18.42
 

--- a/src/kit.ts
+++ b/src/kit.ts
@@ -1370,7 +1370,8 @@ export function kitChangeNeedsClean(newKit: Kit, oldKit: Kit | null): boolean {
         vs: k.visualStudio,
         vsArch: k.visualStudioArchitecture,
         tc: k.toolchainFile,
-        preferredGenerator: k.preferredGenerator ? k.preferredGenerator.name : null
+        preferredGeneratorName: k.preferredGenerator ? k.preferredGenerator.name : null,
+        preferredGeneratorPlatform: k.preferredGenerator && k.preferredGenerator.platform ? k.preferredGenerator.platform : null
     });
     const new_imp = important_params(newKit);
     const old_imp = important_params(oldKit);

--- a/src/kit.ts
+++ b/src/kit.ts
@@ -1371,7 +1371,8 @@ export function kitChangeNeedsClean(newKit: Kit, oldKit: Kit | null): boolean {
         vsArch: k.visualStudioArchitecture,
         tc: k.toolchainFile,
         preferredGeneratorName: k.preferredGenerator ? k.preferredGenerator.name : null,
-        preferredGeneratorPlatform: k.preferredGenerator && k.preferredGenerator.platform ? k.preferredGenerator.platform : null
+        preferredGeneratorPlatform: k.preferredGenerator && k.preferredGenerator.platform ? k.preferredGenerator.platform : null,
+        preferredGeneratorToolset: k.preferredGenerator && k.preferredGenerator.toolset ? k.preferredGenerator.toolset : null
     });
     const new_imp = important_params(newKit);
     const old_imp = important_params(oldKit);


### PR DESCRIPTION
## This change addresses item #2699 

### This changes visible behavior

The following changes are proposed:

-When the user changes the selected kit, I added a check to see if the platform changed, which triggers a clean configure.