### PR TITLE
Skip loading variants when using CMakePresets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 1.19
 
+Improvements:
+
+- Skip loading variants when using CMakePresets. [#3300](https://github.com/microsoft/vscode-cmake-tools/issues/3300)
+
 Bug Fixes:
 
 - Fix issue where `cmake.preferredGenerators` wasn't falling back to the next entry when the first entry didn't exist [#2709](https://github.com/microsoft/vscode-cmake-tools/issues/2709)

--- a/src/cmakeProject.ts
+++ b/src/cmakeProject.ts
@@ -1069,7 +1069,16 @@ export class CMakeProject {
             this.statusMessage.set(localize('ready.status', 'Ready'));
         }
 
-        await drv.setVariant(this.variantManager.activeVariantOptions, this.variantManager.activeKeywordSetting);
+        // Set variant in driver when not using presets
+        if (!this.useCMakePresets) {
+            // Make sure the variant manager is initialized first
+            if (!this.variantManager.hasInitialized()) {
+                await this.variantManager.initialize(this.folderName);
+            }
+
+            await drv.setVariant(this.variantManager.activeVariantOptions, this.variantManager.activeKeywordSetting);
+        }
+
         const newTargetName = this.defaultBuildTarget || (this.useCMakePresets ? this.targetsInPresetName : drv.allTargetName);
         if (this.targetName.value !== newTargetName) {
             this.targetName.set(newTargetName);
@@ -1146,14 +1155,28 @@ export class CMakeProject {
         log.debug(localize('second.phase.init', 'Starting CMake Tools second-phase init'));
         await this.setSourceDir(await util.normalizeAndVerifySourceDir(sourceDirectory, CMakeDriver.sourceDirExpansionOptions(this.workspaceContext.folder.uri.fsPath)));
         this.doStatusChange(this.workspaceContext.config.options);
-        // Start up the variant manager
-        await this.variantManager.initialize(this.folderName);
-        // Set the status bar message
-        this.activeVariant.set(this.variantManager.activeVariantOptions.short);
         // Restore the debug target
         this._launchTargetName.set(this.workspaceContext.state.getLaunchTargetName(this.folderName, this.isMultiProjectFolder) || '');
 
         // Hook up event handlers
+        this.cTestController.onTestingEnabledChanged(enabled => this._ctestEnabled.set(enabled));
+        this.cPackageController.onPackagingEnabledChanged(enabled => this._cpackEnabled.set(enabled));
+
+        this.statusMessage.set(localize('ready.status', 'Ready'));
+
+        this.kitsController = await KitsController.init(this);
+        this.presetsController = await PresetsController.init(this, this.kitsController, this.isMultiProjectFolder);
+
+        await this.doUseCMakePresetsChange();
+
+        // Only initialize the variant manager when not using presets
+        if (!this.useCMakePresets) {
+            // Start up the variant manager
+            await this.variantManager.initialize(this.folderName);
+            // Set the status bar message
+            this.activeVariant.set(this.variantManager.activeVariantOptions.short);
+        }
+
         // Listen for the variant to change
         this.variantManager.onActiveVariantChanged(() => {
             log.debug(localize('active.build.variant.changed', 'Active build variant changed'));
@@ -1166,15 +1189,6 @@ export class CMakeProject {
                 }
             });
         });
-        this.cTestController.onTestingEnabledChanged(enabled => this._ctestEnabled.set(enabled));
-        this.cPackageController.onPackagingEnabledChanged(enabled => this._cpackEnabled.set(enabled));
-
-        this.statusMessage.set(localize('ready.status', 'Ready'));
-
-        this.kitsController = await KitsController.init(this);
-        this.presetsController = await PresetsController.init(this, this.kitsController, this.isMultiProjectFolder);
-
-        await this.doUseCMakePresetsChange();
 
         this.disposables.push(this.onPresetsChanged(() => this.doUseCMakePresetsChange()));
         this.disposables.push(this.onUserPresetsChanged(() => this.doUseCMakePresetsChange()));
@@ -1761,6 +1775,10 @@ export class CMakeProject {
                 log.debug(localize('no.kit.abort', 'No kit selected. Abort configure'));
                 return { result: -1, resultType: ConfigureResultType.Other };
             }
+            // Make sure variant manager has initialized before checking for variant
+            if (!this.variantManager.hasInitialized()) {
+                await this.variantManager.initialize(this.folderName);
+            }
             if (!this.variantManager.haveVariant) {
                 progress.report({ message: localize('waiting.on.variant', 'Waiting on variant selection') });
                 await this.variantManager.selectVariant();
@@ -2286,6 +2304,11 @@ export class CMakeProject {
      */
     async setVariant(name?: string) {
         // Make this function compatibile with return code style...
+        // Make sure the variant manager is initialized first
+        if (!this.variantManager.hasInitialized()) {
+            await this.variantManager.initialize(this.folderName);
+        }
+
         if (await this.variantManager.selectVariant(name)) {
             if (this.workspaceContext.config.automaticReconfigure) {
                 await this.configureInternal(ConfigureTrigger.setVariant, [], ConfigureType.Normal);
@@ -2510,6 +2533,11 @@ export class CMakeProject {
                 buildType = preset.getStringValueFromCacheVar(this.configurePreset.cacheVariables["CMAKE_BUILD_TYPE"]);
             }
         } else {
+            // Make sure the variant manager is initialized first
+            if (!this.variantManager.hasInitialized()) {
+                await this.variantManager.initialize(this.folderName);
+            }
+
             buildType = this.variantManager.activeVariantOptions.buildType || null;
         }
         return buildType;

--- a/src/drivers/cmakeDriver.ts
+++ b/src/drivers/cmakeDriver.ts
@@ -850,7 +850,7 @@ export abstract class CMakeDriver implements vscode.Disposable {
     }
 
     /**
-     * Get the current build type, according to the current selected variant.
+     * Get the current build type, according to the current selected preset or variant.
      *
      * This is the value passed to CMAKE_BUILD_TYPE or --config for multiconf
      */

--- a/src/variant.ts
+++ b/src/variant.ts
@@ -190,6 +190,11 @@ export class VariantManager implements vscode.Disposable {
     private readonly _variantFileWatcher = chokidar.watch([], { ignoreInitial: true, followSymlinks: false });
     private customVariantsFileExists: boolean = false;
 
+    /**
+     * Whether the variant manager has been initialized
+     */
+    private initialized: boolean = false;
+
     dispose() {
         void this._variantFileWatcher.close();
         this._activeVariantChanged.dispose();
@@ -331,7 +336,7 @@ export class VariantManager implements vscode.Disposable {
         const invalid_variant = {
             key: '__invalid__',
             short: 'Unknown',
-            long: 'Unknwon'
+            long: 'Unknown'
         };
         const kws = this.stateManager.getActiveVariantSettings(this.folderName, this.isMultiProject);
         if (!kws) {
@@ -435,5 +440,11 @@ export class VariantManager implements vscode.Disposable {
             const defaultChoices = this.findDefaultChoiceCombination();
             await this.publishActiveKeywordSettings(defaultChoices);
         }
+
+        this.initialized = true;
+    }
+
+    hasInitialized(): boolean {
+        return this.initialized;
     }
 }


### PR DESCRIPTION
## This change addresses item #3300

### This changes when variants are loaded

The following changes are proposed:

- When initializing the cmakeProject, skip initializing the variantManager if CMakePresets is found the be used
- Initialize the variantManager when not using CMakePresets or if the project switches to not use CMakePresets
- Add a hasInitialized function to VariantManager so we know whether the variantManager has been initialized or not, so we know when to initialize variantManager and to prevent initializing multiple times
- Other minor cleanup

## Other Notes/Information

Still testing, will update when I'm done testing
