### PR TITLE
if Win64 is at the end of the generator, use platform x64

### DIFF
--- a/src/drivers/cmakeDriver.ts
+++ b/src/drivers/cmakeDriver.ts
@@ -1006,9 +1006,13 @@ export abstract class CMakeDriver implements vscode.Disposable {
             if (!generator_present) {
                 const vsMatch = /^(Visual Studio \d{2} \d{4})($|\sWin64$|\sARM$)/.exec(gen.name);
                 if (platform === 'win32' && vsMatch) {
+                    let possibleArchitecture = vsMatch[2].trim();
+                    if (possibleArchitecture && possibleArchitecture === "Win64") {
+                        possibleArchitecture = "x64";
+                    }
                     return {
                         name: vsMatch[1],
-                        platform: gen.platform || vsMatch[2],
+                        platform: gen.platform || possibleArchitecture,
                         toolset: gen.toolset
                     };
                 }


### PR DESCRIPTION
Fixes issue brought up in #4020. 

In short, there is an edge case of back compatibility for cmake versions 3.1 and earlier. Our recent changes to preferred generators logic made this bug evident. 

This bug only affects kits, and only affects users who are using that back compatibility, documented here: https://cmake.org/cmake/help/latest/generator/Visual%20Studio%2015%202017.html#platform-selection