### PR TITLE
Fix #4056, Debugger statements in production code

### DIFF
--- a/src/drivers/cmakeServerClient.ts
+++ b/src/drivers/cmakeServerClient.ts
@@ -385,7 +385,9 @@ export class CMakeServerClient {
                 break;
             }
             if (mat.length !== 3) {
-                debugger;
+                if (process.env.NODE_ENV === 'development') {
+                    debugger;
+                }
                 throw new global.Error(localize('protocol.error.cmake', 'Protocol error talking to CMake! Got this input: {0}', input));
             }
             this.accInput = mat[2];
@@ -474,7 +476,9 @@ export class CMakeServerClient {
                 }
             }
         }
-        debugger;
+        if (process.env.NODE_ENV === 'development') {
+            debugger;
+        }
         log.warning(localize('cant.yet.handle.message', 'Can\'t yet handle the {0} messages', some.type));
     }
 
@@ -587,7 +591,9 @@ export class CMakeServerClient {
                 pipe.on('error', e => {
                     pipe.end();
                     if (!this.shutDownFlag) {
-                        debugger;
+                        if (process.env.NODE_ENV === 'development') {
+                            debugger;
+                        }
                         rollbar.takePromise(localize('pipe.error.from.cmake-server', 'Pipe error from cmake-server'),
                             { pipe: pipeFile },
                             params.onPipeError(e));

--- a/src/projectOutline/projectOutline.ts
+++ b/src/projectOutline/projectOutline.ts
@@ -381,7 +381,9 @@ export class TargetNode extends BaseNode {
             ].join(',');
             return item;
         } catch (e) {
-            debugger;
+            if (process.env.NODE_ENV === 'development') {
+                debugger;
+            }
             return new vscode.TreeItem(`${this.name} (${localize('item.render.issue', 'There was an issue rendering this item. This is a bug')})`);
         }
     }

--- a/src/rollbar.ts
+++ b/src/rollbar.ts
@@ -97,7 +97,9 @@ class RollbarController {
      */
     error(what: string, additional: object = {}): void {
         log.error(what, JSON.stringify(additional, (key, value) => stringifyReplacer(key, value)));
-        debugger;
+        if (process.env.NODE_ENV === 'development') {
+            debugger;
+        }
     }
 
     info(what: string, additional: object = {}): void {


### PR DESCRIPTION
<!-- Thanks for your contribution! To make things easier, please fill out the template below. -->

<!-- Please delete any unused sections. -->

<!-- Delete the following heading if there is no corresponding issue -->
## This change addresses item #4056 

### This changes [[visible behavior/performance/documentation/etc.]]

The following changes are proposed:

- Guard `debugger;` statements with checks for if the code is running in development mode (already controlled by the mode switch on webpack)
