### PR TITLE
Allow CMake to select a default internal generator when the user selects "__unspec__" for the kit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,11 @@
 
 Bug Fixes:
 
-- Fix issue where `cmake.preferredGenerators` wasn't falling back to the next entry when the first entry didn't exist [#2709](https://github.com/microsoft/vscode-cmake-tools/issues/2709)
-- Potential fix for attempting to load a non-variants file as a variants file and throwing a parse exception [#3727](https://github.com/microsoft/vscode-cmake-tools/issues/3727)
+- Fix issue where `cmake.preferredGenerators` wasn't falling back to the next entry when the first entry didn't exist. [#2709](https://github.com/microsoft/vscode-cmake-tools/issues/2709)
+- Potential fix for attempting to load a non-variants file as a variants file and throwing a parse exception. [#3727](https://github.com/microsoft/vscode-cmake-tools/issues/3727)
 - Fix edge case where parsing tests fails when additional output is printed before tests json. [#3750](https://github.com/microsoft/vscode-cmake-tools/issues/3750)
 - Fix issue where `Configure with CMake Debugger` fails on restart because the previously used pipe to CMake Debugger is no longer available. [#3582](https://github.com/microsoft/vscode-cmake-tools/issues/3582)
+- Fix issue where we don't let CMake select a default generator when the selected kit is `__unspec__` and the CMake version supports setting an internal default generator (>=3.15.0). [#3405](https://github.com/microsoft/vscode-cmake-tools/issues/3405)
 
 ## 1.18.43
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,12 @@
 # What's New?
 
-## 1.19.0
+## 1.19
 
 Bug Fixes:
 
 - Fix issue where `cmake.preferredGenerators` wasn't falling back to the next entry when the first entry didn't exist [#2709](https://github.com/microsoft/vscode-cmake-tools/issues/2709)
 - Potential fix for attempting to load a non-variants file as a variants file and throwing a parse exception [#3727](https://github.com/microsoft/vscode-cmake-tools/issues/3727)
+- Fix edge case where parsing tests fails when additional output is printed before tests json. [#3750](https://github.com/microsoft/vscode-cmake-tools/issues/3750)
 - Fix issue where `Configure with CMake Debugger` fails on restart because the previously used pipe to CMake Debugger is no longer available. [#3582](https://github.com/microsoft/vscode-cmake-tools/issues/3582)
 
 ## 1.18.43

--- a/src/cmake/cmakeExecutable.ts
+++ b/src/cmake/cmakeExecutable.ts
@@ -15,9 +15,11 @@ export interface CMakeExecutable {
     isServerModeSupported?: boolean;
     isFileApiModeSupported?: boolean;
     isDebuggerSupported?: boolean;
+    isDefaultGeneratorSupported?: boolean;
     version?: util.Version;
     minimalServerModeVersion: util.Version;
     minimalFileApiModeVersion: util.Version;
+    minimalDefaultGeneratorVersion: util.Version;
 }
 
 const cmakeInfo = new Map<string, CMakeExecutable>();
@@ -27,7 +29,8 @@ export async function getCMakeExecutableInformation(path: string): Promise<CMake
         path,
         isPresent: false,
         minimalServerModeVersion: util.parseVersion('3.7.1'),
-        minimalFileApiModeVersion: util.parseVersion('3.14.0')
+        minimalFileApiModeVersion: util.parseVersion('3.14.0'),
+        minimalDefaultGeneratorVersion: util.parseVersion('3.15.0')
     };
 
     // The check for 'path' seems unnecessary, but crash logs tell us otherwise. It is not clear
@@ -61,6 +64,9 @@ export async function getCMakeExecutableInformation(path: string): Promise<CMake
                 // Support for new file based API, it replace the server mode
                 cmake.isFileApiModeSupported = util.versionGreaterOrEquals(cmake.version, cmake.minimalFileApiModeVersion);
                 cmake.isPresent = true;
+
+                // Support for CMake using an internal default generator when one isn't provided
+                cmake.isDefaultGeneratorSupported = util.versionGreaterOrEquals(cmake.version, cmake.minimalDefaultGeneratorVersion);
             }
             const debuggerPresent = await proc.execute(path, ['-E', 'capabilities'], null, execOpt).result;
             if (debuggerPresent.retc === 0 && debuggerPresent.stdout) {

--- a/src/ctest.ts
+++ b/src/ctest.ts
@@ -705,7 +705,13 @@ export class CTestDriver implements vscode.Disposable {
                 log.error(localize('ctest.error', 'There was an error running ctest to determine available test executables'));
                 return result.retc || -3;
             }
-            this.tests = JSON.parse(result.stdout) ?? undefined;
+
+            try {
+                this.tests = JSON.parse(result.stdout.slice(result.stdout.indexOf("{"))) ?? undefined;
+            } catch {
+                this.tests = undefined;
+            }
+
             if (this.tests && this.tests.kind === 'ctestInfo') {
                 this.tests.tests.forEach(test => {
                     let testDefFile: string | undefined;

--- a/src/drivers/cmakeDriver.ts
+++ b/src/drivers/cmakeDriver.ts
@@ -377,6 +377,10 @@ export abstract class CMakeDriver implements vscode.Disposable {
      */
     private _kit: Kit | null = null;
 
+    get kit(): Kit | null {
+        return this._kit;
+    }
+
     private _kitDetect: KitDetect | null = null;
 
     private _useCMakePresets: boolean = true;

--- a/src/drivers/cmakeDriver.ts
+++ b/src/drivers/cmakeDriver.ts
@@ -214,7 +214,9 @@ export abstract class CMakeDriver implements vscode.Disposable {
         protected sourceDirUnexpanded: string, // The un-expanded original source directory path, where the CMakeLists.txt exists.
         private readonly isMultiProject: boolean,
         private readonly __workspaceFolder: string,
-        readonly preconditionHandler: CMakePreconditionProblemSolver) {
+        readonly preconditionHandler: CMakePreconditionProblemSolver,
+        private readonly usingFileApi: boolean = false
+    ) {
         this.sourceDir = this.sourceDirUnexpanded;
         // We have a cache of file-compilation terminals. Wipe them out when the
         // user closes those terminals.
@@ -728,7 +730,11 @@ export abstract class CMakeDriver implements vscode.Disposable {
 
         // If no preferred generator is defined by the current kit or the user settings,
         // it's time to consider the defaults.
-        if (preferredGenerators.length === 0) {
+        if (preferredGenerators.length === 0
+            && !(this.usingFileApi
+                && (this.cmake.version && util.versionGreaterOrEquals(this.cmake.version, this.cmake.minimalDefaultGeneratorVersion))
+                && kit.name === "Unspecified")
+        ) {
             preferredGenerators.push({ name: "Ninja" });
             preferredGenerators.push({ name: "Unix Makefiles" });
         }

--- a/src/drivers/cmakeDriver.ts
+++ b/src/drivers/cmakeDriver.ts
@@ -733,7 +733,7 @@ export abstract class CMakeDriver implements vscode.Disposable {
         if (preferredGenerators.length === 0
             && !(this.usingFileApi
                 && (this.cmake.version && util.versionGreaterOrEquals(this.cmake.version, this.cmake.minimalDefaultGeneratorVersion))
-                && kit.name === "Unspecified")
+                && kit.name === "__unspec__")
         ) {
             preferredGenerators.push({ name: "Ninja" });
             preferredGenerators.push({ name: "Unix Makefiles" });

--- a/src/drivers/cmakeFileApiDriver.ts
+++ b/src/drivers/cmakeFileApiDriver.ts
@@ -38,7 +38,7 @@ const localize: nls.LocalizeFunc = nls.loadMessageBundle();
 
 const log = logging.createLogger('cmakefileapi-driver');
 /**
- * The CMake driver with FileApi of CMake >= 3.15.0
+ * The CMake driver with FileApi of CMake >= 3.14.0
  */
 export class CMakeFileApiDriver extends CMakeDriver {
 
@@ -52,7 +52,7 @@ export class CMakeFileApiDriver extends CMakeDriver {
         isMultiProject: boolean,
         workspaceRootPath: string,
         preconditionHandler: CMakePreconditionProblemSolver) {
-        super(cmake, config, sourceDir, isMultiProject, workspaceRootPath, preconditionHandler);
+        super(cmake, config, sourceDir, isMultiProject, workspaceRootPath, preconditionHandler, true);
     }
 
     static async create(cmake: CMakeExecutable,
@@ -148,7 +148,7 @@ export class CMakeFileApiDriver extends CMakeDriver {
 
             this._generatorInformation = this.generator;
         }
-        if (!this.generator && !this.useCMakePresets) {
+        if (!this.cmake.isDefaultGeneratorSupported && !this.generator && !this.useCMakePresets) {
             throw new NoGeneratorError();
         }
 
@@ -169,7 +169,7 @@ export class CMakeFileApiDriver extends CMakeDriver {
     async doSetKit(cb: () => Promise<void>): Promise<void> {
         this._needsReconfigure = true;
         await cb();
-        if (!this.generator) {
+        if (!this.cmake.isDefaultGeneratorSupported && !this.generator) {
             throw new NoGeneratorError();
         }
     }

--- a/src/drivers/cmakeFileApiDriver.ts
+++ b/src/drivers/cmakeFileApiDriver.ts
@@ -148,7 +148,7 @@ export class CMakeFileApiDriver extends CMakeDriver {
 
             this._generatorInformation = this.generator;
         }
-        if (!this.cmake.isDefaultGeneratorSupported && !this.generator && !this.useCMakePresets) {
+        if (!(this.cmake.isDefaultGeneratorSupported && this.kit?.name === '__unspec__') && !this.generator && !this.useCMakePresets) {
             throw new NoGeneratorError();
         }
 
@@ -169,7 +169,7 @@ export class CMakeFileApiDriver extends CMakeDriver {
     async doSetKit(cb: () => Promise<void>): Promise<void> {
         this._needsReconfigure = true;
         await cb();
-        if (!this.cmake.isDefaultGeneratorSupported && !this.generator) {
+        if (!(this.cmake.isDefaultGeneratorSupported && this.kit?.name === '__unspec__') && !this.generator) {
             throw new NoGeneratorError();
         }
     }


### PR DESCRIPTION
## This change addresses item #3405 

CMake file api supports not passing in a generator in versions >= 3.15.0. I added a check for that version and using the file api in order to not pass in Ninja as a preferred generator when the user selects "__unspec__" as a kit and doesn't define any generator/preferredGenerators.