### PR TITLE
Fixed Delete Build Dir on Clean Configure description display

### DIFF
--- a/package.json
+++ b/package.json
@@ -2587,7 +2587,7 @@
         "cmake.deleteBuildDirOnCleanConfigure": {
           "type": "boolean",
           "default": false,
-          "description": "%cmake-tools.configuration.cmake.deleteBuildDirOnCleanCconfigure.description%",
+          "description": "%cmake-tools.configuration.cmake.deleteBuildDirOnCleanConfigure.description%",
           "scope": "resource"
         },
         "cmake.setBuildTypeOnMultiConfig": {


### PR DESCRIPTION
## This change addresses item #3865

### This changes the visible description of the "Delete Build Dir on Clean Configure" setting

The following changes are proposed:

- Fix spelling mistake so the correct description shows up
