### PR TITLE
Don't require Ninja or Make on PATH when checking generators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Bug Fixes:
 - Fix localized file path for schema files. [#3872](https://github.com/microsoft/vscode-cmake-tools/issues/3872)
 - Disable annoy and invalid extenion message about fix windows sdk for MSVC 2022. [#3837](https://github.com/microsoft/vscode-cmake-tools/pull/3837)
 - Fix re-using a terminal for launching even when the environment has changed. [#3478](https://github.com/microsoft/vscode-cmake-tools/issues/3478)
+- Don't require Ninja or Make on command line when checking for supported generators. [#3924](https://github.com/microsoft/vscode-cmake-tools/issues/3924)
 
 ## 1.18.43
 

--- a/src/drivers/cmakeDriver.ts
+++ b/src/drivers/cmakeDriver.ts
@@ -984,25 +984,15 @@ export abstract class CMakeDriver implements vscode.Disposable {
 
         for (const gen of preferredGenerators) {
             const gen_name = gen.name;
-            const generator_present = await (async (): Promise<boolean> => {
-                if (gen_name === 'Ninja' || gen_name === 'Ninja Multi-Config') {
-                    return await this.testHaveCommand('ninja') || this.testHaveCommand('ninja-build');
+            if (gen_name === 'Ninja' || gen_name === 'Ninja Multi-Config' ||
+                    gen_name === 'Unix Makefiles') {
+                return gen;
+            } else if (gen_name === 'MinGW Makefiles' || gen_name === 'NMake Makefiles' ||
+                        gen_name === 'MSYS Makefiles') {
+                if (platform === 'win32') {
+                    return gen;
                 }
-                if (gen_name === 'MinGW Makefiles') {
-                    return platform === 'win32' && this.testHaveCommand('mingw32-make');
-                }
-                if (gen_name === 'NMake Makefiles') {
-                    return platform === 'win32' && this.testHaveCommand('nmake', ['/?']);
-                }
-                if (gen_name === 'Unix Makefiles') {
-                    return this.testHaveCommand('make');
-                }
-                if (gen_name === 'MSYS Makefiles') {
-                    return platform === 'win32' && this.testHaveCommand('make');
-                }
-                return false;
-            })();
-            if (!generator_present) {
+            } else {
                 const vsMatch = /^(Visual Studio \d{2} \d{4})($|\sWin64$|\sARM$)/.exec(gen.name);
                 if (platform === 'win32' && vsMatch) {
                     return {
@@ -1014,12 +1004,8 @@ export abstract class CMakeDriver implements vscode.Disposable {
                 if (gen.name.toLowerCase().startsWith('xcode') && platform === 'darwin') {
                     return gen;
                 }
-
-                // If the generator isn't found, move on to the next one
-                continue;
-            } else {
-                return gen;
             }
+            // If the generator isn't supported on the current system, move on to the next one.
         }
         return null;
     }


### PR DESCRIPTION
## This change addresses item #3924

### This changes how a generator is selected

The following changes are proposed:

- Removed the testHaveCommand check for Ninja and Make to align them with how we check Visual Studio and XCode generators, so we only skip a generator if the platform doesn't support it
