### PR TITLE
fix auto select active project (#4146)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Bug Fixes:
 - Fix reloading presets when included files are changed or renamed and updated. [#3963](https://github.com/microsoft/vscode-cmake-tools/issues/3963)
 - Fix compilation database path comparison with the `cmake.copyCompileCommands` that could otherwise overwrite that file. [#4207](https://github.com/microsoft/vscode-cmake-tools/issues/4207) [@k0zmo](https://github.com/k0zmo)
 - Fix parsing of CMakeUserPresets.json containing configure preset that is referenced in workflow preset. [#4202](https://github.com/microsoft/vscode-cmake-tools/pull/4202)
+- Fix auto select active project corner case. [#4146](https://github.com/microsoft/vscode-cmake-tools/issues/4146) Contributed by STMicroelectronics
 
 ## 1.19.52
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -954,7 +954,13 @@ export async function scheduleAsyncTask<T>(task: () => Promise<T>): Promise<T> {
 export function isFileInsideFolder(uri: vscode.Uri, folderPath: string): boolean {
     const parent = platformNormalizePath(folderPath);
     const file = platformNormalizePath(uri.fsPath);
-    return file.startsWith(parent);
+
+    // Ensure project path ends with a path separator to avoid partial matches
+    const parentWithEndingSeparator = parent.endsWith(path.posix.sep)
+        ? parent
+        : `${parent}${path.posix.sep}`;
+
+    return file.startsWith(parentWithEndingSeparator);
 }
 
 /**


### PR DESCRIPTION
## This change addresses item #4146

### This fixes the active project change behavior

The following change is proposed:

- Update utils function isFileInsideFolder to avoid partial match and thus, wrong active project change

Contributed by STMicroelectronics
Signed-off-by: Matthieu NAUD <matthieu.naud@st.com>