### PR TITLE
Fix localized file path for schemas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Bug Fixes:
 - Fix custom build tasks not showing up. [#3622](https://github.com/microsoft/vscode-cmake-tools/issues/3622)
 - Fix the bug where if a relative path specified for `installDir`, it is not calculated relative to the source directory, which is how it should be according to the CMake `installDir` docs [here](https://cmake.org/cmake/help/latest/manual/cmake-presets.7.html#configure-preset). [#3871](https://github.com/microsoft/vscode-cmake-tools/issues/3871)
 - Fix issue with CMakeLists.txt depth search. [#3901](https://github.com/microsoft/vscode-cmake-tools/issues/3901)
+- Fix localized file path for schema files. [#3872](https://github.com/microsoft/vscode-cmake-tools/issues/3872)
 
 ## 1.18.43
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2344,7 +2344,7 @@ class SchemaProvider implements vscode.TextDocumentContentProvider {
         console.assert(uri.path[0] === '/', "A preceeding slash is expected on schema uri path");
         const fileName: string = uri.path.substr(1);
         const locale: string = util.getLocaleId();
-        let localizedFilePath: string = path.join(util.thisExtensionPath(), "dist/schema/", locale, fileName);
+        let localizedFilePath: string = path.join(util.thisExtensionPath(), "dist/schema/", locale, "schemas", fileName);
         const fileExists: boolean = await util.checkFileExists(localizedFilePath);
         if (!fileExists) {
             localizedFilePath = path.join(util.thisExtensionPath(), "schemas", fileName);


### PR DESCRIPTION
Fixes #3872. Can now correctly get localized schema descriptions.