### PR TITLE
add telemetry for developer environment use

### DIFF
--- a/src/drivers/cmakeDriver.ts
+++ b/src/drivers/cmakeDriver.ts
@@ -1562,8 +1562,16 @@ export abstract class CMakeDriver implements vscode.Disposable {
                 telemetryProperties.CppCompilerName = 'cl';
             }
 
-            if (this._kit?.visualStudioArchitecture) {
-                telemetryProperties.VisualStudioArchitecture = this._kit?.visualStudioArchitecture;
+            if (this.useCMakePresets) {
+                const arch = presetOverride ? presetOverride.__developerEnvironmentArchitecture : this._configurePreset ? this._configurePreset.__developerEnvironmentArchitecture : undefined;
+                if (arch) {
+                    telemetryProperties.VisualStudioArchitecture = arch;
+                }
+            } else {
+                if (this._kit?.visualStudioArchitecture) {
+                    telemetryProperties.VisualStudioArchitecture =
+                        this._kit?.visualStudioArchitecture;
+                }
             }
 
             const telemetryMeasures: telemetry.Measures = {

--- a/src/preset.ts
+++ b/src/preset.ts
@@ -262,6 +262,9 @@ export interface ConfigurePreset extends Preset {
     vendor?: VendorVsSettings | VendorType;
     toolchainFile?: string;
     installDir?: string;
+
+    // Private fields
+    __developerEnvironmentArchitecture?: string; // Private field to indicate which VS Dev Env architecture we're using, if VS Dev Env is used.
 }
 
 export interface InheritsConfigurePreset extends Preset {
@@ -1088,7 +1091,11 @@ async function tryApplyVsDevEnv(preset: ConfigurePreset, workspaceFolder: string
         }
     }
 
-    preset.__parentEnvironment = EnvironmentUtils.mergePreserveNull([process.env, developerEnvironment]);
+    if (developerEnvironment) {
+        preset.__developerEnvironmentArchitecture = getArchitecture(preset);
+    }
+
+    preset.__parentEnvironment = EnvironmentUtils.mergePreserveNull([process.env, preset.__parentEnvironment, developerEnvironment]);
 }
 /**
  * Expands the configure preset variables.


### PR DESCRIPTION
See title.

Note: Changed this `preset.__parentEnvironment = EnvironmentUtils.mergePreserveNull([process.env, developerEnvironment]);` to `preset.__parentEnvironment = EnvironmentUtils.mergePreserveNull([process.env, preset.__parentEnvironment, developerEnvironment]);`. 

This helps ensure that in various scenarios, such as a test preset referencing a configure preset, we don't accidentally ignore the devenv parentEnvironment. 