### PR TITLE
only set `isUserPreset` to `true` if it's defined in a user presets file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # What's New?
 
+## 1.20
+
+Bug Fixes:
+
+- Fix our setting of `isUserPreset` for presets, only set it to `true` if it's defined in a user presets file. [#4059](https://github.com/microsoft/vscode-cmake-tools/issues/4059)
+
 ## 1.19.52
 
 Improvements:

--- a/src/preset.ts
+++ b/src/preset.ts
@@ -467,24 +467,39 @@ export function setPresetsPlusIncluded(folder: string, presets: PresetsFile | un
     presetsPlusIncluded.set(folder, presets);
 }
 
-export function setUserPresetsPlusIncluded(folder: string, presets: PresetsFile | undefined) {
+export function setUserPresetsHelper(presets: PresetsFile | undefined) {
     if (presets) {
+        // for each condition of `isUserPreset`, if we don't find file.path, then we default to true like before.
         if (presets.configurePresets) {
             for (const configPreset of presets.configurePresets) {
-                configPreset.isUserPreset = true;
+                configPreset.isUserPreset = configPreset.__file?.__path?.endsWith("CMakeUserPresets.json") ?? true;
             }
         }
         if (presets.buildPresets) {
             for (const buildPreset of presets.buildPresets) {
-                buildPreset.isUserPreset = true;
+                buildPreset.isUserPreset = buildPreset.__file?.__path?.endsWith("CMakeUserPresets.json") ?? true;
             }
         }
         if (presets.testPresets) {
             for (const testPreset of presets.testPresets) {
-                testPreset.isUserPreset = true;
+                testPreset.isUserPreset = testPreset.__file?.__path?.endsWith("CMakeUserPresets.json") ?? true;
+            }
+        }
+        if (presets.packagePresets) {
+            for (const packagePreset of presets.packagePresets) {
+                packagePreset.isUserPreset = packagePreset.__file?.__path?.endsWith("CMakeUserPresets.json") ?? true;
+            }
+        }
+        if (presets.workflowPresets) {
+            for (const workflowPreset of presets.workflowPresets) {
+                workflowPreset.isUserPreset = workflowPreset.__file?.__path?.endsWith("CMakeUserPresets.json") ?? true;
             }
         }
     }
+}
+
+export function setUserPresetsPlusIncluded(folder: string, presets: PresetsFile | undefined) {
+    setUserPresetsHelper(presets);
     userPresetsPlusIncluded.set(folder, presets);
 }
 
@@ -544,23 +559,7 @@ function updateCachedExpandedPresethelper(cache: PresetsFile | undefined, preset
 }
 
 export function setExpandedUserPresetsFile(folder: string, presets: PresetsFile | undefined) {
-    if (presets) {
-        if (presets.configurePresets) {
-            for (const configPreset of presets.configurePresets) {
-                configPreset.isUserPreset = true;
-            }
-        }
-        if (presets.buildPresets) {
-            for (const buildPreset of presets.buildPresets) {
-                buildPreset.isUserPreset = true;
-            }
-        }
-        if (presets.testPresets) {
-            for (const testPreset of presets.testPresets) {
-                testPreset.isUserPreset = true;
-            }
-        }
-    }
+    setUserPresetsHelper(presets);
     expandedUserPresets.set(folder, presets);
 }
 


### PR DESCRIPTION
Fixes bug #4059. 

We were not showing presets as being available to select because we are determining that the preset is a user preset, when it really isn't. This is due to the fact that we were incorrectly setting `isUserPreset`, we should check which file the configure preset was defined in. 