### PR TITLE
fix: re-classify configureOnOpen setting

### DIFF
--- a/package.json
+++ b/package.json
@@ -2593,7 +2593,8 @@
           "description": "%cmake-tools.configuration.cmake.configureOnOpen.description%",
           "scope": "resource",
           "tags": [
-            "experimental"
+            "onExP",
+            "preview"
           ]
         },
         "cmake.configureOnEdit": {

--- a/package.json
+++ b/package.json
@@ -2591,11 +2591,7 @@
           "type": "boolean",
           "default": true,
           "description": "%cmake-tools.configuration.cmake.configureOnOpen.description%",
-          "scope": "resource",
-          "tags": [
-            "onExP",
-            "preview"
-          ]
+          "scope": "resource"
         },
         "cmake.configureOnEdit": {
           "type": "boolean",


### PR DESCRIPTION
VS Code 1.95.0 is now out, and with it comes changes to the tagging system.

This PR changes the tags of the cmake.configureOnOpen setting.

For reference, the `preview` tag indicates that the setting ID has been finalized and that the setting is almost stable, the `onExP` tag indicates that the setting can be referenced in an ExP experiment, and the `experimental` tag, which this PR removes, now denotes a WIP setting that could potentially be renamed or removed later. If a setting is stable and not controlled by an experiment, it does not need any of these tags.

Let me know if the tags I suggest in the diff are inaccurate.