### PR TITLE
determine shell for .cmd, .bat, .ps1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,12 +15,14 @@ Bug Fixes:
 Improvements:
 
 - Update signing to support VSCode extension signing. [#4055](https://github.com/microsoft/vscode-cmake-tools/pull/4055)
+- Ensure that any uses of `proc.spawn` work, especially for .bat and .cmd files, due to VS Code updating to Node 20. [#4037](https://github.com/microsoft/vscode-cmake-tools/issues/4037)
 
 ## 1.19.51
 
 Bug Fixes:
 
 - Fix generator and preferredGenerator logic. [#4031](https://github.com/microsoft/vscode-cmake-tools/issues/4031), [#4005](https://github.com/microsoft/vscode-cmake-tools/issues/4005), [#4032](https://github.com/microsoft/vscode-cmake-tools/issues/4032)
+
 
 ## 1.19.50
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,6 @@ Bug Fixes:
 
 - Fix generator and preferredGenerator logic. [#4031](https://github.com/microsoft/vscode-cmake-tools/issues/4031), [#4005](https://github.com/microsoft/vscode-cmake-tools/issues/4005), [#4032](https://github.com/microsoft/vscode-cmake-tools/issues/4032)
 
-
 ## 1.19.50
 
 Bug Fixes:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Features:
 
 - Add support for Presets v9, which enables more macro expansion for the `include` field. [#3946](https://github.com/microsoft/vscode-cmake-tools/issues/3946)
 
+Improvements:
+
+- Ensure that any uses of `proc.spawn` work, especially for .bat and .cmd files, due to VS Code updating to Node 20. [#4037](https://github.com/microsoft/vscode-cmake-tools/issues/4037)
+
 Bug Fixes:
 
 - Fix issue where duplicate presets are being listed in dropdown. [#4104](https://github.com/microsoft/vscode-cmake-tools/issues/4104)
@@ -15,7 +19,6 @@ Bug Fixes:
 Improvements:
 
 - Update signing to support VSCode extension signing. [#4055](https://github.com/microsoft/vscode-cmake-tools/pull/4055)
-- Ensure that any uses of `proc.spawn` work, especially for .bat and .cmd files, due to VS Code updating to Node 20. [#4037](https://github.com/microsoft/vscode-cmake-tools/issues/4037)
 
 ## 1.19.51
 

--- a/src/proc.ts
+++ b/src/proc.ts
@@ -161,7 +161,7 @@ export function execute(command: string, args?: string[], outputConsumer?: Outpu
 
     const spawn_opts: proc.SpawnOptions = {
         env: final_env,
-        shell: options.shell ?? determineShell(command)
+        shell: options.shell ?? process.platform === "win32" ? determineShell(command) : undefined
     };
     if (options?.cwd !== undefined) {
         util.createDirIfNotExistsSync(options.cwd);

--- a/src/proc.ts
+++ b/src/proc.ts
@@ -159,9 +159,13 @@ export function execute(command: string, args?: string[], outputConsumer?: Outpu
         }
     }
 
+    if (options.shell === undefined && process.platform === "win32") {
+        options.shell = determineShell(command);
+    }
+
     const spawn_opts: proc.SpawnOptions = {
         env: final_env,
-        shell: options.shell ?? process.platform === "win32" ? determineShell(command) : false
+        shell: !!options.shell
     };
     if (options?.cwd !== undefined) {
         util.createDirIfNotExistsSync(options.cwd);

--- a/src/proc.ts
+++ b/src/proc.ts
@@ -161,7 +161,7 @@ export function execute(command: string, args?: string[], outputConsumer?: Outpu
 
     const spawn_opts: proc.SpawnOptions = {
         env: final_env,
-        shell: options.shell ?? process.platform === "win32" ? determineShell(command) : undefined
+        shell: options.shell ?? process.platform === "win32" ? determineShell(command) : false
     };
     if (options?.cwd !== undefined) {
         util.createDirIfNotExistsSync(options.cwd);

--- a/src/proc.ts
+++ b/src/proc.ts
@@ -95,7 +95,7 @@ export interface ExecutionResult {
 
 export interface ExecutionOptions {
     environment?: Environment;
-    shell?: boolean;
+    shell?: boolean | string;
     silent?: boolean;
     cwd?: string;
     encoding?: BufferEncoding;
@@ -111,6 +111,18 @@ export function buildCmdStr(command: string, args?: string[]): string {
         cmdarr = cmdarr.concat(args);
     }
     return cmdarr.map(a => /[ \n\r\f;\t]/.test(a) ? `"${a}"` : a).join(' ');
+}
+
+export function determineShell(command: string): string | boolean {
+    if (command.endsWith('.cmd') || command.endsWith('.bat')) {
+        return 'cmd';
+    }
+
+    if (command.endsWith('.ps1')) {
+        return 'powershell';
+    }
+
+    return false;
 }
 
 /**
@@ -146,9 +158,10 @@ export function execute(command: string, args?: string[], outputConsumer?: Outpu
             log.debug(localize('execution.environment', '  with environment: {0}', JSON.stringify(final_env)));
         }
     }
+
     const spawn_opts: proc.SpawnOptions = {
         env: final_env,
-        shell: !!options.shell
+        shell: options.shell ?? determineShell(command)
     };
     if (options?.cwd !== undefined) {
         util.createDirIfNotExistsSync(options.cwd);

--- a/src/proc.ts
+++ b/src/proc.ts
@@ -159,7 +159,7 @@ export function execute(command: string, args?: string[], outputConsumer?: Outpu
         }
     }
 
-    if (options.shell === undefined && process.platform === "win32") {
+    if (process.platform === "win32" && options.shell === undefined) {
         options.shell = determineShell(command);
     }
 


### PR DESCRIPTION
Test VSIX:
[cmake-tools.zip](https://github.com/user-attachments/files/16893465/cmake-tools.zip)


Fixes #4037. Fixes #4042 

We did not change anything regarding this between 1.18 and 1.19. This issue comes from a breaking change in VS Code, where in version 1.92, which came out in July, they update to node v20 which requires more strict options regarding proc.spawn: [Visual Studio Code July 2024](https://code.visualstudio.com/updates/v1_92#_electron-30-update).
