### PR TITLE
Add guard against reloading a file that's not a variants file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Bug Fixes:
 - Still allow for users to add `--warn-unused-cli`. Now instead of overriding, it will remove our default `--no-warn-unused-cli`. [#1090](https://github.com/microsoft/vscode-cmake-tools/issues/1090)
 - Ensure `useCMakePresets` context is set after making a CMakePreset.json with `Quick Start`. [#3734](https://github.com/microsoft/vscode-cmake-tools/issues/3734)
 - Fix issue where `cmake.preferredGenerators` wasn't falling back to the next entry when the first entry didn't exist [#2709](https://github.com/microsoft/vscode-cmake-tools/issues/2709)
+- Potential fix for attempting to load a non-variants file as a variants file and throwing a parse exception [#3727](https://github.com/microsoft/vscode-cmake-tools/issues/3727)
 
 ## 1.18.42
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # What's New?
 
+## 1.19.0
+
+Bug Fixes:
+
+- Fix issue where `cmake.preferredGenerators` wasn't falling back to the next entry when the first entry didn't exist [#2709](https://github.com/microsoft/vscode-cmake-tools/issues/2709)
+- Potential fix for attempting to load a non-variants file as a variants file and throwing a parse exception [#3727](https://github.com/microsoft/vscode-cmake-tools/issues/3727)
+
 ## 1.18.43
 
 Features:
@@ -21,8 +28,6 @@ Bug Fixes:
 - Fix issue where `preferredGenerator.platform` and `preferredGenerator.toolset` wasn't being compared between the old and new kit to trigger a clean configure on a kit selection change. [#2699](https://github.com/microsoft/vscode-cmake-tools/issues/2699)
 - Still allow for users to add `--warn-unused-cli`. Now instead of overriding, it will remove our default `--no-warn-unused-cli`. [#1090](https://github.com/microsoft/vscode-cmake-tools/issues/1090)
 - Ensure `useCMakePresets` context is set after making a CMakePreset.json with `Quick Start`. [#3734](https://github.com/microsoft/vscode-cmake-tools/issues/3734)
-- Fix issue where `cmake.preferredGenerators` wasn't falling back to the next entry when the first entry didn't exist [#2709](https://github.com/microsoft/vscode-cmake-tools/issues/2709)
-- Potential fix for attempting to load a non-variants file as a variants file and throwing a parse exception [#3727](https://github.com/microsoft/vscode-cmake-tools/issues/3727)
 
 ## 1.18.42
 

--- a/src/variant.ts
+++ b/src/variant.ts
@@ -233,14 +233,16 @@ export class VariantManager implements vscode.Disposable {
         this.customVariantsFileExists = false;
         const validate = await loadSchema('./schemas/variants-schema.json');
 
-        if (!filepath || !await fs.exists(filepath)) {
-            const workspaceFolder: string = this.workspaceFolder.uri.fsPath;
-            const candidates = [
-                path.join(workspaceFolder, 'cmake-variants.json'),
-                path.join(workspaceFolder, 'cmake-variants.yaml'),
-                path.join(workspaceFolder, '.vscode/cmake-variants.json'),
-                path.join(workspaceFolder, '.vscode/cmake-variants.yaml')
-            ];
+        // Variants file should be one of these four options
+        const workspaceFolder: string = this.workspaceFolder.uri.fsPath;
+        const candidates = [
+            path.join(workspaceFolder, 'cmake-variants.json'),
+            path.join(workspaceFolder, 'cmake-variants.yaml'),
+            path.join(workspaceFolder, '.vscode/cmake-variants.json'),
+            path.join(workspaceFolder, '.vscode/cmake-variants.yaml')
+        ];
+
+        if (!filepath || !await fs.exists(filepath) || !candidates.includes(filepath)) {
             for (const testpath of candidates) {
                 if (await fs.exists(testpath)) {
                     filepath = testpath;


### PR DESCRIPTION
## This change addresses item #3727 

The following changes are proposed:

- Add an explicit guard when reloading the variants file to make sure that the file we're loading is actually a variants file, so we don't try to treat any other file as a variants file and throw a parsing exception.

## Other Notes/Information

Ideally, we would figure out why the reload variants functionality would be given a path other than a variants file, since our file watcher should only be watching for variants files, but I haven't figured that out yet