### PR TITLE
if installDir is a relative path, calculate it relative to the source directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,10 +15,11 @@ Bug Fixes:
 - Fix issue where `cmakeUserPresets.json` not showing up in project outline. [#3832](https://github.com/microsoft/vscode-cmake-tools/issues/3832)
 - Fix edge case where parsing tests fails when additional output is printed before tests json. [#3750](https://github.com/microsoft/vscode-cmake-tools/issues/3750)
 - Fix issue where `Configure with CMake Debugger` fails on restart because the previously used pipe to CMake Debugger is no longer available. [#3582](https://github.com/microsoft/vscode-cmake-tools/issues/3582)
-- Fix custom kit PATH being overriden [#3849](https://github.com/microsoft/vscode-cmake-tools/issues/3849)
-- Fix debug variables being overriden [#3806](https://github.com/microsoft/vscode-cmake-tools/issues/3806)
+- Fix custom kit PATH being overriden. [#3849](https://github.com/microsoft/vscode-cmake-tools/issues/3849)
+- Fix debug variables being overriden. [#3806](https://github.com/microsoft/vscode-cmake-tools/issues/3806)
 - Fix issue in Quick Start where a C file was generated in place of a C++ file. [#3856](https://github.com/microsoft/vscode-cmake-tools/issues/3856)
-- Fix custom build tasks not showing up [#3622](https://github.com/microsoft/vscode-cmake-tools/issues/3622)
+- Fix custom build tasks not showing up. [#3622](https://github.com/microsoft/vscode-cmake-tools/issues/3622)
+- Fix the bug where if a relative path specified for `installDir`, it is not calculated relative to the source directory, which is how it should be according to the CMake `installDir` docs [here](https://cmake.org/cmake/help/latest/manual/cmake-presets.7.html#configure-preset). [#3871](https://github.com/microsoft/vscode-cmake-tools/issues/3871)
 
 ## 1.18.43
 

--- a/src/preset.ts
+++ b/src/preset.ts
@@ -1137,6 +1137,9 @@ async function tryApplyVsDevEnv(preset: ConfigurePreset) {
 
 async function expandConfigurePresetHelper(folder: string, preset: ConfigurePreset, workspaceFolder: string, sourceDir: string, allowUserPreset: boolean = false) {
     if (preset.__expanded) {
+        if (preset.installDir) {
+            preset.installDir = util.resolvePath(preset.installDir, sourceDir);
+        }
         return preset;
     }
 
@@ -1204,6 +1207,9 @@ async function expandConfigurePresetHelper(folder: string, preset: ConfigurePres
     preset.environment = EnvironmentUtils.mergePreserveNull([inheritedEnv, preset.environment]);
 
     preset.__expanded = true;
+    if (preset.installDir) {
+        preset.installDir = util.resolvePath(preset.installDir, sourceDir);
+    }
     return preset;
 }
 

--- a/src/preset.ts
+++ b/src/preset.ts
@@ -807,6 +807,9 @@ export async function expandConfigurePreset(folder: string, name: string, worksp
     if (!preset) {
         return null;
     }
+    if (preset.installDir) {
+        preset.installDir = util.resolvePath(preset.installDir, sourceDir);
+    }
     preset = await tryApplyVsDevEnv(preset);
 
     preset.environment = EnvironmentUtils.mergePreserveNull([process.env, preset.environment]);
@@ -1137,9 +1140,6 @@ async function tryApplyVsDevEnv(preset: ConfigurePreset) {
 
 async function expandConfigurePresetHelper(folder: string, preset: ConfigurePreset, workspaceFolder: string, sourceDir: string, allowUserPreset: boolean = false) {
     if (preset.__expanded) {
-        if (preset.installDir) {
-            preset.installDir = util.resolvePath(preset.installDir, sourceDir);
-        }
         return preset;
     }
 
@@ -1207,9 +1207,6 @@ async function expandConfigurePresetHelper(folder: string, preset: ConfigurePres
     preset.environment = EnvironmentUtils.mergePreserveNull([inheritedEnv, preset.environment]);
 
     preset.__expanded = true;
-    if (preset.installDir) {
-        preset.installDir = util.resolvePath(preset.installDir, sourceDir);
-    }
     return preset;
 }
 

--- a/src/preset.ts
+++ b/src/preset.ts
@@ -807,9 +807,6 @@ export async function expandConfigurePreset(folder: string, name: string, worksp
     if (!preset) {
         return null;
     }
-    if (preset.installDir) {
-        preset.installDir = util.resolvePath(preset.installDir, sourceDir);
-    }
     preset = await tryApplyVsDevEnv(preset);
 
     preset.environment = EnvironmentUtils.mergePreserveNull([process.env, preset.environment]);
@@ -853,7 +850,7 @@ export async function expandConfigurePreset(folder: string, name: string, worksp
     }
 
     if (preset.installDir) {
-        expandedPreset.installDir = util.lightNormalizePath(await expandString(preset.installDir, expansionOpts));
+        expandedPreset.installDir = util.resolvePath(await expandString(preset.installDir, expansionOpts), sourceDir);
     }
 
     if (preset.toolchainFile) {


### PR DESCRIPTION
## This change addresses item #3871 


after installDir is expanded, if it is still a relative path, we calculate it according to the source directory ([docs](https://cmake.org/cmake/help/latest/manual/cmake-presets.7.html#configure-preset)).