### PR TITLE
support additional macros for include field for presets v9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # What's New?
 
+## 1.20
+
+Features:
+
+- Add support for Presets v9, which enables more macro expansion for the `include` field. [#3946](https://github.com/microsoft/vscode-cmake-tools/issues/3946)
+
 ## 1.19.52
 
 Improvements:

--- a/src/expand.ts
+++ b/src/expand.ts
@@ -24,7 +24,6 @@ export const envDelimiter: string = (process.platform === 'win32') ? ";" : ":";
  * variables are specified as properties on this interface.
  */
 interface RequiredExpansionContextVars {
-    generator: string;
     workspaceFolder: string;
     workspaceFolderBasename: string;
     sourceDir: string;
@@ -50,6 +49,7 @@ export interface KitContextVars extends RequiredExpansionContextVars {
 
 export interface PresetContextVars extends RequiredExpansionContextVars {
     [key: string]: string;
+    generator: string;
     sourceDir: string;
     sourceParentDir: string;
     sourceDirName: string;
@@ -61,6 +61,16 @@ export interface MinimalPresetContextVars extends RequiredExpansionContextVars {
     [key: string]: string;
 }
 
+export interface NonPresetSpecificContextVars {
+    [key: string]: string;
+    sourceDir: string;
+    sourceParentDir: string;
+    sourceDirName: string;
+    hostSystemName: string;
+    fileDir: string;
+    pathListSep: string;
+}
+
 /**
  * Options to control the behavior of `expandString`.
  */
@@ -68,7 +78,7 @@ export interface ExpansionOptions {
     /**
      * Plain `${variable}` style expansions.
      */
-    vars: KitContextVars | PresetContextVars | MinimalPresetContextVars;
+    vars: KitContextVars | PresetContextVars | MinimalPresetContextVars | NonPresetSpecificContextVars;
     /**
      * Override the values used in `${env:var}`-style and `${env.var}`-style expansions.
      *

--- a/src/expand.ts
+++ b/src/expand.ts
@@ -61,16 +61,6 @@ export interface MinimalPresetContextVars extends RequiredExpansionContextVars {
     [key: string]: string;
 }
 
-export interface NonPresetSpecificContextVars {
-    [key: string]: string;
-    sourceDir: string;
-    sourceParentDir: string;
-    sourceDirName: string;
-    hostSystemName: string;
-    fileDir: string;
-    pathListSep: string;
-}
-
 /**
  * Options to control the behavior of `expandString`.
  */
@@ -78,7 +68,7 @@ export interface ExpansionOptions {
     /**
      * Plain `${variable}` style expansions.
      */
-    vars: KitContextVars | PresetContextVars | MinimalPresetContextVars | NonPresetSpecificContextVars;
+    vars: KitContextVars | PresetContextVars | MinimalPresetContextVars;
     /**
      * Override the values used in `${env:var}`-style and `${env.var}`-style expansions.
      *

--- a/src/expand.ts
+++ b/src/expand.ts
@@ -24,6 +24,7 @@ export const envDelimiter: string = (process.platform === 'win32') ? ";" : ":";
  * variables are specified as properties on this interface.
  */
 interface RequiredExpansionContextVars {
+    generator: string;
     workspaceFolder: string;
     workspaceFolderBasename: string;
     sourceDir: string;
@@ -49,7 +50,6 @@ export interface KitContextVars extends RequiredExpansionContextVars {
 
 export interface PresetContextVars extends RequiredExpansionContextVars {
     [key: string]: string;
-    generator: string;
     sourceDir: string;
     sourceParentDir: string;
     sourceDirName: string;

--- a/src/expand.ts
+++ b/src/expand.ts
@@ -48,13 +48,19 @@ export interface KitContextVars extends RequiredExpansionContextVars {
     buildKitVersionMinor: string;
 }
 
-export interface PresetContextVars extends RequiredExpansionContextVars {
+export interface PresetContextVars extends PresetContextNotPresetSpecificVars, RequiredExpansionContextVars {
+    [key: string]: string;
+    presetName: string;
+}
+
+export interface PresetContextNotPresetSpecificVars {
     [key: string]: string;
     sourceDir: string;
     sourceParentDir: string;
     sourceDirName: string;
-    presetName: string;
     fileDir: string;
+    hostSystemName: string;
+    pathListSep: string;
 }
 
 export interface MinimalPresetContextVars extends RequiredExpansionContextVars {
@@ -68,7 +74,7 @@ export interface ExpansionOptions {
     /**
      * Plain `${variable}` style expansions.
      */
-    vars: KitContextVars | PresetContextVars | MinimalPresetContextVars;
+    vars: KitContextVars | PresetContextVars | MinimalPresetContextVars | PresetContextNotPresetSpecificVars;
     /**
      * Override the values used in `${env:var}`-style and `${env.var}`-style expansions.
      *

--- a/src/preset.ts
+++ b/src/preset.ts
@@ -1212,7 +1212,7 @@ async function getConfigurePresetInheritsImpl(folder: string, name: string, allo
     }
 
     log.error(localize('config.preset.not.found.full', 'Could not find configure preset with name {0}', name));
-    errorHandler?.errorList.push([localize('config.preset.not.found', 'Could not find configure preset'), name]);
+    errorHandler?.tempErrorList.push([localize('config.preset.not.found', 'Could not find configure preset'), name]);
     return null;
 }
 
@@ -1593,7 +1593,7 @@ async function getBuildPresetInheritsImpl(folder: string, name: string, workspac
     }
 
     log.error(localize('build.preset.not.found.full', 'Could not find build preset with name {0}', name));
-    errorHandler?.errorList.push([localize('build.preset.not.found', 'Could not find build preset'), name]);
+    errorHandler?.tempErrorList.push([localize('build.preset.not.found', 'Could not find build preset'), name]);
     return null;
 }
 
@@ -1654,7 +1654,7 @@ async function getBuildPresetInheritsHelper(folder: string, preset: BuildPreset,
 
         if (!expandedConfigurePreset) {
             log.error(localize('configure.preset.not.found.full', 'Could not find configure preset with name {0}', preset.configurePreset));
-            errorHandler?.errorList.push([localize('configure.preset.not.found', 'Could not find configure preset'), preset.configurePreset]);
+            errorHandler?.tempErrorList.push([localize('configure.preset.not.found', 'Could not find configure preset'), preset.configurePreset]);
             return null;
         }
 
@@ -1771,7 +1771,7 @@ async function getTestPresetInheritsImpl(folder: string, name: string, workspace
     }
 
     log.error(localize('test.preset.not.found.full', 'Could not find test preset with name {0}', name));
-    errorHandler?.errorList.push([localize('test.preset.not.found', 'Could not find test preset'), name]);
+    errorHandler?.tempErrorList.push([localize('test.preset.not.found', 'Could not find test preset'), name]);
     return null;
 }
 
@@ -1830,7 +1830,7 @@ async function getTestPresetInheritsHelper(folder: string, preset: TestPreset, w
 
         if (!expandedConfigurePreset) {
             log.error(localize('configure.preset.not.found.full', 'Could not find configure preset with name {0}', preset.configurePreset));
-            errorHandler?.errorList.push([localize('configure.preset.not.found', 'Could not find configure preset'), preset.configurePreset]);
+            errorHandler?.tempErrorList.push([localize('configure.preset.not.found', 'Could not find configure preset'), preset.configurePreset]);
             return null;
         }
 
@@ -2044,7 +2044,7 @@ async function getPackagePresetInheritsHelper(folder: string, preset: PackagePre
 
         if (!expandedConfigurePreset) {
             log.error(localize('configure.preset.not.found.full', 'Could not find configure preset with name {0}', preset.configurePreset));
-            errorHandler?.errorList.push([localize('configure.preset.not.found', 'Could not find configure preset'), preset.configurePreset]);
+            errorHandler?.tempErrorList.push([localize('configure.preset.not.found', 'Could not find configure preset'), preset.configurePreset]);
             return null;
         }
 
@@ -2155,7 +2155,7 @@ async function getWorkflowPresetInheritsImpl(folder: string, name: string, works
         return getWorkflowPresetInheritsHelper(folder, preset, workspaceFolder, sourceDir, true, usePresetsPlusIncluded, errorHandler);
     }
     log.error(localize('workflow.preset.not.found', 'Could not find workflow preset with name {0}', name));
-    errorHandler?.errorList.push([localize('workflow.preset.not.found', 'Could not find workflow preset'), name]);
+    errorHandler?.tempErrorList.push([localize('workflow.preset.not.found', 'Could not find workflow preset'), name]);
     return null;
 }
 
@@ -2200,7 +2200,7 @@ async function getWorkflowPresetInheritsHelper(folder: string, preset: WorkflowP
         }
         if (!expandedConfigurePreset) {
             log.error(localize('configure.preset.not.found.full', 'Could not find configure preset with name {0}', workflowConfigurePreset));
-            errorHandler?.errorList.push([localize('configure.preset.not.found', 'Could not find configure preset'), workflowConfigurePreset]);
+            errorHandler?.tempErrorList.push([localize('configure.preset.not.found', 'Could not find configure preset'), workflowConfigurePreset]);
             return null;
         }
         // The below is critical when the workflow step0 configure preset is different than the

--- a/src/preset.ts
+++ b/src/preset.ts
@@ -1212,7 +1212,7 @@ async function getConfigurePresetInheritsImpl(folder: string, name: string, allo
     }
 
     log.error(localize('config.preset.not.found.full', 'Could not find configure preset with name {0}', name));
-    errorHandler?.tempErrorList.push([localize('config.preset.not.found', 'Could not find configure preset'), name]);
+    errorHandler?.errorList.push([localize('config.preset.not.found', 'Could not find configure preset'), name]);
     return null;
 }
 
@@ -1593,7 +1593,7 @@ async function getBuildPresetInheritsImpl(folder: string, name: string, workspac
     }
 
     log.error(localize('build.preset.not.found.full', 'Could not find build preset with name {0}', name));
-    errorHandler?.tempErrorList.push([localize('build.preset.not.found', 'Could not find build preset'), name]);
+    errorHandler?.errorList.push([localize('build.preset.not.found', 'Could not find build preset'), name]);
     return null;
 }
 
@@ -1654,7 +1654,7 @@ async function getBuildPresetInheritsHelper(folder: string, preset: BuildPreset,
 
         if (!expandedConfigurePreset) {
             log.error(localize('configure.preset.not.found.full', 'Could not find configure preset with name {0}', preset.configurePreset));
-            errorHandler?.tempErrorList.push([localize('configure.preset.not.found', 'Could not find configure preset'), preset.configurePreset]);
+            errorHandler?.errorList.push([localize('configure.preset.not.found', 'Could not find configure preset'), preset.configurePreset]);
             return null;
         }
 
@@ -1771,7 +1771,7 @@ async function getTestPresetInheritsImpl(folder: string, name: string, workspace
     }
 
     log.error(localize('test.preset.not.found.full', 'Could not find test preset with name {0}', name));
-    errorHandler?.tempErrorList.push([localize('test.preset.not.found', 'Could not find test preset'), name]);
+    errorHandler?.errorList.push([localize('test.preset.not.found', 'Could not find test preset'), name]);
     return null;
 }
 
@@ -1830,7 +1830,7 @@ async function getTestPresetInheritsHelper(folder: string, preset: TestPreset, w
 
         if (!expandedConfigurePreset) {
             log.error(localize('configure.preset.not.found.full', 'Could not find configure preset with name {0}', preset.configurePreset));
-            errorHandler?.tempErrorList.push([localize('configure.preset.not.found', 'Could not find configure preset'), preset.configurePreset]);
+            errorHandler?.errorList.push([localize('configure.preset.not.found', 'Could not find configure preset'), preset.configurePreset]);
             return null;
         }
 
@@ -2044,7 +2044,7 @@ async function getPackagePresetInheritsHelper(folder: string, preset: PackagePre
 
         if (!expandedConfigurePreset) {
             log.error(localize('configure.preset.not.found.full', 'Could not find configure preset with name {0}', preset.configurePreset));
-            errorHandler?.tempErrorList.push([localize('configure.preset.not.found', 'Could not find configure preset'), preset.configurePreset]);
+            errorHandler?.errorList.push([localize('configure.preset.not.found', 'Could not find configure preset'), preset.configurePreset]);
             return null;
         }
 
@@ -2155,7 +2155,7 @@ async function getWorkflowPresetInheritsImpl(folder: string, name: string, works
         return getWorkflowPresetInheritsHelper(folder, preset, workspaceFolder, sourceDir, true, usePresetsPlusIncluded, errorHandler);
     }
     log.error(localize('workflow.preset.not.found', 'Could not find workflow preset with name {0}', name));
-    errorHandler?.tempErrorList.push([localize('workflow.preset.not.found', 'Could not find workflow preset'), name]);
+    errorHandler?.errorList.push([localize('workflow.preset.not.found', 'Could not find workflow preset'), name]);
     return null;
 }
 
@@ -2200,7 +2200,7 @@ async function getWorkflowPresetInheritsHelper(folder: string, preset: WorkflowP
         }
         if (!expandedConfigurePreset) {
             log.error(localize('configure.preset.not.found.full', 'Could not find configure preset with name {0}', workflowConfigurePreset));
-            errorHandler?.tempErrorList.push([localize('configure.preset.not.found', 'Could not find configure preset'), workflowConfigurePreset]);
+            errorHandler?.errorList.push([localize('configure.preset.not.found', 'Could not find configure preset'), workflowConfigurePreset]);
             return null;
         }
         // The below is critical when the workflow step0 configure preset is different than the

--- a/src/preset.ts
+++ b/src/preset.ts
@@ -823,13 +823,13 @@ async function getExpansionOptions(workspaceFolder: string, sourceDir: string, p
     };
 
     if (preset.__file && preset.__file.version >= 3) {
-        expansionOpts.vars['hostSystemName'] = await util.getHostSystemNameMemo();
+        expansionOpts.vars.hostSystemName = await util.getHostSystemNameMemo();
     }
     if (preset.__file && preset.__file.version >= 4) {
-        expansionOpts.vars['fileDir'] = path.dirname(preset.__file!.__path!);
+        expansionOpts.vars.fileDir = path.dirname(preset.__file!.__path!);
     }
     if (preset.__file && preset.__file.version >= 5) {
-        expansionOpts.vars['pathListSep'] = path.delimiter;
+        expansionOpts.vars.pathListSep = path.delimiter;
     }
 
     return expansionOpts;

--- a/src/presetsController.ts
+++ b/src/presetsController.ts
@@ -10,7 +10,7 @@ import { fs } from '@cmt/pr';
 import * as preset from '@cmt/preset';
 import * as util from '@cmt/util';
 import rollbar from '@cmt/rollbar';
-import { expandString, ExpansionErrorHandler, ExpansionOptions, getParentEnvSubstitutions, MinimalPresetContextVars, substituteAll } from '@cmt/expand';
+import { expandString, ExpansionErrorHandler, ExpansionOptions, MinimalPresetContextVars } from '@cmt/expand';
 import paths from '@cmt/paths';
 import { KitsController } from '@cmt/kitsController';
 import { descriptionForKit, Kit, SpecialKits } from '@cmt/kit';

--- a/src/presetsController.ts
+++ b/src/presetsController.ts
@@ -1615,6 +1615,13 @@ export class PresetsController implements vscode.Disposable {
         return presetsFile.version >= 9
             ? expandString(include, {
                 vars: {
+                    generator: "${generator}", // Not supported in presets includes v9.
+                    userHome: "${userHome}", // Not supported in presets includes v9.
+                    workspaceFolder: "${workspaceFolder}", // Not supported in presets includes v9.
+                    workspaceFolderBasename: "${workspaceFolderBasename}", // Not supported in presets includes v9.
+                    workspaceHash: "${workspaceHash}", // Not supported in presets includes v9.
+                    workspaceRoot: "${workspaceRoot}", // Not supported in presets includes v9.
+                    workspaceRootFolderName: "${workspaceRootFolderName}", // Not supported in presets includes v9.
                     sourceDir: this.folderPath,
                     sourceParentDir: path.dirname(this.folderPath),
                     sourceDirName: path.basename(this.folderPath),
@@ -1622,11 +1629,24 @@ export class PresetsController implements vscode.Disposable {
                     fileDir: path.dirname(file),
                     pathListSep: path.delimiter
                 },
-                envOverride: {} // $env{} expansions are not supported in include paths
+                envOverride: {} // $env{} expansions are not supported in `include` v9
             }, expansionErrors)
             : presetsFile.version >= 7
                 ? // Version 7 and later support $penv{} expansions in include paths
-                substituteAll(include, getParentEnvSubstitutions(include, new Map<string, string>())).result
+                expandString(include, {
+                    // No vars are supported in Version 7 for include paths.
+                    vars: {
+                        generator: "${generator}", // Not supported in presets includes v7.
+                        userHome: "${userHome}", // Not supported in presets includes v7.
+                        workspaceFolder: "${workspaceFolder}", // Not supported in presets includes v7.
+                        workspaceFolderBasename: "${workspaceFolderBasename}", // Not supported in presets includes v7.
+                        workspaceHash: "${workspaceHash}", // Not supported in presets includes v7.
+                        workspaceRoot: "${workspaceRoot}", // Not supported in presets includes v7.
+                        workspaceRootFolderName: "${workspaceRootFolderName}", // Not supported in presets includes v7.
+                        sourceDir: "${sourceDir}" // Not support in presets includes v7
+                    },
+                    envOverride: {} // $env{} expansions are not supported in `include` v9
+                }, expansionErrors)
                 : include;
     }
 

--- a/src/presetsController.ts
+++ b/src/presetsController.ts
@@ -10,7 +10,7 @@ import { fs } from '@cmt/pr';
 import * as preset from '@cmt/preset';
 import * as util from '@cmt/util';
 import rollbar from '@cmt/rollbar';
-import { errorHandlerHelper, expandString, ExpansionErrorHandler, ExpansionOptions, getParentEnvSubstitutions, substituteAll } from '@cmt/expand';
+import { errorHandlerHelper, expandString, ExpansionErrorHandler, ExpansionOptions, getParentEnvSubstitutions, MinimalPresetContextVars, substituteAll } from '@cmt/expand';
 import paths from '@cmt/paths';
 import { KitsController } from '@cmt/kitsController';
 import { descriptionForKit, Kit, SpecialKits } from '@cmt/kit';
@@ -1615,13 +1615,6 @@ export class PresetsController implements vscode.Disposable {
         return presetsFile.version >= 9
             ? expandString(include, {
                 vars: {
-                    generator: "${generator}", // Not supported in presets includes v9.
-                    userHome: "${userHome}", // Not supported in presets includes v9.
-                    workspaceFolder: "${workspaceFolder}", // Not supported in presets includes v9.
-                    workspaceFolderBasename: "${workspaceFolderBasename}", // Not supported in presets includes v9.
-                    workspaceHash: "${workspaceHash}", // Not supported in presets includes v9.
-                    workspaceRoot: "${workspaceRoot}", // Not supported in presets includes v9.
-                    workspaceRootFolderName: "${workspaceRootFolderName}", // Not supported in presets includes v9.
                     sourceDir: this.folderPath,
                     sourceParentDir: path.dirname(this.folderPath),
                     sourceDirName: path.basename(this.folderPath),
@@ -1635,16 +1628,7 @@ export class PresetsController implements vscode.Disposable {
                 ? // Version 7 and later support $penv{} expansions in include paths
                 expandString(include, {
                     // No vars are supported in Version 7 for include paths.
-                    vars: {
-                        generator: "${generator}", // Not supported in presets includes v7.
-                        userHome: "${userHome}", // Not supported in presets includes v7.
-                        workspaceFolder: "${workspaceFolder}", // Not supported in presets includes v7.
-                        workspaceFolderBasename: "${workspaceFolderBasename}", // Not supported in presets includes v7.
-                        workspaceHash: "${workspaceHash}", // Not supported in presets includes v7.
-                        workspaceRoot: "${workspaceRoot}", // Not supported in presets includes v7.
-                        workspaceRootFolderName: "${workspaceRootFolderName}", // Not supported in presets includes v7.
-                        sourceDir: "${sourceDir}" // Not support in presets includes v7
-                    },
+                    vars: {} as MinimalPresetContextVars,
                     envOverride: {} // $env{} expansions are not supported in `include` v9
                 }, expansionErrors)
                 : include;

--- a/src/presetsController.ts
+++ b/src/presetsController.ts
@@ -10,7 +10,7 @@ import { fs } from '@cmt/pr';
 import * as preset from '@cmt/preset';
 import * as util from '@cmt/util';
 import rollbar from '@cmt/rollbar';
-import { errorHandlerHelper, expandString, ExpansionErrorHandler, ExpansionOptions, getParentEnvSubstitutions, MinimalPresetContextVars, substituteAll } from '@cmt/expand';
+import { expandString, ExpansionErrorHandler, ExpansionOptions, getParentEnvSubstitutions, MinimalPresetContextVars, substituteAll } from '@cmt/expand';
 import paths from '@cmt/paths';
 import { KitsController } from '@cmt/kitsController';
 import { descriptionForKit, Kit, SpecialKits } from '@cmt/kit';

--- a/src/presetsController.ts
+++ b/src/presetsController.ts
@@ -10,7 +10,7 @@ import { fs } from '@cmt/pr';
 import * as preset from '@cmt/preset';
 import * as util from '@cmt/util';
 import rollbar from '@cmt/rollbar';
-import { ExpansionErrorHandler, ExpansionOptions, getParentEnvSubstitutions, substituteAll } from '@cmt/expand';
+import { errorHandlerHelper, expandString, ExpansionErrorHandler, ExpansionOptions, getParentEnvSubstitutions, substituteAll } from '@cmt/expand';
 import paths from '@cmt/paths';
 import { KitsController } from '@cmt/kitsController';
 import { descriptionForKit, Kit, SpecialKits } from '@cmt/kit';
@@ -187,18 +187,24 @@ export class PresetsController implements vscode.Disposable {
             setOriginalPresetsFile(this.folderPath, undefined);
         }
 
+        const expansionErrors: ExpansionErrorHandler = { errorList: [], tempErrorList: []};
+
         presetsFile = await this.validatePresetsFile(presetsFile, file);
         if (presetsFile) {
             // Private fields must be set after validation, otherwise validation would fail.
             this.populatePrivatePresetsFields(presetsFile, file);
-            await this.mergeIncludeFiles(presetsFile, file, referencedFiles);
+            await this.mergeIncludeFiles(presetsFile, file, referencedFiles, expansionErrors);
 
-            // add the include files to the original presets file
-            setPresetsPlusIncluded(this.folderPath, presetsFile);
+            if (expansionErrors.errorList.length > 0 || expansionErrors.tempErrorList.length > 0) {
+                presetsFile = undefined;
+            } else {
+                // add the include files to the original presets file
+                setPresetsPlusIncluded(this.folderPath, presetsFile);
 
-            // set the pre-expanded version so we can call expandPresetsFile on it
-            setExpandedPresets(this.folderPath, presetsFile);
-            presetsFile = await this.expandPresetsFile(presetsFile);
+                // set the pre-expanded version so we can call expandPresetsFile on it
+                setExpandedPresets(this.folderPath, presetsFile);
+                presetsFile = await this.expandPresetsFile(presetsFile, expansionErrors);
+            }
         }
 
         setExpandedPresets(this.folderPath, presetsFile);
@@ -1605,22 +1611,43 @@ export class PresetsController implements vscode.Disposable {
         setFile(presetsFile.packagePresets);
     }
 
-    private async mergeIncludeFiles(presetsFile: preset.PresetsFile | undefined, file: string, referencedFiles: Map<string, preset.PresetsFile | undefined>): Promise<void> {
+    private async getExpandedInclude(presetsFile: preset.PresetsFile, include: string, file: string, hostSystemName: string, expansionErrors: ExpansionErrorHandler): Promise<string> {
+        return presetsFile.version >= 9
+            ? expandString(include, {
+                vars: {
+                    sourceDir: this.folderPath,
+                    sourceParentDir: path.dirname(this.folderPath),
+                    sourceDirName: path.basename(this.folderPath),
+                    hostSystemName: hostSystemName,
+                    fileDir: path.dirname(file),
+                    pathListSep: path.delimiter
+                },
+                envOverride: {} // $env{} expansions are not supported in include paths
+            }, expansionErrors)
+            : presetsFile.version >= 7
+                ? // Version 7 and later support $penv{} expansions in include paths
+                substituteAll(include, getParentEnvSubstitutions(include, new Map<string, string>())).result
+                : include;
+    }
+
+    private async mergeIncludeFiles(presetsFile: preset.PresetsFile | undefined, file: string, referencedFiles: Map<string, preset.PresetsFile | undefined>, expansionErrors: ExpansionErrorHandler): Promise<void> {
         if (!presetsFile) {
             return;
         }
 
+        const hostSystemName = await util.getHostSystemNameMemo();
+
         // CMakeUserPresets.json file should include CMakePresets.json file, by default.
         if (this.presetsFileExist && file === this.userPresetsPath) {
             presetsFile.include = presetsFile.include || [];
-            const filteredIncludes = presetsFile.include.filter(include => {
-                // Ensuring that we handle expansions. Duplicated from loop below.
-                const includePath = presetsFile.version >= 7 ?
-                // Version 7 and later support $penv{} expansions in include paths
-                    substituteAll(include, getParentEnvSubstitutions(include, new Map<string, string>())).result :
-                    include;
-                path.normalize(path.resolve(path.dirname(file), includePath)) === this.presetsPath;
-            });
+            const filteredIncludes = [];
+            for (const include of presetsFile.include) {
+                const expandedInclude = await this.getExpandedInclude(presetsFile, include, file, hostSystemName, expansionErrors);
+                if (path.normalize(path.resolve(path.dirname(file), expandedInclude)) === this.presetsPath) {
+                    filteredIncludes.push(include);
+                }
+            }
+
             if (filteredIncludes.length === 0) {
                 presetsFile.include.push(this.presetsPath);
             }
@@ -1633,10 +1660,7 @@ export class PresetsController implements vscode.Disposable {
         // Merge the includes in reverse order so that the final presets order is correct
         for (let i = presetsFile.include.length - 1; i >= 0; i--) {
             const rawInclude = presetsFile.include[i];
-            const includePath = presetsFile.version >= 7 ?
-                // Version 7 and later support $penv{} expansions in include paths
-                substituteAll(rawInclude, getParentEnvSubstitutions(rawInclude, new Map<string, string>())).result :
-                rawInclude;
+            const includePath = await this.getExpandedInclude(presetsFile, rawInclude, file, hostSystemName, expansionErrors);
             const fullIncludePath = path.normalize(path.resolve(path.dirname(file), includePath));
 
             // Do not include files more than once
@@ -1672,6 +1696,7 @@ export class PresetsController implements vscode.Disposable {
             const includeFileBuffer = await this.readPresetsFile(fullIncludePath);
             if (!includeFileBuffer) {
                 log.error(localize('included.presets.file.not.found', 'Included presets file {0} cannot be found', fullIncludePath));
+                expansionErrors.errorList.push([localize('included.presets.file.not.found', 'Included presets file {0} cannot be found', fullIncludePath), file]);
                 continue;
             }
 
@@ -1686,7 +1711,7 @@ export class PresetsController implements vscode.Disposable {
             this.populatePrivatePresetsFields(includeFile, fullIncludePath);
 
             // Recursively merge included files
-            await this.mergeIncludeFiles(includeFile, fullIncludePath, referencedFiles);
+            await this.mergeIncludeFiles(includeFile, fullIncludePath, referencedFiles, expansionErrors);
 
             if (includeFile.configurePresets) {
                 presetsFile.configurePresets = lodash.unionWith(includeFile.configurePresets, presetsFile.configurePresets || [], (a, b) => a.name === b.name);
@@ -1709,21 +1734,27 @@ export class PresetsController implements vscode.Disposable {
                 }
             }
         }
+
+        if (expansionErrors.errorList.length > 0 || expansionErrors.tempErrorList.length > 0) {
+            expansionErrors.tempErrorList.forEach((error) => expansionErrors.errorList.unshift(error));
+            log.error(localize('expansion.errors', 'Expansion errors found in the presets file.'));
+            await this.reportPresetsFileErrors(presetsFile.__path, expansionErrors);
+        } else {
+            collections.presets.set(vscode.Uri.file(presetsFile.__path || ""), undefined);
+        }
     }
 
     /**
      * Returns the expanded presets file if there are no errors, otherwise returns undefined
      * Does not apply vsdevenv to the presets file
      */
-    private async expandPresetsFile(presetsFile: preset.PresetsFile | undefined): Promise<preset.PresetsFile | undefined> {
+    private async expandPresetsFile(presetsFile: preset.PresetsFile | undefined, expansionErrors: ExpansionErrorHandler): Promise<preset.PresetsFile | undefined> {
 
         if (!presetsFile) {
             return undefined;
         }
 
         log.info(localize('expanding.presets.file', 'Expanding presets file {0}', presetsFile?.__path || ''));
-
-        const expansionErrors: ExpansionErrorHandler = { errorList: [], tempErrorList: []};
 
         const expandedConfigurePresets: preset.ConfigurePreset[] = [];
         for (const configurePreset of presetsFile?.configurePresets || []) {
@@ -1884,7 +1915,7 @@ export class PresetsController implements vscode.Disposable {
 
         log.info(localize('validating.presets.file', 'Reading and validating the presets "file {0}"', file));
         let schemaFile;
-        const maxSupportedVersion = 8;
+        const maxSupportedVersion = 9;
         const validationErrorsAreWarnings = presetsFile.version > maxSupportedVersion && this.project.workspaceContext.config.allowUnsupportedPresetsVersions;
         if (presetsFile.version < 2) {
             await this.showPresetsFileVersionError(file);
@@ -1902,7 +1933,8 @@ export class PresetsController implements vscode.Disposable {
         } else if (presetsFile.version === 7) {
             schemaFile = './schemas/CMakePresets-v7-schema.json';
         } else {
-            schemaFile = './schemas/CMakePresets-v8-schema.json';
+            // This can be used for v9 as well, there is no schema difference.
+            schemaFile = "./schemas/CMakePresets-v8-schema.json";
         }
 
         const validator = await loadSchema(schemaFile);


### PR DESCRIPTION
Add support for CMake Presets v9.

Presets v9 adds support for additional macros in the `include` field, enabling more macro expansion. The macros in the include field as of v9 are the following:
- `sourceDir`
- `sourceParentDir`
- `sourceDirName`
- `fileDir`
- `hostSystemName`
- `pathListSep`