### PR TITLE
Revert "Don't require Ninja or Make on PATH when checking generators (#3927)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,6 @@ Bug Fixes:
 - Fix localized file path for schema files. [#3872](https://github.com/microsoft/vscode-cmake-tools/issues/3872)
 - Disable annoy and invalid extenion message about fix windows sdk for MSVC 2022. [#3837](https://github.com/microsoft/vscode-cmake-tools/pull/3837)
 - Fix re-using a terminal for launching even when the environment has changed. [#3478](https://github.com/microsoft/vscode-cmake-tools/issues/3478)
-- Don't require Ninja or Make on command line when checking for supported generators. [#3924](https://github.com/microsoft/vscode-cmake-tools/issues/3924)
 - Fix our keybindings for debug and run without debugging to better match VS Code. [#3507](https://github.com/microsoft/vscode-cmake-tools/issues/3507)
 
 ## 1.18.43


### PR DESCRIPTION
### This changes how a generator is selected

The following changes are proposed:

- This reverts commit bbc74d879706ef4f90587f3333494c31ce3facc8

## The purpose of this change

Some customers rely on the behavior to use Make instead of Ninja since Ninja is not on PATH
