### PR TITLE
Use mementos for state management for pinned commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Improvements:
 - Fix "Test output isn't visible when failed" and also mark skipped tests as so. [#4116](https://github.com/microsoft/vscode-cmake-tools/issues/4116)
 - Ensure that stopping tests actually forces the tests to stop running. [#2095](https://github.com/microsoft/vscode-cmake-tools/issues/2095)
 - Retire the Show Options Moved Notification [#4039](https://github.com/microsoft/vscode-cmake-tools/issues/4039)
+- Improve the pinned commands experience by defaulting settings and using VS Code state rather than modifying user settings. [#3977](https://github.com/microsoft/vscode-cmake-tools/issues/3977)
 
 Bug Fixes:
 

--- a/package.json
+++ b/package.json
@@ -3578,7 +3578,10 @@
             "type": "string"
           },
           "description": "%cmake-tools.configuration.cmake.pinnedCommands.description%",
-          "default": [],
+          "default": [
+            "workbench.action.tasks.configureTaskRunner",
+            "workbench.action.tasks.runTask"
+          ],
           "scope": "resource"
         },
         "cmake.enableAutomaticKitScan": {

--- a/package.nls.json
+++ b/package.nls.json
@@ -271,7 +271,7 @@
     },
     "cmake-tools.configuration.cmake.launchBehavior.description": "Controls what happens with the launch terminal when you launch a target.",
     "cmake-tools.configuration.cmake.automaticReconfigure.description": "Automatically configure CMake project directories when the kit or the configuration preset is changed.",
-    "cmake-tools.configuration.cmake.pinnedCommands.description":"List of CMake commands to pin.",
+    "cmake-tools.configuration.cmake.pinnedCommands.description":"List of CMake commands to always pin by default.",
     "cmake-tools.configuration.cmake.enableAutomaticKitScan.description": "Enable automatic scanning for kits when a kit isn't selected. This will only take affect when CMake Presets aren't being used.",
     "cmake-tools.debugger.pipeName.description": "Name of the pipe (on Windows) or domain socket (on Unix) to use for debugger communication.",
     "cmake-tools.debugger.clean.description": "Clean prior to configuring.",

--- a/src/ui/pinnedCommands.ts
+++ b/src/ui/pinnedCommands.ts
@@ -8,7 +8,6 @@ nls.config({ messageFormat: nls.MessageFormat.bundle, bundleFormat: nls.BundleFo
 const localize: nls.LocalizeFunc = nls.loadMessageBundle();
 const log = logging.createLogger('pinnedCommands');
 const defaultTaskCommands: string[] = ["workbench.action.tasks.configureTaskRunner", "workbench.action.tasks.runTask"];
-const mementoKey = "pinDefaultTasks";
 
 interface PinnedCommandsQuickPickItem extends vscode.QuickPickItem {
     command: string;
@@ -97,7 +96,6 @@ class PinnedCommandsTreeDataProvider implements vscode.TreeDataProvider<PinnedCo
     private config: vscode.WorkspaceConfiguration | null;
     private pinnedCommandsKey: string = "cmake.pinnedCommands";
     private isInitialized = false;
-    private pinDefaultTasks = true;
     private readonly _settingsSub ;
     private extensionContext: vscode.ExtensionContext;
 
@@ -106,7 +104,6 @@ class PinnedCommandsTreeDataProvider implements vscode.TreeDataProvider<PinnedCo
         this._settingsSub = configReader.onChange('pinnedCommands', () => this.doConfigureSettingsChange());
         this.config = vscode.workspace.getConfiguration();
         this.extensionContext = extensionContext;
-        this.pinDefaultTasks = this.extensionContext.globalState.get(mementoKey) === undefined; // the user has not unpinned any of the tasks commands yet.
         onExtensionActiveCommandsChanged(this.doConfigureSettingsChange, this);
     }
 
@@ -118,29 +115,29 @@ class PinnedCommandsTreeDataProvider implements vscode.TreeDataProvider<PinnedCo
         this.config = vscode.workspace.getConfiguration();
         this.pinnedCommands = []; //reset to empty list.
         const localization = getExtensionLocalizedStrings();
+        const activeCommands = new Set<string>(PinnedCommands.getPinnableCommands());
+
+        const tryPushCommands = (commands: string[]) => {
+            commands.forEach((x) => {
+                const label = localization[`cmake-tools.command.${x}.title`];
+                if (this.findNode(label) === -1) {
+                    this.pinnedCommands.push(new PinnedCommandNode(label, x, true));
+                }
+            });
+        };
+
+        // Pin the commands that are requested from the users settings.
         if (this.config.has(this.pinnedCommandsKey)) {
             const settingsPinnedCommands = this.config.get(this.pinnedCommandsKey) as string[];
-            const activeCommands = new Set<string>(PinnedCommands.getPinnableCommands());
-            for (const commandName of settingsPinnedCommands) {
-                const label = localization[`cmake-tools.command.${commandName}.title`];
-                if (this.findNode(label) === -1) {
-                    // only show commands that are contained in the active commands for the extension.
-                    this.pinnedCommands.push(new PinnedCommandNode(label, commandName, activeCommands.has(commandName)));
-                }
-            }
+            tryPushCommands(settingsPinnedCommands);
         }
 
-        if (this.pinDefaultTasks) {
-            if (this.pinnedCommands.filter(x => defaultTaskCommands.includes(x.commandName)).length !== defaultTaskCommands.length) {
-                defaultTaskCommands.forEach((x) => {
-                    const label = localization[`cmake-tools.command.${x}.title`];
-                    if (this.findNode(label) === -1) {
-                        this.pinnedCommands.push(new PinnedCommandNode(label, x, true));
-                    }
-                });
-                await this.updateSettings();
-            }
+        // Pin commands that were pinned in the last session.
+        const lastSessionPinnedCommands = this.extensionContext.workspaceState.get(this.pinnedCommandsKey) as string[];
+        if (lastSessionPinnedCommands) {
+            tryPushCommands(lastSessionPinnedCommands);
         }
+
         this.isInitialized = true;
     }
 
@@ -174,10 +171,6 @@ class PinnedCommandsTreeDataProvider implements vscode.TreeDataProvider<PinnedCo
             this.pinnedCommands.splice(index, 1);
             await this.refresh();
         }
-        if (this.pinDefaultTasks && defaultTaskCommands.includes(node.commandName)) {
-            await this.extensionContext.globalState.update(mementoKey, false);
-            this.pinDefaultTasks = false;
-        }
         await this.updateSettings();
     }
 
@@ -191,8 +184,8 @@ class PinnedCommandsTreeDataProvider implements vscode.TreeDataProvider<PinnedCo
 
     async updateSettings() {
         if (this.config) {
-            const newValue: string[] = this.pinnedCommands.map(x => x.commandName);
-            await this.config.update(this.pinnedCommandsKey, newValue, true); // update global
+            const pinnedCommands: string[] = this.pinnedCommands.map(x => x.commandName);
+            await this.extensionContext.workspaceState.update(this.pinnedCommandsKey, pinnedCommands);
         }
     }
 

--- a/src/ui/pinnedCommands.ts
+++ b/src/ui/pinnedCommands.ts
@@ -121,7 +121,7 @@ class PinnedCommandsTreeDataProvider implements vscode.TreeDataProvider<PinnedCo
             commands.forEach((x) => {
                 const label = localization[`cmake-tools.command.${x}.title`];
                 if (this.findNode(label) === -1) {
-                    this.pinnedCommands.push(new PinnedCommandNode(label, x, true));
+                    this.pinnedCommands.push(new PinnedCommandNode(label, x, activeCommands.has(x)));
                 }
             });
         };


### PR DESCRIPTION
<!-- Thanks for your contribution! To make things easier, please fill out the template below. -->

<!-- Please delete any unused sections. -->

<!-- Delete the following heading if there is no corresponding issue -->
## Fixes #3977

### This changes how our pinned commands view interacts with user settings

The following changes are proposed:

- Rather than updating user settings when commands are pinned/unpinned, we update a memento that tracks session to session state.
- Add default settings for the `cmake.pinnedCommands` setting for the task runners. 
- Modify the behavior of the `cmake.pinnedCommands` setting. It no longer is a place that we store everything that is currently pinned. It only stores things that the user always wants to pin by default, regardless of whether they've unpinned it in the past. 


### Video
https://github.com/user-attachments/assets/134c6967-297b-4ebe-9368-1f759071db7d
