### PR TITLE
Localized the additional properties case in schema validation

### DIFF
--- a/src/presetsController.ts
+++ b/src/presetsController.ts
@@ -1623,7 +1623,7 @@ export class PresetsController {
                 logFunc(localize('unsupported.presets', 'Unsupported presets detected in {0}. Support is limited to features defined by version {1}.', file, maxSupportedVersion));
                 for (const err of errors) {
                     if (err.params && 'additionalProperty' in err.params) {
-                        logFunc(` >> ${err.dataPath}: ${err.message}: ${err.params.additionalProperty}`);
+                        logFunc(` >> ${err.dataPath}: ${localize('no.additional.properties', 'should NOT have additional properties')}: ${err.params.additionalProperty}`);
                     } else {
                         logFunc(` >> ${err.dataPath}: ${err.message}`);
                     }


### PR DESCRIPTION
## This change addresses item #3862 
localized it with same string so nothing changes for English users.