### PR TITLE
Updated command string to better reflect function

### DIFF
--- a/package.nls.json
+++ b/package.nls.json
@@ -64,7 +64,7 @@
     "cmake-tools.command.cmake.debugTargetAll.title": "Debug All Projects",
     "cmake-tools.command.cmake.launchTarget.title": "Run Without Debugging",
     "cmake-tools.command.cmake.launchTargetAll.title": "Run All Projects Without Debugging",
-    "cmake-tools.command.cmake.selectLaunchTarget.title": "Set Debug Target",
+    "cmake-tools.command.cmake.selectLaunchTarget.title": "Set Launch/Debug Target",
     "cmake-tools.command.cmake.stop.title": "Cancel Build",
     "cmake-tools.command.cmake.stopAll.title": "Cancel Build for All Projects",
     "cmake-tools.command.cmake.resetState.title": "Reset CMake Tools Extension State (For troubleshooting)",


### PR DESCRIPTION
"CMake: Set Debug Target" -> "CMake: Set Launch/Debug Target"

The latter string is what is used in the UI for the same function call so I updated the command palette string to say the same thing. This isn't the requested bug fix, but I noticed this discrepancy in #1405 