### PR TITLE
Enable basic CMake language services

### DIFF
--- a/assets/commands.json
+++ b/assets/commands.json
@@ -1,0 +1,1060 @@
+{
+  "add_compile_definitions": {
+    "name": "add_compile_definitions",
+    "description": "Add preprocessor definitions to the compilation of source files.",
+    "syntax_examples": ["add_compile_definitions(<definition> ...)"]
+  },
+  "add_compile_options": {
+    "name": "add_compile_options",
+    "description": "Add options to the compilation of source files.",
+    "syntax_examples": ["add_compile_options(<option> ...)"]
+  },
+  "add_custom_command": {
+    "name": "add_custom_command",
+    "description": "Add a custom build rule to the generated build system.",
+    "syntax_examples": [
+      "add_custom_command(OUTPUT output1 [output2 ...] COMMAND command1 [ARGS] [args1...] [COMMAND command2 [ARGS] [args2...] ...] [MAIN_DEPENDENCY depend] [DEPENDS [depends...]] [BYPRODUCTS [files...]] [IMPLICIT_DEPENDS <lang1> depend1 [<lang2> depend2] ...] [WORKING_DIRECTORY dir] [COMMENT comment] [DEPFILE depfile] [JOB_POOL job_pool] [JOB_SERVER_AWARE <bool>] [VERBATIM] [APPEND] [USES_TERMINAL] [COMMAND_EXPAND_LISTS] [DEPENDS_EXPLICIT_ONLY])",
+      "add_custom_command( OUTPUT out.c COMMAND someTool -i ${CMAKE_CURRENT_SOURCE_DIR}/in.txt -o out.c DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/in.txt VERBATIM) add_library(myLib out.c)",
+      "add_custom_command( OUTPUT table.csv COMMAND makeTable -i ${CMAKE_CURRENT_SOURCE_DIR}/input.dat -o table.csv DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/input.dat VERBATIM) add_custom_target(generate_table_csv DEPENDS table.csv) add_custom_command( OUTPUT foo.cxx COMMAND genFromTable -i table.csv -case foo -o foo.cxx DEPENDS table.csv generate_table_csv VERBATIM) add_library(foo foo.cxx) add_custom_command( OUTPUT bar.cxx COMMAND genFromTable -i table.csv -case bar -o bar.cxx DEPENDS table.csv generate_table_csv VERBATIM) add_library(bar bar.cxx)",
+      "add_custom_command(TARGET <target> PRE_BUILD | PRE_LINK | POST_BUILD COMMAND command1 [ARGS] [args1...] [COMMAND command2 [ARGS] [args2...] ...] [BYPRODUCTS [files...]] [WORKING_DIRECTORY dir] [COMMENT comment] [VERBATIM] [COMMAND_EXPAND_LISTS])"
+    ]
+  },
+  "add_custom_target": {
+    "name": "add_custom_target",
+    "description": "Add a target with no output so it will always be built.",
+    "syntax_examples": [
+      "add_custom_target(Name [ALL] [command1 [args1...]] [COMMAND command2 [args2...] ...] [DEPENDS depend depend depend ... ] [BYPRODUCTS [files...]] [WORKING_DIRECTORY dir] [COMMENT comment] [JOB_POOL job_pool] [JOB_SERVER_AWARE <bool>] [VERBATIM] [USES_TERMINAL] [COMMAND_EXPAND_LISTS] [SOURCES src1 [src2...]])"
+    ]
+  },
+  "add_definitions": {
+    "name": "add_definitions",
+    "description": "Add -D define flags to the compilation of source files.",
+    "syntax_examples": ["add_definitions(-DFOO -DBAR ...)"]
+  },
+  "add_dependencies": {
+    "name": "add_dependencies",
+    "description": "Add a dependency between top-level targets.",
+    "syntax_examples": ["add_dependencies(<target> [<target-dependency>]...)"]
+  },
+  "add_executable": {
+    "name": "add_executable",
+    "description": "Add an executable to the project using the specified source files.",
+    "syntax_examples": [
+      "add_executable(<name> <options>... <sources>...) :target: normal Add an executable target called ``<name>`` to be built from the source files listed in the command invocation. The options are: ``WIN32`` Set the :prop_tgt:`WIN32_EXECUTABLE` target property automatically. See documentation of that target property for details. ``MACOSX_BUNDLE`` Set the :prop_tgt:`MACOSX_BUNDLE` target property automatically. See documentation of that target property for details. ``EXCLUDE_FROM_ALL`` Set the :prop_tgt:`EXCLUDE_FROM_ALL` target property automatically. See documentation of that target property for details.",
+      "add_executable(<name> IMPORTED [GLOBAL]) :target: IMPORTED Add an :ref:`IMPORTED executable target <Imported Targets>` to reference an executable file located outside the project. The target name may be referenced like any target built within the project, except that by default it is visible only in the directory in which it is created, and below. The options are: ``GLOBAL`` Make the target name globally visible.",
+      "add_executable(<name> ALIAS <target>) :target: ALIAS Creates an :ref:`Alias Target <Alias Targets>`, such that ``<name>`` can be used to refer to ``<target>`` in subsequent commands. The ``<name>`` does not appear in the generated buildsystem as a make target. The ``<target>`` may not be an ``ALIAS``."
+    ]
+  },
+  "add_library": {
+    "name": "add_library",
+    "description": "Add a library to the project using the specified source files.",
+    "syntax_examples": [
+      "add_library(<name> [<type>] [EXCLUDE_FROM_ALL] <sources>...) :target: normal Add a library target called ``<name>`` to be built from the source files listed in the command invocation. The optional ``<type>`` specifies the type of library to be created: ``STATIC`` An archive of object files for use when linking other targets. ``SHARED`` A dynamic library that may be linked by other targets and loaded at runtime. ``MODULE`` A plugin that may not be linked by other targets, but may be dynamically loaded at runtime using dlopen-like functionality. If no ``<type>`` is given the default is ``STATIC`` or ``SHARED`` based on the value of the :variable:`BUILD_SHARED_LIBS` variable. The options are: ``EXCLUDE_FROM_ALL`` Set the :prop_tgt:`EXCLUDE_FROM_ALL` target property automatically. See documentation of that target property for details.",
+      "add_library(<name> OBJECT <sources>...) :target: OBJECT Add an :ref:`Object Library <Object Libraries>` to compile source files without archiving or linking their object files into a library.",
+      "add_library(... $<TARGET_OBJECTS:objlib> ...) add_executable(... $<TARGET_OBJECTS:objlib> ...)",
+      "add_library(<name> INTERFACE) :target: INTERFACE Add an :ref:`Interface Library <Interface Libraries>` target that may specify usage requirements for dependents but does not compile sources and does not produce a library artifact on disk. An interface library with no source files is not included as a target in the generated buildsystem. However, it may have properties set on it and it may be installed and exported. Typically, ``INTERFACE_*`` properties are populated on an interface target using the commands: * :command:`set_property`, * :command:`target_link_libraries(INTERFACE)`, * :command:`target_link_options(INTERFACE)`, * :command:`target_include_directories(INTERFACE)`, * :command:`target_compile_options(INTERFACE)`, * :command:`target_compile_definitions(INTERFACE)`, and * :command:`target_sources(INTERFACE)`, and then it is used as an argument to :command:`target_link_libraries` like any other target. .. versionadded:: 3.15 An interface library can have :prop_tgt:`PUBLIC_HEADER` and :prop_tgt:`PRIVATE_HEADER` properties. The headers specified by those properties can be installed using the :command:`install(TARGETS)` command.",
+      "add_library(<name> INTERFACE [EXCLUDE_FROM_ALL] <sources>...) :target: INTERFACE-with-sources .. versionadded:: 3.19 Add an :ref:`Interface Library <Interface Libraries>` target with source files (in addition to usage requirements and properties as documented by the :command:`above signature <add_library(INTERFACE)>`). Source files may be listed directly in the ``add_library`` call or added later by calls to :command:`target_sources` with the ``PRIVATE`` or ``PUBLIC`` keywords. If an interface library has source files (i.e. the :prop_tgt:`SOURCES` target property is set), or header sets (i.e. the :prop_tgt:`HEADER_SETS` target property is set), it will appear in the generated buildsystem as a build target much like a target defined by the :command:`add_custom_target` command. It does not compile any sources, but does contain build rules for custom commands created by the :command:`add_custom_command` command. The options are: ``EXCLUDE_FROM_ALL`` Set the :prop_tgt:`EXCLUDE_FROM_ALL` target property automatically. See documentation of that target property for details. .. note:: In most command signatures where the ``INTERFACE`` keyword appears, the items listed after it only become part of that target's usage requirements and are not part of the target's own settings. However, in this signature of ``add_library``, the ``INTERFACE`` keyword refers to the library type only. Sources listed after it in the ``add_library`` call are ``PRIVATE`` to the interface library and do not appear in its :prop_tgt:`INTERFACE_SOURCES` target property.",
+      "add_library(<name> <type> IMPORTED [GLOBAL]) :target: IMPORTED Add an :ref:`IMPORTED library target <Imported Targets>` called ``<name>``. The target name may be referenced like any target built within the project, except that by default it is visible only in the directory in which it is created, and below. The ``<type>`` must be one of: ``STATIC``, ``SHARED``, ``MODULE``, ``UNKNOWN`` References a library file located outside the project. The :prop_tgt:`IMPORTED_LOCATION` target property (or its per-configuration variant :prop_tgt:`IMPORTED_LOCATION_<CONFIG>`) specifies the location of the main library file on disk: * For a ``SHARED`` library on most non-Windows platforms, the main library file is the ``.so`` or ``.dylib`` file used by both linkers and dynamic loaders. If the referenced library file has a ``SONAME`` (or on macOS, has a ``LC_ID_DYLIB`` starting in ``@rpath/``), the value of that field should be set in the :prop_tgt:`IMPORTED_SONAME` target property. If the referenced library file does not have a ``SONAME``, but the platform supports it, then the :prop_tgt:`IMPORTED_NO_SONAME` target property should be set. * For a ``SHARED`` library on Windows, the :prop_tgt:`IMPORTED_IMPLIB` target property (or its per-configuration variant :prop_tgt:`IMPORTED_IMPLIB_<CONFIG>`) specifies the location of the DLL import library file (``.lib`` or ``.dll.a``) on disk, and the ``IMPORTED_LOCATION`` is the location of the ``.dll`` runtime library (and is optional, but needed by the :genex:`TARGET_RUNTIME_DLLS` generator expression). Additional usage requirements may be specified in ``INTERFACE_*`` properties. An ``UNKNOWN`` library type is typically only used in the implementation of :ref:`Find Modules`. It allows the path to an imported library (often found using the :command:`find_library` command) to be used without having to know what type of library it is. This is especially useful on Windows where a static library and a DLL's import library both have the same file extension. ``OBJECT`` References a set of object files located outside the project. The :prop_tgt:`IMPORTED_OBJECTS` target property (or its per-configuration variant :prop_tgt:`IMPORTED_OBJECTS_<CONFIG>`) specifies the locations of object files on disk. Additional usage requirements may be specified in ``INTERFACE_*`` properties. ``INTERFACE`` Does not reference any library or object files on disk, but may specify usage requirements in ``INTERFACE_*`` properties. The options are: ``GLOBAL`` Make the target name globally visible.",
+      "add_library(<name> ALIAS <target>) :target: ALIAS Creates an :ref:`Alias Target <Alias Targets>`, such that ``<name>`` can be used to refer to ``<target>`` in subsequent commands. The ``<name>`` does not appear in the generated buildsystem as a make target. The ``<target>`` may not be an ``ALIAS``."
+    ]
+  },
+  "add_link_options": {
+    "name": "add_link_options",
+    "description": "Add options to the link step for executable, shared library or module library targets in the current directory and below that are added after this command is invoked.",
+    "syntax_examples": ["add_link_options(<option> ...)"]
+  },
+  "add_subdirectory": {
+    "name": "add_subdirectory",
+    "description": "Add a subdirectory to the build.",
+    "syntax_examples": [
+      "add_subdirectory(source_dir [binary_dir] [EXCLUDE_FROM_ALL] [SYSTEM])"
+    ]
+  },
+  "add_test": {
+    "name": "add_test",
+    "description": "Add a test to the project to be run by ctest.",
+    "syntax_examples": [
+      "add_test(NAME <name> COMMAND <command> [<arg>...] [CONFIGURATIONS <config>...] [WORKING_DIRECTORY <dir>] [COMMAND_EXPAND_LISTS])",
+      "add_test(NAME mytest COMMAND testDriver --config $<CONFIG> --exe $<TARGET_FILE:myexe>)",
+      "add_test(<name> <command> [<arg>...])"
+    ]
+  },
+  "aux_source_directory": {
+    "name": "aux_source_directory",
+    "description": "Find all source files in a directory.",
+    "syntax_examples": ["aux_source_directory(<dir> <variable>)"]
+  },
+  "block": {
+    "name": "block",
+    "description": "Evaluate a group of commands with a dedicated variable and/or policy scope.",
+    "syntax_examples": [
+      "block([SCOPE_FOR [POLICIES] [VARIABLES]] [PROPAGATE <var-name>...]) <commands> endblock()",
+      "block(SCOPE_FOR VARIABLES POLICIES)"
+    ]
+  },
+  "break": {
+    "name": "break",
+    "description": "Break from an enclosing foreach or while loop.",
+    "syntax_examples": ["break()"]
+  },
+  "build_command": {
+    "name": "build_command",
+    "description": "Get a command line to build the current project. This is mainly intended for internal use by the CTest module.",
+    "syntax_examples": [
+      "build_command(<variable> [CONFIGURATION <config>] [PARALLEL_LEVEL <parallel>] [TARGET <target>] [PROJECT_NAME <projname>])",
+      "build_command(<cachevariable> <makecommand>)"
+    ]
+  },
+  "build_name": {
+    "name": "build_name",
+    "description": "Disallowed since version 3.0. See CMake Policy CMP0036.",
+    "syntax_examples": ["build_name(variable)"]
+  },
+  "cmake_file_api": {
+    "name": "cmake_file_api",
+    "description": "Enables interacting with the CMake file API <cmake-file-api(7)>.",
+    "syntax_examples": [
+      "cmake_file_api(QUERY ...) The ``QUERY`` subcommand adds a file API query for the current CMake invocation. cmake_file_api( QUERY API_VERSION <version> [CODEMODEL <versions>...] [CACHE <versions>...] [CMAKEFILES <versions>...] [TOOLCHAINS <versions>...]) The ``API_VERSION`` must always be given. Currently, the only supported value for ``<version>`` is 1. See :ref:`file-api v1` for details of the reply content and location. Each of the optional keywords ``CODEMODEL``, ``CACHE``, ``CMAKEFILES`` and ``TOOLCHAINS`` correspond to one of the object kinds that can be requested by the project. The ``configureLog`` object kind cannot be set with this command, since it must be set before CMake starts reading the top level ``CMakeLists.txt`` file. For each of the optional keywords, the ``<versions>`` list must contain one or more version values of the form ``major`` or ``major.minor``, where ``major`` and ``minor`` are integers. Projects should list the versions they accept in their preferred order, as only the first supported value from the list will be selected. The command will ignore versions with a ``major`` version higher than any major version it supports for that object kind. It will raise an error if it encounters an invalid version number, or if none of the requested versions is supported. For each type of object kind requested, a query equivalent to a shared, stateless query will be added internally. No query file will be created in the file system. The reply *will* be written to the file system at generation time. It is not an error to add a query for the same thing more than once, whether from query files or from multiple calls to ``cmake_file_api(QUERY)``. The final set of queries will be a merged combination of all queries specified on disk and queries submitted by the project.",
+      "cmake_file_api( QUERY API_VERSION 1 CODEMODEL 2.3 TOOLCHAINS 1 ) add_custom_target(verify_project COMMAND ${CMAKE_COMMAND} -D BUILD_DIR=${CMAKE_BINARY_DIR} -D CONFIG=$<CONFIG> -P ${CMAKE_CURRENT_SOURCE_DIR}/verify_project.cmake )"
+    ]
+  },
+  "cmake_host_system_information": {
+    "name": "cmake_host_system_information",
+    "description": "Query various host system information.",
+    "syntax_examples": [
+      "cmake_host_system_information(RESULT <variable> QUERY <key> ...)",
+      "cmake_host_system_information(RESULT PRETTY_NAME QUERY DISTRIB_PRETTY_NAME) message(STATUS \"${PRETTY_NAME}\") cmake_host_system_information(RESULT DISTRO QUERY DISTRIB_INFO) foreach(VAR IN LISTS DISTRO) message(STATUS \"${VAR}=`${${VAR}}`\") endforeach()",
+      "cmake_host_system_information(RESULT <variable> QUERY WINDOWS_REGISTRY <key> [VALUE_NAMES|SUBKEYS|VALUE <name>] [VIEW (64|32|64_32|32_64|HOST|TARGET|BOTH)] [SEPARATOR <separator>] [ERROR_VARIABLE <result>])",
+      "cmake_host_system_information(RESULT result QUERY WINDOWS_REGISTRY \"HKLM\") cmake_host_system_information(RESULT result QUERY WINDOWS_REGISTRY \"HKLM/SOFTWARE/Kitware\") cmake_host_system_information(RESULT result QUERY WINDOWS_REGISTRY \"HKCU\\\\SOFTWARE\\\\Kitware\")",
+      "cmake_host_system_information(RESULT result QUERY WINDOWS_REGISTRY \"HKLM/SOFTWARE/Kitware\") cmake_host_system_information(RESULT result QUERY WINDOWS_REGISTRY \"HKLM/SOFTWARE/Kitware\" VALUE \"(default)\")"
+    ]
+  },
+  "cmake_language": {
+    "name": "cmake_language",
+    "description": "Call meta-operations on CMake commands.",
+    "syntax_examples": [
+      "cmake_language(CALL <command> [<arg>...]) cmake_language(EVAL CODE <code>...) cmake_language(DEFER <options>... CALL <command> [<arg>...]) cmake_language(SET_DEPENDENCY_PROVIDER <command> SUPPORTED_METHODS <methods>...) cmake_language(GET_MESSAGE_LOG_LEVEL <out-var>) cmake_language(EXIT <exit-code>)",
+      "cmake_language(CALL <command> [<arg>...]) Calls the named ``<command>`` with the given arguments (if any). For example, the code: set(message_command \"message\") cmake_language(CALL ${message_command} STATUS \"Hello World!\") is equivalent to message(STATUS \"Hello World!\") .. note:: To ensure consistency of the code, the following commands are not allowed: * ``if`` / ``elseif`` / ``else`` / ``endif`` * ``block`` / ``endblock`` * ``while`` / ``endwhile`` * ``foreach`` / ``endforeach`` * ``function`` / ``endfunction`` * ``macro`` / ``endmacro``",
+      "cmake_language(EVAL CODE <code>...) :target: EVAL Evaluates the ``<code>...`` as CMake code. For example, the code: set(A TRUE) set(B TRUE) set(C TRUE) set(condition \"(A AND B) OR C\") cmake_language(EVAL CODE \" if (${condition}) message(STATUS TRUE) else() message(STATUS FALSE) endif()\" ) is equivalent to set(A TRUE) set(B TRUE) set(C TRUE) set(condition \"(A AND B) OR C\") file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/eval.cmake \" if (${condition}) message(STATUS TRUE) else() message(STATUS FALSE) endif()\" ) include(${CMAKE_CURRENT_BINARY_DIR}/eval.cmake)",
+      "cmake_language(DEFER <options>... CALL <command> [<arg>...]) Schedules a call to the named ``<command>`` with the given arguments (if any) to occur at a later time. By default, deferred calls are executed as if written at the end of the current directory's ``CMakeLists.txt`` file, except that they run even after a :command:`return` call. Variable references in arguments are evaluated at the time the deferred call is executed. The options are: ``DIRECTORY <dir>`` Schedule the call for the end of the given directory instead of the current directory. The ``<dir>`` may reference either a source directory or its corresponding binary directory. Relative paths are treated as relative to the current source directory. The given directory must be known to CMake, being either the top-level directory or one added by :command:`add_subdirectory`. Furthermore, the given directory must not yet be finished processing. This means it can be the current directory or one of its ancestors. ``ID <id>`` Specify an identification for the deferred call. The ``<id>`` may not be empty and may not begin with a capital letter ``A-Z``. The ``<id>`` may begin with an underscore (``_``) only if it was generated automatically by an earlier call that used ``ID_VAR`` to get the id. ``ID_VAR <var>`` Specify a variable in which to store the identification for the deferred call. If ``ID <id>`` is not given, a new identification will be generated and the generated id will start with an underscore (``_``). The currently scheduled list of deferred calls may be retrieved: cmake_language(DEFER [DIRECTORY <dir>] GET_CALL_IDS <var>) This will store in ``<var>`` a :ref:`semicolon-separated list <CMake Language Lists>` of deferred call ids. The ids are for the directory scope in which the calls have been deferred to (i.e. where they will be executed), which can be different to the scope in which they were created. The ``DIRECTORY`` option can be used to specify the scope for which to retrieve the call ids. If that option is not given, the call ids for the current directory scope will be returned. Details of a specific call may be retrieved from its id: cmake_language(DEFER [DIRECTORY <dir>] GET_CALL <id> <var>) This will store in ``<var>`` a :ref:`semicolon-separated list <CMake Language Lists>` in which the first element is the name of the command to be called, and the remaining elements are its unevaluated arguments (any contained ``;`` characters are included literally and cannot be distinguished from multiple arguments). If multiple calls are scheduled with the same id, this retrieves the first one. If no call is scheduled with the given id in the specified ``DIRECTORY`` scope (or the current directory scope if no ``DIRECTORY`` option is given), this stores an empty string in the variable. Deferred calls may be canceled by their id: cmake_language(DEFER [DIRECTORY <dir>] CANCEL_CALL <id>...) This cancels all deferred calls matching any of the given ids in the specified ``DIRECTORY`` scope (or the current directory scope if no ``DIRECTORY`` option is given). Unknown ids are silently ignored.",
+      "cmake_language(DEFER CALL message \"${deferred_message}\") cmake_language(DEFER ID_VAR id CALL message \"Canceled Message\") cmake_language(DEFER CANCEL_CALL ${id}) message(\"Immediate Message\") set(deferred_message \"Deferred Message\")",
+      "cmake_language(SET_DEPENDENCY_PROVIDER <command> SUPPORTED_METHODS <methods>...) When a call is made to :command:`find_package` or :command:`FetchContent_MakeAvailable`, the call may be forwarded to a dependency provider which then has the opportunity to fulfill the request. If the request is for one of the ``<methods>`` specified when the provider was set, CMake calls the provider's ``<command>`` with a set of method-specific arguments. If the provider does not fulfill the request, or if the provider doesn't support the request's method, or no provider is set, the built-in :command:`find_package` or :command:`FetchContent_MakeAvailable` implementation is used to fulfill the request in the usual way. One or more of the following values can be specified for the ``<methods>`` when setting the provider: ``FIND_PACKAGE`` The provider command accepts :command:`find_package` requests. ``FETCHCONTENT_MAKEAVAILABLE_SERIAL`` The provider command accepts :command:`FetchContent_MakeAvailable` requests. It expects each dependency to be fed to the provider command one at a time, not the whole list in one go. Only one provider can be set at any point in time. If a provider is already set when ``cmake_language(SET_DEPENDENCY_PROVIDER)`` is called, the new provider replaces the previously set one. The specified ``<command>`` must already exist when ``cmake_language(SET_DEPENDENCY_PROVIDER)`` is called. As a special case, providing an empty string for the ``<command>`` and no ``<methods>`` will discard any previously set provider. The dependency provider can only be set while processing one of the files specified by the :variable:`CMAKE_PROJECT_TOP_LEVEL_INCLUDES` variable. Thus, dependency providers can only be set as part of the first call to :command:`project`. Calling ``cmake_language(SET_DEPENDENCY_PROVIDER)`` outside of that context will result in an error. .. versionadded:: 3.30 The :prop_gbl:`PROPAGATE_TOP_LEVEL_INCLUDES_TO_TRY_COMPILE` global property can be set if the dependency provider also wants to be enabled in whole-project calls to :command:`try_compile`. .. note:: The choice of dependency provider should always be under the user's control. As a convenience, a project may choose to provide a file that users can list in their :variable:`CMAKE_PROJECT_TOP_LEVEL_INCLUDES` variable, but the use of such a file should always be the user's choice.",
+      "cmake_language(GET_MESSAGE_LOG_LEVEL <output_variable>) Writes the current :command:`message` logging level into the given ``<output_variable>``. See :command:`message` for the possible logging levels. The current message logging level can be set either using the :option:`--log-level <cmake --log-level>` command line option of the :manual:`cmake(1)` program or using the :variable:`CMAKE_MESSAGE_LOG_LEVEL` variable. If both the command line option and the variable are set, the command line option takes precedence. If neither are set, the default logging level is returned.",
+      "cmake_language(EXIT <exit-code>) Terminate the current :option:`cmake -P` script and exit with ``<exit-code>``. This command works only in :ref:`script mode <Script Processing Mode>`. If used outside of that context, it will cause a fatal error. The ``<exit-code>`` should be non-negative. If ``<exit-code>`` is negative, then the behavior is unspecified (e.g., on Windows the error code -1 becomes ``0xffffffff``, and on Linux it becomes 255). Exit codes above 255 may not be supported by the underlying shell or platform, and some shells may interpret values above 125 specially. Therefore, it is advisable to only specify an ``<exit-code>`` in the range 0 to 125."
+    ]
+  },
+  "cmake_minimum_required": {
+    "name": "cmake_minimum_required",
+    "description": "Require a minimum version of cmake.",
+    "syntax_examples": [
+      "cmake_minimum_required(VERSION <min>[...<policy_max>] [FATAL_ERROR])"
+    ]
+  },
+  "cmake_parse_arguments": {
+    "name": "cmake_parse_arguments",
+    "description": "Parse function or macro arguments.",
+    "syntax_examples": [
+      "cmake_parse_arguments(<prefix> <options> <one_value_keywords> <multi_value_keywords> <args>...) cmake_parse_arguments(PARSE_ARGV <N> <prefix> <options> <one_value_keywords> <multi_value_keywords>)"
+    ]
+  },
+  "cmake_path": {
+    "name": "cmake_path",
+    "description": "This command is for the manipulation of paths. Only syntactic aspects of paths are handled, there is no interaction of any kind with any underlying file system. The path may represent a non-existing path or even one that is not allowed to exist on the current file system or platform. For operations that do interact with the filesystem, see the file command.",
+    "syntax_examples": [
+      "cmake_path(GET <path-var> ROOT_NAME <out-var>) cmake_path(GET <path-var> ROOT_DIRECTORY <out-var>) cmake_path(GET <path-var> ROOT_PATH <out-var>) cmake_path(GET <path-var> FILENAME <out-var>) cmake_path(GET <path-var> EXTENSION [LAST_ONLY] <out-var>) cmake_path(GET <path-var> STEM [LAST_ONLY] <out-var>) cmake_path(GET <path-var> RELATIVE_PART <out-var>) cmake_path(GET <path-var> PARENT_PATH <out-var>)",
+      "cmake_path(HAS_ROOT_NAME <path-var> <out-var>) cmake_path(HAS_ROOT_DIRECTORY <path-var> <out-var>) cmake_path(HAS_ROOT_PATH <path-var> <out-var>) cmake_path(HAS_FILENAME <path-var> <out-var>) cmake_path(HAS_EXTENSION <path-var> <out-var>) cmake_path(HAS_STEM <path-var> <out-var>) cmake_path(HAS_RELATIVE_PART <path-var> <out-var>) cmake_path(HAS_PARENT_PATH <path-var> <out-var>)",
+      "cmake_path(IS_ABSOLUTE <path-var> <out-var>)",
+      "cmake_path(IS_RELATIVE <path-var> <out-var>)",
+      "cmake_path(IS_PREFIX <path-var> <input> [NORMALIZE] <out-var>)",
+      "cmake_path(COMPARE <input1> EQUAL <input2> <out-var>) cmake_path(COMPARE <input1> NOT_EQUAL <input2> <out-var>)",
+      "cmake_path(SET <path-var> [NORMALIZE] <input>)",
+      "cmake_path(APPEND <path-var> [<input>...] [OUTPUT_VARIABLE <out-var>])",
+      "cmake_path(APPEND_STRING <path-var> [<input>...] [OUTPUT_VARIABLE <out-var>])",
+      "cmake_path(REMOVE_FILENAME <path-var> [OUTPUT_VARIABLE <out-var>])",
+      "cmake_path(REPLACE_FILENAME <path-var> <input> [OUTPUT_VARIABLE <out-var>])",
+      "cmake_path(HAS_FILENAME path has_filename) if(has_filename) cmake_path(REMOVE_FILENAME path) cmake_path(APPEND path input); endif()",
+      "cmake_path(REMOVE_EXTENSION <path-var> [LAST_ONLY] [OUTPUT_VARIABLE <out-var>])",
+      "cmake_path(REPLACE_EXTENSION <path-var> [LAST_ONLY] <input> [OUTPUT_VARIABLE <out-var>])",
+      "cmake_path(REMOVE_EXTENSION path) if(NOT \"input\" MATCHES \"^\\\\.\") cmake_path(APPEND_STRING path \".\") endif() cmake_path(APPEND_STRING path \"input\")",
+      "cmake_path(NORMAL_PATH <path-var> [OUTPUT_VARIABLE <out-var>])",
+      "cmake_path(RELATIVE_PATH <path-var> [BASE_DIRECTORY <input>] [OUTPUT_VARIABLE <out-var>])",
+      "cmake_path(ABSOLUTE_PATH <path-var> [BASE_DIRECTORY <input>] [NORMALIZE] [OUTPUT_VARIABLE <out-var>])",
+      "cmake_path(NATIVE_PATH <path-var> [NORMALIZE] <out-var>)",
+      "cmake_path(CONVERT <input> TO_CMAKE_PATH_LIST <out-var> [NORMALIZE])",
+      "cmake_path(CONVERT <input> TO_NATIVE_PATH_LIST <out-var> [NORMALIZE])",
+      "cmake_path(HASH <path-var> <out-var>)"
+    ]
+  },
+  "cmake_policy": {
+    "name": "cmake_policy",
+    "description": "Manage CMake Policy settings. See the cmake-policies manual for defined policies.",
+    "syntax_examples": [
+      "cmake_policy(VERSION <min>[...<max>]) :target: VERSION",
+      "cmake_policy(SET CMP<NNNN> NEW|OLD) :target: SET",
+      "cmake_policy(GET CMP<NNNN> <variable>) :target: GET",
+      "cmake_policy(PUSH) :target: PUSH Create a new entry on the policy stack.",
+      "cmake_policy(POP) :target: POP Remove the last policy stack entry created with ``cmake_policy(PUSH)``."
+    ]
+  },
+  "configure_file": {
+    "name": "configure_file",
+    "description": "Copy a file to another location and modify its contents.",
+    "syntax_examples": [
+      "configure_file(<input> <output> [NO_SOURCE_PERMISSIONS | USE_SOURCE_PERMISSIONS | FILE_PERMISSIONS <permissions>...] [COPYONLY] [ESCAPE_QUOTES] [@ONLY] [NEWLINE_STYLE [UNIX|DOS|WIN32|LF|CRLF]])"
+    ]
+  },
+  "continue": {
+    "name": "continue",
+    "description": "Continue to the top of enclosing foreach or while loop.",
+    "syntax_examples": ["continue()"]
+  },
+  "create_test_sourcelist": {
+    "name": "create_test_sourcelist",
+    "description": "Create a test driver program that links together many small tests into a single executable. This is useful when building static executables with large libraries to shrink the total required size.",
+    "syntax_examples": [
+      "create_test_sourcelist(<sourceListName> <driverName> <test>... <options>...) :target: original Generate a test driver source file from a list of individual test sources and provide a combined list of sources that can be built as an executable. The options are: ``<sourceListName>`` The name of a variable in which to store the list of source files needed to build the test driver. The list will contain the ``<test>...`` sources and the generated ``<driverName>`` source. .. versionchanged:: 3.29 The test driver source is listed by absolute path in the build tree. Previously it was listed only as ``<driverName>``. ``<driverName>`` Name of the test driver source file to be generated into the build tree. The source file will contain a ``main()`` program entry point that dispatches to whatever test is named on the command line. ``<test>...`` Test source files to be added to the driver binary. Each test source file must have a function in it that is the same name as the file with the extension removed. For example, a ``foo.cxx`` test source might contain: .. code-block:: c++ int foo(int argc, char** argv) ``EXTRA_INCLUDE <header>`` Specify a header file to `` ``FUNCTION <function>`` Specify a function to be called with pointers to ``argc`` and ``argv``. The function may be provided in the ``EXTRA_INCLUDE`` header: .. code-block:: c++ void function(int* pargc, char*** pargv) This can be used to add extra command line processing to each test."
+    ]
+  },
+  "ctest_build": {
+    "name": "ctest_build",
+    "description": "Perform the CTest Build Step as a Dashboard Client.",
+    "syntax_examples": [
+      "ctest_build([BUILD <build-dir>] [APPEND] [CONFIGURATION <config>] [PARALLEL_LEVEL <parallel>] [FLAGS <flags>] [PROJECT_NAME <project-name>] [TARGET <target-name>] [NUMBER_ERRORS <num-err-var>] [NUMBER_WARNINGS <num-warn-var>] [RETURN_VALUE <result-var>] [CAPTURE_CMAKE_ERROR <result-var>])"
+    ]
+  },
+  "ctest_configure": {
+    "name": "ctest_configure",
+    "description": "Perform the CTest Configure Step as a Dashboard Client.",
+    "syntax_examples": [
+      "ctest_configure([BUILD <build-dir>] [SOURCE <source-dir>] [APPEND] [OPTIONS <options>] [RETURN_VALUE <result-var>] [QUIET] [CAPTURE_CMAKE_ERROR <result-var>])"
+    ]
+  },
+  "ctest_coverage": {
+    "name": "ctest_coverage",
+    "description": "Perform the CTest Coverage Step as a Dashboard Client.",
+    "syntax_examples": [
+      "ctest_coverage([BUILD <build-dir>] [APPEND] [LABELS <label>...] [RETURN_VALUE <result-var>] [CAPTURE_CMAKE_ERROR <result-var>] [QUIET])"
+    ]
+  },
+  "ctest_empty_binary_directory": {
+    "name": "ctest_empty_binary_directory",
+    "description": "empties the binary directory",
+    "syntax_examples": ["ctest_empty_binary_directory(<directory>)"]
+  },
+  "ctest_memcheck": {
+    "name": "ctest_memcheck",
+    "description": "Perform the CTest MemCheck Step as a Dashboard Client.",
+    "syntax_examples": [
+      "ctest_memcheck([BUILD <build-dir>] [APPEND] [START <start-number>] [END <end-number>] [STRIDE <stride-number>] [EXCLUDE <exclude-regex>] [INCLUDE <include-regex>] [EXCLUDE_LABEL <label-exclude-regex>] [INCLUDE_LABEL <label-include-regex>] [EXCLUDE_FIXTURE <regex>] [EXCLUDE_FIXTURE_SETUP <regex>] [EXCLUDE_FIXTURE_CLEANUP <regex>] [PARALLEL_LEVEL <level>] [RESOURCE_SPEC_FILE <file>] [TEST_LOAD <threshold>] [SCHEDULE_RANDOM <ON|OFF>] [STOP_ON_FAILURE] [STOP_TIME <time-of-day>] [RETURN_VALUE <result-var>] [CAPTURE_CMAKE_ERROR <result-var>] [REPEAT <mode>:<n>] [OUTPUT_JUNIT <file>] [DEFECT_COUNT <defect-count-var>] [QUIET])"
+    ]
+  },
+  "ctest_read_custom_files": {
+    "name": "ctest_read_custom_files",
+    "description": "read CTestCustom files.",
+    "syntax_examples": ["ctest_read_custom_files(<directory>...)"]
+  },
+  "ctest_run_script": {
+    "name": "ctest_run_script",
+    "description": "runs a ctest -S script",
+    "syntax_examples": [
+      "ctest_run_script([NEW_PROCESS] script_file_name script_file_name1 script_file_name2 ... [RETURN_VALUE var])"
+    ]
+  },
+  "ctest_sleep": {
+    "name": "ctest_sleep",
+    "description": "sleeps for some amount of time",
+    "syntax_examples": [
+      "ctest_sleep(<seconds>)",
+      "ctest_sleep(<time1> <duration> <time2>)"
+    ]
+  },
+  "ctest_start": {
+    "name": "ctest_start",
+    "description": "Starts the testing for a given model",
+    "syntax_examples": [
+      "ctest_start(<model> [<source> [<binary>]] [GROUP <group>] [QUIET]) ctest_start([<model> [<source> [<binary>]]] [GROUP <group>] APPEND [QUIET])",
+      "ctest_start(Experimental GROUP GroupExperimental)",
+      "ctest_start(APPEND)",
+      "ctest_start(Experimental path/to/source path/to/binary GROUP SomeGroup QUIET APPEND) ctest_start(GROUP SomeGroup Experimental QUIET path/to/source APPEND path/to/binary) ctest_start(APPEND QUIET Experimental path/to/source GROUP SomeGroup path/to/binary)"
+    ]
+  },
+  "ctest_submit": {
+    "name": "ctest_submit",
+    "description": "Perform the CTest Submit Step as a Dashboard Client.",
+    "syntax_examples": [
+      "ctest_submit([PARTS <part>...] [FILES <file>...] [SUBMIT_URL <url>] [BUILD_ID <result-var>] [HTTPHEADER <header>] [RETRY_COUNT <count>] [RETRY_DELAY <delay>] [RETURN_VALUE <result-var>] [CAPTURE_CMAKE_ERROR <result-var>] [QUIET])",
+      "ctest_submit(HTTPHEADER \"Authorization: Bearer <auth-token>\")",
+      "ctest_submit(CDASH_UPLOAD <file> [CDASH_UPLOAD_TYPE <type>] [SUBMIT_URL <url>] [BUILD_ID <result-var>] [HTTPHEADER <header>] [RETRY_COUNT <count>] [RETRY_DELAY <delay>] [RETURN_VALUE <result-var>] [QUIET])"
+    ]
+  },
+  "ctest_test": {
+    "name": "ctest_test",
+    "description": "Perform the CTest Test Step as a Dashboard Client.",
+    "syntax_examples": [
+      "ctest_test([BUILD <build-dir>] [APPEND] [START <start-number>] [END <end-number>] [STRIDE <stride-number>] [EXCLUDE <exclude-regex>] [INCLUDE <include-regex>] [EXCLUDE_LABEL <label-exclude-regex>] [INCLUDE_LABEL <label-include-regex>] [EXCLUDE_FROM_FILE <filename>] [INCLUDE_FROM_FILE <filename>] [EXCLUDE_FIXTURE <regex>] [EXCLUDE_FIXTURE_SETUP <regex>] [EXCLUDE_FIXTURE_CLEANUP <regex>] [PARALLEL_LEVEL [<level>]] [RESOURCE_SPEC_FILE <file>] [TEST_LOAD <threshold>] [SCHEDULE_RANDOM <ON|OFF>] [STOP_ON_FAILURE] [STOP_TIME <time-of-day>] [RETURN_VALUE <result-var>] [CAPTURE_CMAKE_ERROR <result-var>] [REPEAT <mode>:<n>] [OUTPUT_JUNIT <file>] [QUIET])"
+    ]
+  },
+  "ctest_update": {
+    "name": "ctest_update",
+    "description": "Perform the CTest Update Step as a Dashboard Client.",
+    "syntax_examples": [
+      "ctest_update([SOURCE <source-dir>] [RETURN_VALUE <result-var>] [CAPTURE_CMAKE_ERROR <result-var>] [QUIET])"
+    ]
+  },
+  "ctest_upload": {
+    "name": "ctest_upload",
+    "description": "Upload files to a dashboard server as a Dashboard Client.",
+    "syntax_examples": [
+      "ctest_upload(FILES <file>... [QUIET] [CAPTURE_CMAKE_ERROR <result-var>])"
+    ]
+  },
+  "define_property": {
+    "name": "define_property",
+    "description": "Define and document custom properties.",
+    "syntax_examples": [
+      "define_property(<GLOBAL | DIRECTORY | TARGET | SOURCE | TEST | VARIABLE | CACHED_VARIABLE> PROPERTY <name> [INHERITED] [BRIEF_DOCS <brief-doc> [docs...]] [FULL_DOCS <full-doc> [docs...]] [INITIALIZE_FROM_VARIABLE <variable>])",
+      "define_property(TARGET PROPERTY MY_NEW_PROP BRIEF_DOCS \"My new custom property\" ) get_property(my_new_prop_exists TARGET NONE PROPERTY MY_NEW_PROP DEFINED ) if(my_new_prop_exists) get_property(my_new_prop_docs TARGET NONE PROPERTY MY_NEW_PROP BRIEF_DOCS ) endif()"
+    ]
+  },
+  "else": {
+    "name": "else",
+    "description": "Starts the else portion of an if block.",
+    "syntax_examples": ["else([<condition>])"]
+  },
+  "elseif": {
+    "name": "elseif",
+    "description": "Starts an elseif portion of an if block.",
+    "syntax_examples": ["elseif(<condition>)"]
+  },
+  "enable_language": {
+    "name": "enable_language",
+    "description": "Enable languages (CXX/C/OBJC/OBJCXX/Fortran/etc)",
+    "syntax_examples": ["enable_language(<lang>... [OPTIONAL])"]
+  },
+  "enable_testing": {
+    "name": "enable_testing",
+    "description": "Enable testing for current directory and below.",
+    "syntax_examples": ["enable_testing()"]
+  },
+  "endblock": {
+    "name": "endblock",
+    "description": "Ends a list of commands in a block and removes the scopes created by the block command.",
+    "syntax_examples": ["endblock()"]
+  },
+  "endforeach": {
+    "name": "endforeach",
+    "description": "Ends a list of commands in a foreach block.",
+    "syntax_examples": ["endforeach([<loop_var>])"]
+  },
+  "endfunction": {
+    "name": "endfunction",
+    "description": "Ends a list of commands in a function block.",
+    "syntax_examples": ["endfunction([<name>])"]
+  },
+  "endif": {
+    "name": "endif",
+    "description": "Ends a list of commands in an if block.",
+    "syntax_examples": ["endif([<condition>])"]
+  },
+  "endmacro": {
+    "name": "endmacro",
+    "description": "Ends a list of commands in a macro block.",
+    "syntax_examples": ["endmacro([<name>])"]
+  },
+  "endwhile": {
+    "name": "endwhile",
+    "description": "Ends a list of commands in a while block.",
+    "syntax_examples": ["endwhile([<condition>])"]
+  },
+  "execute_process": {
+    "name": "execute_process",
+    "description": "Execute one or more child processes.",
+    "syntax_examples": [
+      "execute_process(COMMAND <cmd1> [<arguments>] [COMMAND <cmd2> [<arguments>]]... [WORKING_DIRECTORY <directory>] [TIMEOUT <seconds>] [RESULT_VARIABLE <variable>] [RESULTS_VARIABLE <variable>] [OUTPUT_VARIABLE <variable>] [ERROR_VARIABLE <variable>] [INPUT_FILE <file>] [OUTPUT_FILE <file>] [ERROR_FILE <file>] [OUTPUT_QUIET] [ERROR_QUIET] [COMMAND_ECHO <where>] [OUTPUT_STRIP_TRAILING_WHITESPACE] [ERROR_STRIP_TRAILING_WHITESPACE] [ENCODING <name>] [ECHO_OUTPUT_VARIABLE] [ECHO_ERROR_VARIABLE] [COMMAND_ERROR_IS_FATAL <ANY|LAST>])"
+    ]
+  },
+  "exec_program": {
+    "name": "exec_program",
+    "description": "Run an executable program during the processing of the CMakeList.txt file.",
+    "syntax_examples": [
+      "exec_program(Executable [directory in which to run] [ARGS <arguments to executable>] [OUTPUT_VARIABLE <var>] [RETURN_VALUE <var>])"
+    ]
+  },
+  "export": {
+    "name": "export",
+    "description": "Export targets or packages for outside projects to use them directly from the current project's build tree, without installation.",
+    "syntax_examples": [
+      "export(TARGETS <target>... [...]) export(EXPORT <export-name> [...]) export(PACKAGE <PackageName>) export(SETUP <export-name> [...])",
+      "export(TARGETS <target>... [...])",
+      "export(TARGETS <target>... [NAMESPACE <namespace>] [APPEND] FILE <filename> [EXPORT_LINK_INTERFACE_LIBRARIES] [CXX_MODULES_DIRECTORY <directory>])",
+      "export(TARGETS <target>... ANDROID_MK <filename>)",
+      "export(EXPORT <export-name> [...])",
+      "export(EXPORT <export-name> [NAMESPACE <namespace>] [FILE <filename>] [CXX_MODULES_DIRECTORY <directory>] [EXPORT_PACKAGE_DEPENDENCIES])",
+      "export(PACKAGE <PackageName>)",
+      "export(PACKAGE <PackageName>)",
+      "export(SETUP <export-name> [...])",
+      "export(SETUP <export-name> [PACKAGE_DEPENDENCY <dep> [ENABLED (<bool-true>|<bool-false>|AUTO)] [EXTRA_ARGS <args>...]] [...] [TARGET <target> [XCFRAMEWORK_LOCATION <location>]] [...])"
+    ]
+  },
+  "export_library_dependencies": {
+    "name": "export_library_dependencies",
+    "description": "Disallowed since version 3.0. See CMake Policy CMP0033.",
+    "syntax_examples": ["export_library_dependencies(<file> [APPEND])"]
+  },
+  "file": {
+    "name": "file",
+    "description": "File manipulation command.",
+    "syntax_examples": [
+      "file(READ <filename> <variable> [OFFSET <offset>] [LIMIT <max-in>] [HEX]) Read content from a file called ``<filename>`` and store it in a ``<variable>``. Optionally start from the given ``<offset>`` and read at most ``<max-in>`` bytes. The ``HEX`` option causes data to be converted to a hexadecimal representation (useful for binary data). If the ``HEX`` option is specified, letters in the output (``a`` through ``f``) are in lowercase.",
+      "file(STRINGS <filename> <variable> <options>...) Parse a list of ASCII strings from ``<filename>`` and store it in ``<variable>``. Binary data in the file are ignored. Carriage return (``\\r``, CR) characters are ignored. The options are: ``LENGTH_MAXIMUM <max-len>`` Consider only strings of at most a given length. ``LENGTH_MINIMUM <min-len>`` Consider only strings of at least a given length. ``LIMIT_COUNT <max-num>`` Limit the number of distinct strings to be extracted. ``LIMIT_INPUT <max-in>`` Limit the number of input bytes to read from the file. ``LIMIT_OUTPUT <max-out>`` Limit the number of total bytes to store in the ``<variable>``. ``NEWLINE_CONSUME`` Treat newline characters (``\\n``, LF) as part of string content instead of terminating at them. ``NO_HEX_CONVERSION`` Intel Hex and Motorola S-record files are automatically converted to binary while reading unless this option is given. ``REGEX <regex>`` Consider only strings that match the given regular expression, as described under :ref:`string(REGEX) <Regex Specification>`. .. versionchanged:: 3.29 Capture groups from the last match in the file are stored in :variable:`CMAKE_MATCH_<n>`, similar to :command:`string(REGEX MATCHALL)`. See policy :policy:`CMP0159`. ``ENCODING <encoding-type>`` .. versionadded:: 3.1 Consider strings of a given encoding. Currently supported encodings are: ``UTF-8``, ``UTF-16LE``, ``UTF-16BE``, ``UTF-32LE``, ``UTF-32BE``. If the ``ENCODING`` option is not provided and the file has a Byte Order Mark, the ``ENCODING`` option will be defaulted to respect the Byte Order Mark. .. versionadded:: 3.2 Added the ``UTF-16LE``, ``UTF-16BE``, ``UTF-32LE``, ``UTF-32BE`` encodings. For example, the code file(STRINGS myfile.txt myfile) stores a list in the variable ``myfile`` in which each item is a line from the input file.",
+      "file(<HASH> <filename> <variable>) :target: <HASH> Compute a cryptographic hash of the content of ``<filename>`` and store it in a ``<variable>``. The supported ``<HASH>`` algorithm names are those listed by the :command:`string(<HASH>)` command.",
+      "file(TIMESTAMP <filename> <variable> [<format>] [UTC]) Compute a string representation of the modification time of ``<filename>`` and store it in ``<variable>``. Should the command be unable to obtain a timestamp variable will be set to the empty string (\"\"). See the :command:`string(TIMESTAMP)` command for documentation of the ``<format>`` and ``UTC`` options.",
+      "file(WRITE <filename> <content>...) file(APPEND <filename> <content>...) Write ``<content>`` into a file called ``<filename>``. If the file does not exist, it will be created. If the file already exists, ``WRITE`` mode will overwrite it and ``APPEND`` mode will append to the end. Any directories in the path specified by ``<filename>`` that do not exist will be created. If the file is a build input, use the :command:`configure_file` command to update the file only when its content changes.",
+      "file(TOUCH <files>...) file(TOUCH_NOCREATE <files>...) .. versionadded:: 3.12 Create a file with no content if it does not yet exist. If the file already exists, its access and/or modification will be updated to the time when the function call is executed. Use ``TOUCH_NOCREATE`` to touch a file if it exists but not create it. If a file does not exist it will be silently ignored. With ``TOUCH`` and ``TOUCH_NOCREATE``, the contents of an existing file will not be modified. .. versionchanged:: 3.30 ``<files>`` can be an empty list. CMake 3.29 and earlier required at least one file to be given.",
+      "file(GENERATE [...]) Generate an output file for each build configuration supported by the current :manual:`CMake Generator <cmake-generators(7)>`. Evaluate :manual:`generator expressions <cmake-generator-expressions(7)>` from the input content to produce the output content. file(GENERATE OUTPUT <output-file> <INPUT <input-file>|CONTENT <content>> [CONDITION <expression>] [TARGET <target>] [NO_SOURCE_PERMISSIONS | USE_SOURCE_PERMISSIONS | FILE_PERMISSIONS <permissions>...] [NEWLINE_STYLE [UNIX|DOS|WIN32|LF|CRLF]]) The options are: ``CONDITION <condition>`` Generate the output file for a particular configuration only if the condition is true. The condition must be either ``0`` or ``1`` after evaluating generator expressions. ``CONTENT <content>`` Use the content given explicitly as input. ``INPUT <input-file>`` Use the content from a given file as input. .. versionchanged:: 3.10 A relative path is treated with respect to the value of :variable:`CMAKE_CURRENT_SOURCE_DIR`. See policy :policy:`CMP0070`. ``OUTPUT <output-file>`` Specify the output file name to generate. Use generator expressions such as :genex:`$<CONFIG>` to specify a configuration-specific output file name. Multiple configurations may generate the same output file only if the generated content is identical. Otherwise, the ``<output-file>`` must evaluate to an unique name for each configuration. .. versionchanged:: 3.10 A relative path (after evaluating generator expressions) is treated with respect to the value of :variable:`CMAKE_CURRENT_BINARY_DIR`. See policy :policy:`CMP0070`. ``TARGET <target>`` .. versionadded:: 3.19 Specify which target to use when evaluating generator expressions that require a target for evaluation (e.g. :genex:`$<COMPILE_FEATURES:...>`, :genex:`$<TARGET_PROPERTY:prop>`). ``NO_SOURCE_PERMISSIONS`` .. versionadded:: 3.20 The generated file permissions default to the standard 644 value (-rw-r--r--). ``USE_SOURCE_PERMISSIONS`` .. versionadded:: 3.20 Transfer the file permissions of the ``INPUT`` file to the generated file. This is already the default behavior if none of the three permissions-related keywords are given (``NO_SOURCE_PERMISSIONS``, ``USE_SOURCE_PERMISSIONS`` or ``FILE_PERMISSIONS``). The ``USE_SOURCE_PERMISSIONS`` keyword mostly serves as a way of making the intended behavior clearer at the call site. It is an error to specify this option without ``INPUT``. ``FILE_PERMISSIONS <permissions>...`` .. versionadded:: 3.20 Use the specified permissions for the generated file. ``NEWLINE_STYLE <style>`` .. versionadded:: 3.20 Specify the newline style for the generated file. Specify ``UNIX`` or ``LF`` for ``\\n`` newlines, or specify ``DOS``, ``WIN32``, or ``CRLF`` for ``\\r\\n`` newlines. Exactly one ``CONTENT`` or ``INPUT`` option must be given. A specific ``OUTPUT`` file may be named by at most one invocation of ``file(GENERATE)``. Generated files are modified and their timestamp updated on subsequent cmake runs only if their content is changed. Note also that ``file(GENERATE)`` does not create the output file until the generation phase. The output file will not yet have been written when the ``file(GENERATE)`` command returns, it is written only after processing all of a project's ``CMakeLists.txt`` files.",
+      "file(CONFIGURE OUTPUT <output-file> CONTENT <content> [ESCAPE_QUOTES] [@ONLY] [NEWLINE_STYLE [UNIX|DOS|WIN32|LF|CRLF]]) :target: CONFIGURE .. versionadded:: 3.18 Generate an output file using the input given by ``CONTENT`` and substitute variable values referenced as ``@VAR@`` or ``${VAR}`` contained therein. The substitution rules behave the same as the :command:`configure_file` command. In order to match :command:`configure_file`'s behavior, generator expressions are not supported for both ``OUTPUT`` and ``CONTENT``, and the output file is only modified and its timestamp updated if the content is changed or the file previously didn't exist. The arguments are: ``OUTPUT <output-file>`` Specify the output file name to generate. A relative path is treated with respect to the value of :variable:`CMAKE_CURRENT_BINARY_DIR`. ``<output-file>`` does not support generator expressions. ``CONTENT <content>`` Use the content given explicitly as input. ``<content>`` does not support generator expressions. ``ESCAPE_QUOTES`` Escape any substituted quotes with backslashes (C-style). ``@ONLY`` Restrict variable replacement to references of the form ``@VAR@``. This is useful for configuring scripts that use ``${VAR}`` syntax. ``NEWLINE_STYLE <style>`` Specify the newline style for the output file. Specify ``UNIX`` or ``LF`` for ``\\n`` newlines, or specify ``DOS``, ``WIN32``, or ``CRLF`` for ``\\r\\n`` newlines.",
+      "file(GLOB <variable> [LIST_DIRECTORIES true|false] [RELATIVE <path>] [CONFIGURE_DEPENDS] <globbing-expressions>...) file(GLOB_RECURSE <variable> [FOLLOW_SYMLINKS] [LIST_DIRECTORIES true|false] [RELATIVE <path>] [CONFIGURE_DEPENDS] <globbing-expressions>...) Generate a list of files that match the ``<globbing-expressions>`` and store it into the ``<variable>``. Globbing expressions are similar to regular expressions, but much simpler. If ``RELATIVE`` flag is specified, the results will be returned as relative paths to the given path. .. versionchanged:: 3.6 The results will be ordered lexicographically. On Windows and macOS, globbing is case-insensitive even if the underlying filesystem is case-sensitive (both filenames and globbing expressions are converted to lowercase before matching). On other platforms, globbing is case-sensitive. .. versionadded:: 3.3 By default ``GLOB`` lists directories. Directories are omitted in the result if ``LIST_DIRECTORIES`` is set to false. .. versionadded:: 3.12 If the ``CONFIGURE_DEPENDS`` flag is specified, CMake will add logic to the main build system check target to rerun the flagged ``GLOB`` commands at build time. If any of the outputs change, CMake will regenerate the build system. .. note:: We do not recommend using GLOB to collect a list of source files from your source tree. If no CMakeLists.txt file changes when a source is added or removed then the generated build system cannot know when to ask CMake to regenerate. The ``CONFIGURE_DEPENDS`` flag may not work reliably on all generators, or if a new generator is added in the future that cannot support it, projects using it will be stuck. Even if ``CONFIGURE_DEPENDS`` works reliably, there is still a cost to perform the check on every rebuild. Examples of globbing expressions include: ============== ====================================================== ``*.cxx`` match all files with extension ``cxx`` ``*.vt?`` match all files with extension ``vta``, ..., ``vtz`` ``f[3-5].txt`` match files ``f3.txt``, ``f4.txt``, ``f5.txt`` ============== ====================================================== The ``GLOB_RECURSE`` mode will traverse all the subdirectories of the matched directory and match the files. Subdirectories that are symlinks are only traversed if ``FOLLOW_SYMLINKS`` is given or policy :policy:`CMP0009` is not set to ``NEW``. .. versionadded:: 3.3 By default ``GLOB_RECURSE`` omits directories from result list. Setting ``LIST_DIRECTORIES`` to true adds directories to result list. If ``FOLLOW_SYMLINKS`` is given or policy :policy:`CMP0009` is not set to ``NEW`` then ``LIST_DIRECTORIES`` treats symlinks as directories. Examples of recursive globbing include: ============== ====================================================== ``/dir/*.py`` match all python files in ``/dir`` and subdirectories ============== ======================================================",
+      "file(MAKE_DIRECTORY <directories>...) Create the given directories and their parents as needed. .. versionchanged:: 3.30 ``<directories>`` can be an empty list. CMake 3.29 and earlier required at least one directory to be given.",
+      "file(REMOVE <files>...) file(REMOVE_RECURSE <files>...) Remove the given files. The ``REMOVE_RECURSE`` mode will remove the given files and directories, including non-empty directories. No error is emitted if a given file does not exist. Relative input paths are evaluated with respect to the current source directory. .. versionchanged:: 3.15 Empty input paths are ignored with a warning. Previous versions of CMake interpreted empty strings as a relative path with respect to the current directory and removed its contents.",
+      "file(RENAME <oldname> <newname> [RESULT <result>] [NO_REPLACE]) Move a file or directory within a filesystem from ``<oldname>`` to ``<newname>``, replacing the destination atomically. The options are: ``RESULT <result>`` .. versionadded:: 3.21 Set ``<result>`` variable to ``0`` on success or an error message otherwise. If ``RESULT`` is not specified and the operation fails, an error is emitted. ``NO_REPLACE`` .. versionadded:: 3.21 If the ``<newname>`` path already exists, do not replace it. If ``RESULT <result>`` is used, the result variable will be set to ``NO_REPLACE``. Otherwise, an error is emitted.",
+      "file(COPY_FILE <oldname> <newname> [RESULT <result>] [ONLY_IF_DIFFERENT] [INPUT_MAY_BE_RECENT]) .. versionadded:: 3.21 Copy a file from ``<oldname>`` to ``<newname>``. Directories are not supported. Symlinks are ignored and ``<oldfile>``'s content is read and written to ``<newname>`` as a new file. The options are: ``RESULT <result>`` Set ``<result>`` variable to ``0`` on success or an error message otherwise. If ``RESULT`` is not specified and the operation fails, an error is emitted. ``ONLY_IF_DIFFERENT`` If the ``<newname>`` path already exists, do not replace it if the file's contents are already the same as ``<oldname>`` (this avoids updating ``<newname>``'s timestamp). ``INPUT_MAY_BE_RECENT`` .. versionadded:: 3.26 Tell CMake that the input file may have been recently created. This is meaningful only on Windows, where files may be inaccessible for a short time after they are created. With this option, if permission is denied, CMake will retry reading the input a few times. This sub-command has some similarities to :command:`configure_file` with the ``COPYONLY`` option. An important difference is that :command:`configure_file` creates a dependency on the source file, so CMake will be re-run if it changes. The ``file(COPY_FILE)`` sub-command does not create such a dependency. See also the :command:`file(COPY)` sub-command just below which provides further file-copying capabilities.",
+      "file(COPY [...]) file(INSTALL [...]) The ``COPY`` signature copies files, directories, and symlinks to a destination folder. Relative input paths are evaluated with respect to the current source directory, and a relative destination is evaluated with respect to the current build directory. Copying preserves input file timestamps, and optimizes out a file if it exists at the destination with the same timestamp. Copying preserves input permissions unless explicit permissions or ``NO_SOURCE_PERMISSIONS`` are given (default is ``USE_SOURCE_PERMISSIONS``). file(<COPY|INSTALL> <files>... DESTINATION <dir> [NO_SOURCE_PERMISSIONS | USE_SOURCE_PERMISSIONS] [FILE_PERMISSIONS <permissions>...] [DIRECTORY_PERMISSIONS <permissions>...] [FOLLOW_SYMLINK_CHAIN] [FILES_MATCHING] [[PATTERN <pattern> | REGEX <regex>] [EXCLUDE] [PERMISSIONS <permissions>...]] [...]) .. note:: For a simple file copying operation, the :command:`file(COPY_FILE)` sub-command just above may be easier to use. .. versionadded:: 3.15 If ``FOLLOW_SYMLINK_CHAIN`` is specified, ``COPY`` will recursively resolve the symlinks at the paths given until a real file is found, and install a corresponding symlink in the destination for each symlink encountered. For each symlink that is installed, the resolution is stripped of the directory, leaving only the filename, meaning that the new symlink points to a file in the same directory as the symlink. This feature is useful on some Unix systems, where libraries are installed as a chain of symlinks with version numbers, with less specific versions pointing to more specific versions. ``FOLLOW_SYMLINK_CHAIN`` will install all of these symlinks and the library itself into the destination directory. For example, if you have the following directory structure: * ``/opt/foo/lib/libfoo.so.1.2.3`` * ``/opt/foo/lib/libfoo.so.1.2 -> libfoo.so.1.2.3`` * ``/opt/foo/lib/libfoo.so.1 -> libfoo.so.1.2`` * ``/opt/foo/lib/libfoo.so -> libfoo.so.1`` and you do: file(COPY /opt/foo/lib/libfoo.so DESTINATION lib FOLLOW_SYMLINK_CHAIN) This will install all of the symlinks and ``libfoo.so.1.2.3`` itself into ``lib``. See the :command:`install(DIRECTORY)` command for documentation of permissions, ``FILES_MATCHING``, ``PATTERN``, ``REGEX``, and ``EXCLUDE`` options. Copying directories preserves the structure of their content even if options are used to select a subset of files. The ``INSTALL`` signature differs slightly from ``COPY``: it prints status messages, and ``NO_SOURCE_PERMISSIONS`` is default. Installation scripts generated by the :command:`install` command use this signature (with some undocumented options for internal use). .. versionchanged:: 3.22 The environment variable :envvar:`CMAKE_INSTALL_MODE` can override the default copying behavior of :command:`file(INSTALL)`.",
+      "file(SIZE <filename> <variable>) .. versionadded:: 3.14 Determine the file size of the ``<filename>`` and put the result in ``<variable>`` variable. Requires that ``<filename>`` is a valid path pointing to a file and is readable.",
+      "file(READ_SYMLINK <linkname> <variable>) .. versionadded:: 3.14 Query the symlink ``<linkname>`` and stores the path it points to in the result ``<variable>``. If ``<linkname>`` does not exist or is not a symlink, CMake issues a fatal error. Note that this command returns the raw symlink path and does not resolve a relative path. The following is an example of how to ensure that an absolute path is obtained: set(linkname \"/path/to/foo.sym\") file(READ_SYMLINK \"${linkname}\" result) if(NOT IS_ABSOLUTE \"${result}\") get_filename_component(dir \"${linkname}\" DIRECTORY) set(result \"${dir}/${result}\") endif()",
+      "file(CREATE_LINK <original> <linkname> [RESULT <result>] [COPY_ON_ERROR] [SYMBOLIC]) .. versionadded:: 3.14 Create a link ``<linkname>`` that points to ``<original>``. It will be a hard link by default, but providing the ``SYMBOLIC`` option results in a symbolic link instead. Hard links require that ``original`` exists and is a file, not a directory. If ``<linkname>`` already exists, it will be overwritten. The ``<result>`` variable, if specified, receives the status of the operation. It is set to ``0`` upon success or an error message otherwise. If ``RESULT`` is not specified and the operation fails, a fatal error is emitted. Specifying ``COPY_ON_ERROR`` enables copying the file as a fallback if creating the link fails. It can be useful for handling situations such as ``<original>`` and ``<linkname>`` being on different drives or mount points, which would make them unable to support a hard link.",
+      "file(CHMOD <files>... <directories>... [PERMISSIONS <permissions>...] [FILE_PERMISSIONS <permissions>...] [DIRECTORY_PERMISSIONS <permissions>...]) .. versionadded:: 3.19 Set the permissions for the ``<files>...`` and ``<directories>...`` specified. Valid permissions are ``OWNER_READ``, ``OWNER_WRITE``, ``OWNER_EXECUTE``, ``GROUP_READ``, ``GROUP_WRITE``, ``GROUP_EXECUTE``, ``WORLD_READ``, ``WORLD_WRITE``, ``WORLD_EXECUTE``, ``SETUID``, ``SETGID``. Valid combination of keywords are: ``PERMISSIONS`` All items are changed. ``FILE_PERMISSIONS`` Only files are changed. ``DIRECTORY_PERMISSIONS`` Only directories are changed. ``PERMISSIONS`` and ``FILE_PERMISSIONS`` ``FILE_PERMISSIONS`` overrides ``PERMISSIONS`` for files. ``PERMISSIONS`` and ``DIRECTORY_PERMISSIONS`` ``DIRECTORY_PERMISSIONS`` overrides ``PERMISSIONS`` for directories. ``FILE_PERMISSIONS`` and ``DIRECTORY_PERMISSIONS`` Use ``FILE_PERMISSIONS`` for files and ``DIRECTORY_PERMISSIONS`` for directories.",
+      "file(CHMOD_RECURSE <files>... <directories>... [PERMISSIONS <permissions>...] [FILE_PERMISSIONS <permissions>...] [DIRECTORY_PERMISSIONS <permissions>...]) .. versionadded:: 3.19 Same as :cref:`CHMOD`, but change the permissions of files and directories present in the ``<directories>...`` recursively.",
+      "file(REAL_PATH <path> <out-var> [BASE_DIRECTORY <dir>] [EXPAND_TILDE]) .. versionadded:: 3.19 Compute the absolute path to an existing file or directory with symlinks resolved. The options are: ``BASE_DIRECTORY <dir>`` If the provided ``<path>`` is a relative path, it is evaluated relative to the given base directory ``<dir>``. If no base directory is provided, the default base directory will be :variable:`CMAKE_CURRENT_SOURCE_DIR`. ``EXPAND_TILDE`` .. versionadded:: 3.21 If the ``<path>`` is ``~`` or starts with ``~/``, the ``~`` is replaced by the user's home directory. The path to the home directory is obtained from environment variables. On Windows, the ``USERPROFILE`` environment variable is used, falling back to the ``HOME`` environment variable if ``USERPROFILE`` is not defined. On all other platforms, only ``HOME`` is used. .. versionchanged:: 3.28 All symlinks are resolved before collapsing ``../`` components. See policy :policy:`CMP0152`.",
+      "file(RELATIVE_PATH <variable> <directory> <file>) Compute the relative path from a ``<directory>`` to a ``<file>`` and store it in the ``<variable>``.",
+      "file(TO_CMAKE_PATH \"<path>\" <variable>) file(TO_NATIVE_PATH \"<path>\" <variable>) The ``TO_CMAKE_PATH`` mode converts a native ``<path>`` into a cmake-style path with forward-slashes (``/``). The input can be a single path or a system search path like ``$ENV{PATH}``. A search path will be converted to a cmake-style list separated by ``;`` characters. The ``TO_NATIVE_PATH`` mode converts a cmake-style ``<path>`` into a native path with platform-specific slashes (``\\`` on Windows hosts and ``/`` elsewhere). Always use double quotes around the ``<path>`` to be sure it is treated as a single argument to this command.",
+      "file(DOWNLOAD <url> [<file>] <options>...) file(UPLOAD <file> <url> <options>...) The ``DOWNLOAD`` subcommand downloads the given ``<url>`` to a local ``<file>``. The ``UPLOAD`` mode uploads a local ``<file>`` to a given ``<url>``. .. versionadded:: 3.19 If ``<file>`` is not specified for ``file(DOWNLOAD)``, the file is not saved. This can be useful if you want to know if a file can be downloaded (for example, to check that it exists) without actually saving it anywhere. Options to both ``DOWNLOAD`` and ``UPLOAD`` are: ``INACTIVITY_TIMEOUT <seconds>`` Terminate the operation after a period of inactivity. ``LOG <variable>`` Store a human-readable log of the operation in a variable. ``SHOW_PROGRESS`` Print progress information as status messages until the operation is complete. ``STATUS <variable>`` Store the resulting status of the operation in a variable. The status is a ``;`` separated list of length 2. The first element is the numeric return value for the operation, and the second element is a string value for the error. A ``0`` numeric error means no error in the operation. ``TIMEOUT <seconds>`` Terminate the operation after a given total time has elapsed. ``USERPWD <username>:<password>`` .. versionadded:: 3.7 Set username and password for operation. ``HTTPHEADER <HTTP-header>`` .. versionadded:: 3.7 HTTP header for ``DOWNLOAD`` and ``UPLOAD`` operations. ``HTTPHEADER`` can be repeated for multiple options: file(DOWNLOAD <url> HTTPHEADER \"Authorization: Bearer <auth-token>\" HTTPHEADER \"UserAgent: Mozilla/5.0\") ``NETRC <level>`` .. versionadded:: 3.11 Specify whether the .netrc file is to be used for operation. If this option is not specified, the value of the :variable:`CMAKE_NETRC` variable will be used instead. Valid levels are: ``IGNORED`` The .netrc file is ignored. This is the default. ``OPTIONAL`` The .netrc file is optional, and information in the URL is preferred. The file will be scanned to find which ever information is not specified in the URL. ``REQUIRED`` The .netrc file is required, and information in the URL is ignored. ``NETRC_FILE <file>`` .. versionadded:: 3.11 Specify an alternative .netrc file to the one in your home directory, if the ``NETRC`` level is ``OPTIONAL`` or ``REQUIRED``. If this option is not specified, the value of the :variable:`CMAKE_NETRC_FILE` variable will be used instead. ``TLS_VERSION <min>`` .. versionadded:: 3.30 Specify minimum TLS version for ``https://`` URLs. If this option is not specified, the value of the :variable:`CMAKE_TLS_VERSION` variable or :envvar:`CMAKE_TLS_VERSION` environment variable will be used instead. See :variable:`CMAKE_TLS_VERSION` for allowed values. ``TLS_VERIFY <ON|OFF>`` Specify whether to verify the server certificate for ``https://`` URLs. The default is to *not* verify. If this option is not specified, the value of the :variable:`CMAKE_TLS_VERIFY` variable will be used instead. .. versionadded:: 3.18 Added support to ``file(UPLOAD)``. ``TLS_CAINFO <file>`` Specify a custom Certificate Authority file for ``https://`` URLs. If this option is not specified, the value of the :variable:`CMAKE_TLS_CAINFO` variable will be used instead. .. versionadded:: 3.18 Added support to ``file(UPLOAD)``. For ``https://`` URLs CMake must be built with OpenSSL support. ``TLS/SSL`` certificates are not checked by default. Set ``TLS_VERIFY`` to ``ON`` to check certificates. Additional options to ``DOWNLOAD`` are: ``EXPECTED_HASH <algorithm>=<value>`` Verify that the downloaded content hash matches the expected value, where ``<algorithm>`` is one of the algorithms supported by :cref:`<HASH>`. If the file already exists and matches the hash, the download is skipped. If the file already exists and does not match the hash, the file is downloaded again. If after download the file does not match the hash, the operation fails with an error. It is an error to specify this option if ``DOWNLOAD`` is not given a ``<file>``. ``EXPECTED_MD5 <value>`` Historical short-hand for ``EXPECTED_HASH MD5=<value>``. It is an error to specify this if ``DOWNLOAD`` is not given a ``<file>``. ``RANGE_START <value>`` .. versionadded:: 3.24 Offset of the start of the range in file in bytes. Could be omitted to download up to the specified ``RANGE_END``. ``RANGE_END <value>`` .. versionadded:: 3.24 Offset of the end of the range in file in bytes. Could be omitted to download everything from the specified ``RANGE_START`` to the end of file.",
+      "file(LOCK <path> [DIRECTORY] [RELEASE] [GUARD <FUNCTION|FILE|PROCESS>] [RESULT_VARIABLE <variable>] [TIMEOUT <seconds>]) .. versionadded:: 3.2 Lock a file specified by ``<path>`` if no ``DIRECTORY`` option present and file ``<path>/cmake.lock`` otherwise. The file will be locked for the scope defined by the ``GUARD`` option (default value is ``PROCESS``). The ``RELEASE`` option can be used to unlock the file explicitly. If the ``TIMEOUT`` option is not specified, CMake will wait until the lock succeeds or until a fatal error occurs. If ``TIMEOUT`` is set to ``0``, locking will be tried once and the result will be reported immediately. If ``TIMEOUT`` is not ``0``, CMake will try to lock the file for the period specified by the ``TIMEOUT <seconds>`` value. Any errors will be interpreted as fatal if there is no ``RESULT_VARIABLE`` option. Otherwise, the result will be stored in ``<variable>`` and will be ``0`` on success or an error message on failure. Note that lock is advisory; there is no guarantee that other processes will respect this lock, i.e. lock synchronize two or more CMake instances sharing some modifiable resources. Similar logic applies to the ``DIRECTORY`` option; locking a parent directory doesn't prevent other ``LOCK`` commands from locking any child directory or file. Trying to lock the same file twice is not allowed. Any intermediate directories and the file itself will be created if they not exist. The ``GUARD`` and ``TIMEOUT`` options are ignored on the ``RELEASE`` operation.",
+      "file(ARCHIVE_CREATE OUTPUT <archive> PATHS <paths>... [FORMAT <format>] [COMPRESSION <compression> [COMPRESSION_LEVEL <compression-level>]] [MTIME <mtime>] [VERBOSE]) :target: ARCHIVE_CREATE :break: verbatim .. versionadded:: 3.18 Creates the specified ``<archive>`` file with the files and directories listed in ``<paths>``. Note that ``<paths>`` must list actual files or directories; wildcards are not supported. Use the ``FORMAT`` option to specify the archive format. Supported values for ``<format>`` are ``7zip``, ``gnutar``, ``pax``, ``paxr``, ``raw`` and ``zip``. If ``FORMAT`` is not given, the default format is ``paxr``. Some archive formats allow the type of compression to be specified. The ``7zip`` and ``zip`` archive formats already imply a specific type of compression. The other formats use no compression by default, but can be directed to do so with the ``COMPRESSION`` option. Valid values for ``<compression>`` are ``None``, ``BZip2``, ``GZip``, ``XZ``, and ``Zstd``. .. versionadded:: 3.19 The compression level can be specified with the ``COMPRESSION_LEVEL`` option. The ``<compression-level>`` should be between 0-9, with the default being 0. The ``COMPRESSION`` option must be present when ``COMPRESSION_LEVEL`` is given. .. versionadded:: 3.26 The ``<compression-level>`` of the ``Zstd`` algorithm can be set between 0-19. .. note:: With ``FORMAT`` set to ``raw``, only one file will be compressed with the compression type specified by ``COMPRESSION``. The ``VERBOSE`` option enables verbose output for the archive operation. To specify the modification time recorded in tarball entries, use the ``MTIME`` option.",
+      "file(ARCHIVE_EXTRACT INPUT <archive> [DESTINATION <dir>] [PATTERNS <patterns>...] [LIST_ONLY] [VERBOSE] [TOUCH]) :target: ARCHIVE_EXTRACT .. versionadded:: 3.18 Extracts or lists the content of the specified ``<archive>``. The directory where the content of the archive will be extracted to can be specified using the ``DESTINATION`` option. If the directory does not exist, it will be created. If ``DESTINATION`` is not given, the current binary directory will be used. If required, you may select which files and directories to list or extract from the archive using the specified ``<patterns>``. Wildcards are supported. If the ``PATTERNS`` option is not given, the entire archive will be listed or extracted. ``LIST_ONLY`` will list the files in the archive rather than extract them. .. note:: The working directory for this subcommand is the ``DESTINATION`` directory (provided or computed) except when ``LIST_ONLY`` is specified. Therefore, outside of script mode, it may be best to provide absolute paths to ``INPUT`` archives as they are unlikely to be extracted where a relative path works. .. versionadded:: 3.24 The ``TOUCH`` option gives extracted files a current local timestamp instead of extracting file timestamps from the archive. With ``VERBOSE``, the command will produce verbose output.",
+      "file(GET_RUNTIME_DEPENDENCIES [...]) .. versionadded:: 3.16 Recursively get the list of libraries depended on by the given files: file(GET_RUNTIME_DEPENDENCIES [RESOLVED_DEPENDENCIES_VAR <deps_var>] [UNRESOLVED_DEPENDENCIES_VAR <unresolved_deps_var>] [CONFLICTING_DEPENDENCIES_PREFIX <conflicting_deps_prefix>] [EXECUTABLES <executable_files>...] [LIBRARIES <library_files>...] [MODULES <module_files>...] [DIRECTORIES <directories>...] [BUNDLE_EXECUTABLE <bundle_executable_file>] [PRE_INCLUDE_REGEXES <regexes>...] [PRE_EXCLUDE_REGEXES <regexes>...] [POST_INCLUDE_REGEXES <regexes>...] [POST_EXCLUDE_REGEXES <regexes>...] [POST_INCLUDE_FILES <files>...] [POST_EXCLUDE_FILES <files>...]) Please note that this sub-command is not intended to be used in project mode. It is intended for use at install time, either from code generated by the :command:`install(RUNTIME_DEPENDENCY_SET)` command, or from code provided by the project via :command:`install(CODE)` or :command:`install(SCRIPT)`. For example: install(CODE [[ file(GET_RUNTIME_DEPENDENCIES )]]) The arguments are as follows: ``RESOLVED_DEPENDENCIES_VAR <deps_var>`` Name of the variable in which to store the list of resolved dependencies. ``UNRESOLVED_DEPENDENCIES_VAR <unresolved_deps_var>`` Name of the variable in which to store the list of unresolved dependencies. If this variable is not specified, and there are any unresolved dependencies, an error is issued. ``CONFLICTING_DEPENDENCIES_PREFIX <conflicting_deps_prefix>`` Variable prefix in which to store conflicting dependency information. Dependencies are conflicting if two files with the same name are found in two different directories. The list of filenames that conflict are stored in ``<conflicting_deps_prefix>_FILENAMES``. For each filename, the list of paths that were found for that filename are stored in ``<conflicting_deps_prefix>_<filename>``. ``EXECUTABLES <executable_files>...`` List of executable files to read for dependencies. These are executables that are typically created with :command:`add_executable`, but they do not have to be created by CMake. On Apple platforms, the paths to these files determine the value of ``@executable_path`` when recursively resolving the libraries. Specifying any kind of library (``STATIC``, ``MODULE``, or ``SHARED``) here will result in undefined behavior. ``LIBRARIES <library_files>...`` List of library files to read for dependencies. These are libraries that are typically created with :command:`add_library(SHARED)`, but they do not have to be created by CMake. Specifying ``STATIC`` libraries, ``MODULE`` libraries, or executables here will result in undefined behavior. ``MODULES <module_files>...`` List of loadable module files to read for dependencies. These are modules that are typically created with :command:`add_library(MODULE)`, but they do not have to be created by CMake. They are typically used by calling ``dlopen()`` at runtime rather than linked at link time with ``ld -l``. Specifying ``STATIC`` libraries, ``SHARED`` libraries, or executables here will result in undefined behavior. ``DIRECTORIES <directories>...`` List of additional directories to search for dependencies. On Linux platforms, these directories are searched if the dependency is not found in any of the other usual paths. If it is found in such a directory, a warning is issued, because it means that the file is incomplete (it does not list all of the directories that contain its dependencies). On Windows platforms, these directories are searched if the dependency is not found in any of the other search paths, but no warning is issued, because searching other paths is a normal part of Windows dependency resolution. On Apple platforms, this argument has no effect. ``BUNDLE_EXECUTABLE <bundle_executable_file>`` Executable to treat as the \"bundle executable\" when resolving libraries. On Apple platforms, this argument determines the value of ``@executable_path`` when recursively resolving libraries for ``LIBRARIES`` and ``MODULES`` files. It has no effect on ``EXECUTABLES`` files. On other platforms, it has no effect. This is typically (but not always) one of the executables in the ``EXECUTABLES`` argument which designates the \"main\" executable of the package. The following arguments specify filters for including or excluding libraries to be resolved. See below for a full description of how they work. ``PRE_INCLUDE_REGEXES <regexes>...`` List of pre-include regexes through which to filter the names of not-yet-resolved dependencies. ``PRE_EXCLUDE_REGEXES <regexes>...`` List of pre-exclude regexes through which to filter the names of not-yet-resolved dependencies. ``POST_INCLUDE_REGEXES <regexes>...`` List of post-include regexes through which to filter the names of resolved dependencies. ``POST_EXCLUDE_REGEXES <regexes>...`` List of post-exclude regexes through which to filter the names of resolved dependencies. ``POST_INCLUDE_FILES <files>...`` .. versionadded:: 3.21 List of post-include filenames through which to filter the names of resolved dependencies. Symlinks are resolved when attempting to match these filenames. ``POST_EXCLUDE_FILES <files>...`` .. versionadded:: 3.21 List of post-exclude filenames through which to filter the names of resolved dependencies. Symlinks are resolved when attempting to match these filenames. These arguments can be used to exclude unwanted system libraries when resolving the dependencies, or to include libraries from a specific directory. The filtering works as follows: 1. If the not-yet-resolved dependency matches any of the ``PRE_INCLUDE_REGEXES``, steps 2 and 3 are skipped, and the dependency resolution proceeds to step 4. 2. If the not-yet-resolved dependency matches any of the ``PRE_EXCLUDE_REGEXES``, dependency resolution stops for that dependency. 3. Otherwise, dependency resolution proceeds. 4. ``file(GET_RUNTIME_DEPENDENCIES)`` searches for the dependency according to the linking rules of the platform (see below). 5. If the dependency is found, and its full path matches one of the ``POST_INCLUDE_REGEXES`` or ``POST_INCLUDE_FILES``, the full path is added to the resolved dependencies, and ``file(GET_RUNTIME_DEPENDENCIES)`` recursively resolves that library's own dependencies. Otherwise, resolution proceeds to step 6. 6. If the dependency is found, but its full path matches one of the ``POST_EXCLUDE_REGEXES`` or ``POST_EXCLUDE_FILES``, it is not added to the resolved dependencies, and dependency resolution stops for that dependency. 7. If the dependency is found, and its full path does not match either ``POST_INCLUDE_REGEXES``, ``POST_INCLUDE_FILES``, ``POST_EXCLUDE_REGEXES``, or ``POST_EXCLUDE_FILES``, the full path is added to the resolved dependencies, and ``file(GET_RUNTIME_DEPENDENCIES)`` recursively resolves that library's own dependencies. Different platforms have different rules for how dependencies are resolved. These specifics are described here. On Linux platforms, library resolution works as follows: 1. If the depending file does not have any ``RUNPATH`` entries, and the library exists in one of the depending file's ``RPATH`` entries, or its parents', in that order, the dependency is resolved to that file. 2. Otherwise, if the depending file has any ``RUNPATH`` entries, and the library exists in one of those entries, the dependency is resolved to that file. 3. Otherwise, if the library exists in one of the directories listed by ``ldconfig``, the dependency is resolved to that file. 4. Otherwise, if the library exists in one of the ``DIRECTORIES`` entries, the dependency is resolved to that file. In this case, a warning is issued, because finding a file in one of the ``DIRECTORIES`` means that the depending file is not complete (it does not list all the directories from which it pulls dependencies). 5. Otherwise, the dependency is unresolved. On Windows platforms, library resolution works as follows: 1. DLL dependency names are converted to lowercase for matching filters. Windows DLL names are case-insensitive, and some linkers mangle the case of the DLL dependency names. However, this makes it more difficult for ``PRE_INCLUDE_REGEXES``, ``PRE_EXCLUDE_REGEXES``, ``POST_INCLUDE_REGEXES``, and ``POST_EXCLUDE_REGEXES`` to properly filter DLL names - every regex would have to check for both uppercase and lowercase letters. For example: file(GET_RUNTIME_DEPENDENCIES PRE_INCLUDE_REGEXES \"^[Mm][Yy][Ll][Ii][Bb][Rr][Aa][Rr][Yy]\\\\.[Dd][Ll][Ll]$\" ) Converting the DLL name to lowercase allows the regexes to only match lowercase names, thus simplifying the regex. For example: file(GET_RUNTIME_DEPENDENCIES PRE_INCLUDE_REGEXES \"^mylibrary\\\\.dll$\" ) This regex will match ``mylibrary.dll`` regardless of how it is cased, either on disk or in the depending file. (For example, it will match ``mylibrary.dll``, ``MyLibrary.dll``, and ``MYLIBRARY.DLL``.) .. versionchanged:: 3.27 The conversion to lowercase only applies while matching filters. Results reported after filtering case-preserve each DLL name as it is found on disk, if resolved, and otherwise as it is referenced by the dependent binary. Prior to CMake 3.27, the results were reported with lowercase DLL file names, but the directory portion retained its casing. 2. (**Not yet implemented**) If the depending file is a Windows Store app, and the dependency is listed as a dependency in the application's package manifest, the dependency is resolved to that file. 3. Otherwise, if the library exists in the same directory as the depending file, the dependency is resolved to that file. 4. Otherwise, if the library exists in either the operating system's ``system32`` directory or the ``Windows`` directory, in that order, the dependency is resolved to that file. 5. Otherwise, if the library exists in one of the directories specified by ``DIRECTORIES``, in the order they are listed, the dependency is resolved to that file. In this case, a warning is not issued, because searching other directories is a normal part of Windows library resolution. 6. Otherwise, the dependency is unresolved. On Apple platforms, library resolution works as follows: 1. If the dependency starts with ``@executable_path/``, and an ``EXECUTABLES`` argument is in the process of being resolved, and replacing ``@executable_path/`` with the directory of the executable yields an existing file, the dependency is resolved to that file. 2. Otherwise, if the dependency starts with ``@executable_path/``, and there is a ``BUNDLE_EXECUTABLE`` argument, and replacing ``@executable_path/`` with the directory of the bundle executable yields an existing file, the dependency is resolved to that file. 3. Otherwise, if the dependency starts with ``@loader_path/``, and replacing ``@loader_path/`` with the directory of the depending file yields an existing file, the dependency is resolved to that file. 4. Otherwise, if the dependency starts with ``@rpath/``, and replacing ``@rpath/`` with one of the ``RPATH`` entries of the depending file yields an existing file, the dependency is resolved to that file. Note that ``RPATH`` entries that start with ``@executable_path/`` or ``@loader_path/`` also have these items replaced with the appropriate path. 5. Otherwise, if the dependency is an absolute file that exists, the dependency is resolved to that file. 6. Otherwise, the dependency is unresolved. This function accepts several variables that determine which tool is used for dependency resolution: .. variable:: CMAKE_GET_RUNTIME_DEPENDENCIES_PLATFORM Determines which operating system and executable format the files are built for. This could be one of several values: * ``linux+elf`` * ``windows+pe`` * ``macos+macho`` If this variable is not specified, it is determined automatically by system introspection. .. variable:: CMAKE_GET_RUNTIME_DEPENDENCIES_TOOL Determines the tool to use for dependency resolution. It could be one of several values, depending on the value of :variable:`CMAKE_GET_RUNTIME_DEPENDENCIES_PLATFORM`: ================================================= ============================================= ``CMAKE_GET_RUNTIME_DEPENDENCIES_PLATFORM`` ``CMAKE_GET_RUNTIME_DEPENDENCIES_TOOL`` ================================================= ============================================= ``linux+elf`` ``objdump`` ``windows+pe`` ``objdump`` or ``dumpbin`` ``macos+macho`` ``otool`` ================================================= ============================================= If this variable is not specified, it is determined automatically by system introspection. .. variable:: CMAKE_GET_RUNTIME_DEPENDENCIES_COMMAND Determines the path to the tool to use for dependency resolution. This is the actual path to ``objdump``, ``dumpbin``, or ``otool``. If this variable is not specified, it is determined by the value of ``CMAKE_OBJDUMP`` if set, else by system introspection. .. versionadded:: 3.18 Use ``CMAKE_OBJDUMP`` if set."
+    ]
+  },
+  "find_file": {
+    "name": "find_file",
+    "description": "This command is used to find a full path to named file.",
+    "syntax_examples": [
+      "find_file(<VAR> name1 [path1 path2 ...])",
+      "find_file(<VAR> name | NAMES name1 [name2 ...] [HINTS path1 [path2 ... ENV var]] [PATHS path1 [path2 ... ENV var]] [PATH_SUFFIXES suffix1 [suffix2 ...]] [DOC \"cache documentation string\"] [NO_DEFAULT_PATH] [NO_PACKAGE_ROOT_PATH] [NO_CMAKE_PATH] [NO_CMAKE_ENVIRONMENT_PATH] [NO_SYSTEM_ENVIRONMENT_PATH] [NO_CMAKE_SYSTEM_PATH] [CMAKE_FIND_ROOT_PATH_BOTH | ONLY_CMAKE_FIND_ROOT_PATH | NO_CMAKE_FIND_ROOT_PATH])"
+    ]
+  },
+  "find_library": {
+    "name": "find_library",
+    "description": "This command is used to find a library.",
+    "syntax_examples": [
+      "find_library(<VAR> name1 [path1 path2 ...])",
+      "find_library (<VAR> name | NAMES name1 [name2 ...] [NAMES_PER_DIR] [HINTS path1 [path2 ... ENV var]] [PATHS path1 [path2 ... ENV var]] [PATH_SUFFIXES suffix1 [suffix2 ...]] [DOC \"cache documentation string\"] [NO_DEFAULT_PATH] [NO_PACKAGE_ROOT_PATH] [NO_CMAKE_PATH] [NO_CMAKE_ENVIRONMENT_PATH] [NO_SYSTEM_ENVIRONMENT_PATH] [NO_CMAKE_SYSTEM_PATH] [CMAKE_FIND_ROOT_PATH_BOTH | ONLY_CMAKE_FIND_ROOT_PATH | NO_CMAKE_FIND_ROOT_PATH])"
+    ]
+  },
+  "find_package": {
+    "name": "find_package",
+    "description": "Find a package (usually provided by something external to the project), and load its package-specific details. Calls to this command can also be intercepted by dependency providers .",
+    "syntax_examples": [
+      "find_package(<PackageName> [<version>] [REQUIRED] [COMPONENTS <components>...])",
+      "find_package(<PackageName> [version] [EXACT] [QUIET] [MODULE] [REQUIRED] [[COMPONENTS] [components...]] [OPTIONAL_COMPONENTS components...] [REGISTRY_VIEW (64|32|64_32|32_64|HOST|TARGET|BOTH)] [GLOBAL] [NO_POLICY_SCOPE] [BYPASS_PROVIDER])",
+      "find_package(<PackageName> [version] [EXACT] [QUIET] [REQUIRED] [[COMPONENTS] [components...]] [OPTIONAL_COMPONENTS components...] [CONFIG|NO_MODULE] [GLOBAL] [NO_POLICY_SCOPE] [BYPASS_PROVIDER] [NAMES name1 [name2 ...]] [CONFIGS config1 [config2 ...]] [HINTS path1 [path2 ... ]] [PATHS path1 [path2 ... ]] [REGISTRY_VIEW (64|32|64_32|32_64|HOST|TARGET|BOTH)] [PATH_SUFFIXES suffix1 [suffix2 ...]] [NO_DEFAULT_PATH] [NO_PACKAGE_ROOT_PATH] [NO_CMAKE_PATH] [NO_CMAKE_ENVIRONMENT_PATH] [NO_SYSTEM_ENVIRONMENT_PATH] [NO_CMAKE_PACKAGE_REGISTRY] [NO_CMAKE_BUILDS_PATH] [NO_CMAKE_SYSTEM_PATH] [NO_CMAKE_INSTALL_PREFIX] [NO_CMAKE_SYSTEM_PACKAGE_REGISTRY] [CMAKE_FIND_ROOT_PATH_BOTH | ONLY_CMAKE_FIND_ROOT_PATH | NO_CMAKE_FIND_ROOT_PATH])"
+    ]
+  },
+  "find_path": {
+    "name": "find_path",
+    "description": "This command is used to find a directory containing the named file.",
+    "syntax_examples": [
+      "find_path(<VAR> name1 [path1 path2 ...])",
+      "find_path (<VAR> name | NAMES name1 [name2 ...] [HINTS path1 [path2 ... ENV var]] [PATHS path1 [path2 ... ENV var]] [PATH_SUFFIXES suffix1 [suffix2 ...]] [DOC \"cache documentation string\"] [NO_DEFAULT_PATH] [NO_PACKAGE_ROOT_PATH] [NO_CMAKE_PATH] [NO_CMAKE_ENVIRONMENT_PATH] [NO_SYSTEM_ENVIRONMENT_PATH] [NO_CMAKE_SYSTEM_PATH] [CMAKE_FIND_ROOT_PATH_BOTH | ONLY_CMAKE_FIND_ROOT_PATH | NO_CMAKE_FIND_ROOT_PATH])"
+    ]
+  },
+  "find_program": {
+    "name": "find_program",
+    "description": "This command is used to find a program.",
+    "syntax_examples": [
+      "find_program(<VAR> name1 [path1 path2 ...])",
+      "find_program (<VAR> name | NAMES name1 [name2 ...] [NAMES_PER_DIR] [HINTS path1 [path2 ... ENV var]] [PATHS path1 [path2 ... ENV var]] [PATH_SUFFIXES suffix1 [suffix2 ...]] [DOC \"cache documentation string\"] [NO_DEFAULT_PATH] [NO_PACKAGE_ROOT_PATH] [NO_CMAKE_PATH] [NO_CMAKE_ENVIRONMENT_PATH] [NO_SYSTEM_ENVIRONMENT_PATH] [NO_CMAKE_SYSTEM_PATH] [CMAKE_FIND_ROOT_PATH_BOTH | ONLY_CMAKE_FIND_ROOT_PATH | NO_CMAKE_FIND_ROOT_PATH])"
+    ]
+  },
+  "fltk_wrap_ui": {
+    "name": "fltk_wrap_ui",
+    "description": "Create FLTK user interfaces Wrappers.",
+    "syntax_examples": [
+      "fltk_wrap_ui(resultingLibraryName source1 source2 ... sourceN )"
+    ]
+  },
+  "foreach": {
+    "name": "foreach",
+    "description": "Evaluate a group of commands for each value in a list.",
+    "syntax_examples": [
+      "foreach(<loop_var> <items>) <commands> endforeach()",
+      "foreach(<loop_var> RANGE <stop>)",
+      "foreach(<loop_var> RANGE <start> <stop> [<step>])",
+      "foreach(<loop_var> IN [LISTS [<lists>]] [ITEMS [<items>]])",
+      "foreach(<loop_var>... IN ZIP_LISTS <lists>)"
+    ]
+  },
+  "function": {
+    "name": "function",
+    "description": "Start recording a function for later invocation as a command.",
+    "syntax_examples": [
+      "function(<name> [<arg1> ...]) <commands> endfunction()",
+      "function(foo) <commands> endfunction()"
+    ]
+  },
+  "get_cmake_property": {
+    "name": "get_cmake_property",
+    "description": "Get a global property of the CMake instance.",
+    "syntax_examples": ["get_cmake_property(<variable> <property>)"]
+  },
+  "get_directory_property": {
+    "name": "get_directory_property",
+    "description": "Get a property of DIRECTORY scope.",
+    "syntax_examples": [
+      "get_directory_property(<variable> [DIRECTORY <dir>] <prop-name>)",
+      "get_directory_property(<variable> [DIRECTORY <dir>] DEFINITION <var-name>)"
+    ]
+  },
+  "get_filename_component": {
+    "name": "get_filename_component",
+    "description": "Get a specific component of a full filename.",
+    "syntax_examples": [
+      "get_filename_component(<var> <FileName> <mode> [CACHE])",
+      "get_filename_component(<var> <FileName> <mode> [BASE_DIR <dir>] [CACHE])",
+      "get_filename_component(<var> <FileName> PROGRAM [PROGRAM_ARGS <arg_var>] [CACHE])"
+    ]
+  },
+  "get_property": {
+    "name": "get_property",
+    "description": "Get a property.",
+    "syntax_examples": [
+      "get_property(<variable> <GLOBAL | DIRECTORY [<dir>] | TARGET <target> | SOURCE <source> [DIRECTORY <dir> | TARGET_DIRECTORY <target>] | INSTALL <file> | TEST <test> [DIRECTORY <dir>] | CACHE <entry> | VARIABLE > PROPERTY <name> [SET | DEFINED | BRIEF_DOCS | FULL_DOCS])"
+    ]
+  },
+  "get_source_file_property": {
+    "name": "get_source_file_property",
+    "description": "Get a property for a source file.",
+    "syntax_examples": [
+      "get_source_file_property(<variable> <file> [DIRECTORY <dir> | TARGET_DIRECTORY <target>] <property>)"
+    ]
+  },
+  "get_target_property": {
+    "name": "get_target_property",
+    "description": "Get a property from a target.",
+    "syntax_examples": ["get_target_property(<variable> <target> <property>)"]
+  },
+  "get_test_property": {
+    "name": "get_test_property",
+    "description": "Get a property of the test.",
+    "syntax_examples": [
+      "get_test_property(<test> <property> [DIRECTORY <dir>] <variable>)"
+    ]
+  },
+  "if": {
+    "name": "if",
+    "description": "Conditionally execute a group of commands.",
+    "syntax_examples": [
+      "if(<condition>) <commands> elseif(<condition>) <commands> else() <commands> endif()",
+      "if(<constant>) :target: constant True if the constant is ``1``, ``ON``, ``YES``, ``TRUE``, ``Y``, or a non-zero number (including floating point numbers). False if the constant is ``0``, ``OFF``, ``NO``, ``FALSE``, ``N``, ``IGNORE``, ``NOTFOUND``, the empty string, or ends in the suffix ``-NOTFOUND``. Named boolean constants are case-insensitive. If the argument is not one of these specific constants, it is treated as a variable or string (see `Variable Expansion`_ further below) and one of the following two forms applies.",
+      "if(<variable>) :target: variable True if given a variable that is defined to a value that is not a false constant. False otherwise, including if the variable is undefined. Note that macro arguments are not variables. :ref:`Environment Variables <CMake Language Environment Variables>` also cannot be tested this way, e.g. ``if(ENV{some_var})`` will always evaluate to false.",
+      "if(<string>) :target: string A quoted string always evaluates to false unless: * The string's value is one of the true constants, or * Policy :policy:`CMP0054` is not set to ``NEW`` and the string's value happens to be a variable name that is affected by :policy:`CMP0054`'s behavior.",
+      "if(NOT <condition>) True if the condition is not true.",
+      "if(<cond1> AND <cond2>) :target: AND True if both conditions would be considered true individually.",
+      "if(<cond1> OR <cond2>) :target: OR True if either condition would be considered true individually.",
+      "if((condition) AND (condition OR (condition))) :target: parentheses The conditions inside the parenthesis are evaluated first and then the remaining condition is evaluated as in the other examples. Where there are nested parenthesis the innermost are evaluated as part of evaluating the condition that contains them.",
+      "if(COMMAND <command-name>) True if the given name is a command, macro or function that can be invoked.",
+      "if(POLICY <policy-id>) True if the given name is an existing policy (of the form ``CMP<NNNN>``).",
+      "if(TARGET <target-name>) True if the given name is an existing logical target name created by a call to the :command:`add_executable`, :command:`add_library`, or :command:`add_custom_target` command that has already been invoked (in any directory).",
+      "if(TEST <test-name>) .. versionadded:: 3.3 True if the given name is an existing test name created by the :command:`add_test` command.",
+      "if(DEFINED <name>|CACHE{<name>}|ENV{<name>}) True if a variable, cache variable or environment variable with given ``<name>`` is defined. The value of the variable does not matter. Note the following caveats: * Macro arguments are not variables. * It is not possible to test directly whether a `<name>` is a non-cache variable. The expression ``if(DEFINED someName)`` will evaluate to true if either a cache or non-cache variable ``someName`` exists. In comparison, the expression ``if(DEFINED CACHE{someName})`` will only evaluate to true if a cache variable ``someName`` exists. Both expressions need to be tested if you need to know whether a non-cache variable exists: ``if(DEFINED someName AND NOT DEFINED CACHE{someName})``. .. versionadded:: 3.14 Added support for ``CACHE{<name>}`` variables.",
+      "if(<variable|string> IN_LIST <variable>) :target: IN_LIST .. versionadded:: 3.3 True if the given element is contained in the named list variable.",
+      "if(EXISTS <path-to-file-or-directory>) True if the named file or directory exists and is readable. Behavior is well-defined only for explicit full paths (a leading ``~/`` is not expanded as a home directory and is considered a relative path). Resolves symbolic links, i.e. if the named file or directory is a symbolic link, returns true if the target of the symbolic link exists. False if the given path is an empty string. .. note:: Prefer ``if(IS_READABLE)`` to check file readability. ``if(EXISTS)`` may be changed in the future to only check file existence.",
+      "if(IS_READABLE <path-to-file-or-directory>) .. versionadded:: 3.29 True if the named file or directory is readable. Behavior is well-defined only for explicit full paths (a leading ``~/`` is not expanded as a home directory and is considered a relative path). Resolves symbolic links, i.e. if the named file or directory is a symbolic link, returns true if the target of the symbolic link is readable. False if the given path is an empty string.",
+      "if(IS_WRITABLE <path-to-file-or-directory>) .. versionadded:: 3.29 True if the named file or directory is writable. Behavior is well-defined only for explicit full paths (a leading ``~/`` is not expanded as a home directory and is considered a relative path). Resolves symbolic links, i.e. if the named file or directory is a symbolic link, returns true if the target of the symbolic link is writable. False if the given path is an empty string.",
+      "if(IS_EXECUTABLE <path-to-file-or-directory>) .. versionadded:: 3.29 True if the named file or directory is executable. Behavior is well-defined only for explicit full paths (a leading ``~/`` is not expanded as a home directory and is considered a relative path). Resolves symbolic links, i.e. if the named file or directory is a symbolic link, returns true if the target of the symbolic link is executable. False if the given path is an empty string.",
+      "if(<file1> IS_NEWER_THAN <file2>) :target: IS_NEWER_THAN True if ``file1`` is newer than ``file2`` or if one of the two files doesn't exist. Behavior is well-defined only for full paths. If the file time stamps are exactly the same, an ``IS_NEWER_THAN`` comparison returns true, so that any dependent build operations will occur in the event of a tie. This includes the case of passing the same file name for both file1 and file2.",
+      "if(IS_DIRECTORY <path>) True if ``path`` is a directory. Behavior is well-defined only for full paths. False if the given path is an empty string.",
+      "if(IS_SYMLINK <path>) True if the given path is a symbolic link. Behavior is well-defined only for full paths.",
+      "if(IS_ABSOLUTE <path>) True if the given path is an absolute path. Note the following special cases: * An empty ``path`` evaluates to false. * On Windows hosts, any ``path`` that begins with a drive letter and colon (e.g. ``C:``), a forward slash or a backslash will evaluate to true. This means a path like ``C:no\\base\\dir`` will evaluate to true, even though the non-drive part of the path is relative. * On non-Windows hosts, any ``path`` that begins with a tilde (``~``) evaluates to true.",
+      "if(<variable|string> MATCHES <regex>) :target: MATCHES True if the given string or variable's value matches the given regular expression. See :ref:`Regex Specification` for regex format. .. versionadded:: 3.9 ``()`` groups are captured in :variable:`CMAKE_MATCH_<n>` variables.",
+      "if(<variable|string> LESS <variable|string>) :target: LESS True if the given string or variable's value parses as a real number (like a C ``double``) and less than that on the right.",
+      "if(<variable|string> GREATER <variable|string>) :target: GREATER True if the given string or variable's value parses as a real number (like a C ``double``) and greater than that on the right.",
+      "if(<variable|string> EQUAL <variable|string>) :target: EQUAL True if the given string or variable's value parses as a real number (like a C ``double``) and equal to that on the right.",
+      "if(<variable|string> LESS_EQUAL <variable|string>) :target: LESS_EQUAL .. versionadded:: 3.7 True if the given string or variable's value parses as a real number (like a C ``double``) and less than or equal to that on the right.",
+      "if(<variable|string> GREATER_EQUAL <variable|string>) :target: GREATER_EQUAL .. versionadded:: 3.7 True if the given string or variable's value parses as a real number (like a C ``double``) and greater than or equal to that on the right.",
+      "if(<variable|string> STRLESS <variable|string>) :target: STRLESS True if the given string or variable's value is lexicographically less than the string or variable on the right.",
+      "if(<variable|string> STRGREATER <variable|string>) :target: STRGREATER True if the given string or variable's value is lexicographically greater than the string or variable on the right.",
+      "if(<variable|string> STREQUAL <variable|string>) :target: STREQUAL True if the given string or variable's value is lexicographically equal to the string or variable on the right.",
+      "if(<variable|string> STRLESS_EQUAL <variable|string>) :target: STRLESS_EQUAL .. versionadded:: 3.7 True if the given string or variable's value is lexicographically less than or equal to the string or variable on the right.",
+      "if(<variable|string> STRGREATER_EQUAL <variable|string>) :target: STRGREATER_EQUAL .. versionadded:: 3.7 True if the given string or variable's value is lexicographically greater than or equal to the string or variable on the right.",
+      "if(<variable|string> VERSION_LESS <variable|string>) :target: VERSION_LESS Component-wise integer version number comparison (version format is ``major[.minor[.patch[.tweak]]]``, omitted components are treated as zero). Any non-integer version component or non-integer trailing part of a version component effectively truncates the string at that point.",
+      "if(<variable|string> VERSION_GREATER <variable|string>) :target: VERSION_GREATER Component-wise integer version number comparison (version format is ``major[.minor[.patch[.tweak]]]``, omitted components are treated as zero). Any non-integer version component or non-integer trailing part of a version component effectively truncates the string at that point.",
+      "if(<variable|string> VERSION_EQUAL <variable|string>) :target: VERSION_EQUAL Component-wise integer version number comparison (version format is ``major[.minor[.patch[.tweak]]]``, omitted components are treated as zero). Any non-integer version component or non-integer trailing part of a version component effectively truncates the string at that point.",
+      "if(<variable|string> VERSION_LESS_EQUAL <variable|string>) :target: VERSION_LESS_EQUAL .. versionadded:: 3.7 Component-wise integer version number comparison (version format is ``major[.minor[.patch[.tweak]]]``, omitted components are treated as zero). Any non-integer version component or non-integer trailing part of a version component effectively truncates the string at that point.",
+      "if(<variable|string> VERSION_GREATER_EQUAL <variable|string>) :target: VERSION_GREATER_EQUAL .. versionadded:: 3.7 Component-wise integer version number comparison (version format is ``major[.minor[.patch[.tweak]]]``, omitted components are treated as zero). Any non-integer version component or non-integer trailing part of a version component effectively truncates the string at that point.",
+      "if(<variable|string> PATH_EQUAL <variable|string>) :target: PATH_EQUAL .. versionadded:: 3.24 Compares the two paths component-by-component. Only if every component of both paths match will the two paths compare equal. Multiple path separators are effectively collapsed into a single separator, but note that backslashes are not converted to forward slashes. No other :ref:`path normalization <Normalization>` is performed. Component-wise comparison is superior to string-based comparison due to the handling of multiple path separators. In the following example, the expression evaluates to true using ``PATH_EQUAL``, but false with ``STREQUAL``: if (\"/a//b/c\" PATH_EQUAL \"/a/b/c\") ... endif() if (\"/a//b/c\" STREQUAL \"/a/b/c\") ... endif() See :ref:`cmake_path(COMPARE) <Path COMPARE>` for more details.",
+      "if(var1)",
+      "if(var2)"
+    ]
+  },
+  "include": {
+    "name": "include",
+    "description": "Load and run CMake code from a file or module.",
+    "syntax_examples": [
+      "include(<file|module> [OPTIONAL] [RESULT_VARIABLE <var>] [NO_POLICY_SCOPE])"
+    ]
+  },
+  "include_directories": {
+    "name": "include_directories",
+    "description": "Add include directories to the build.",
+    "syntax_examples": [
+      "include_directories([AFTER|BEFORE] [SYSTEM] dir1 [dir2 ...])"
+    ]
+  },
+  "include_external_msproject": {
+    "name": "include_external_msproject",
+    "description": "Include an external Microsoft project file in a workspace.",
+    "syntax_examples": [
+      "include_external_msproject(projectname location [TYPE projectTypeGUID] [GUID projectGUID] [PLATFORM platformName] dep1 dep2 ...)"
+    ]
+  },
+  "include_guard": {
+    "name": "include_guard",
+    "description": "Provides an include guard for the file currently being processed by CMake.",
+    "syntax_examples": ["include_guard([DIRECTORY|GLOBAL])"]
+  },
+  "include_regular_expression": {
+    "name": "include_regular_expression",
+    "description": "Set the regular expression used for dependency checking.",
+    "syntax_examples": [
+      "include_regular_expression(regex_match [regex_complain])"
+    ]
+  },
+  "install": {
+    "name": "install",
+    "description": "Specify rules to run at install time.",
+    "syntax_examples": [
+      "install(TARGETS <target>... [...]) install(IMPORTED_RUNTIME_ARTIFACTS <target>... [...]) install({FILES | PROGRAMS} <file>... [...]) install(DIRECTORY <dir>... [...]) install(SCRIPT <file> [...]) install(CODE <code> [...]) install(EXPORT <export-name> [...]) install(RUNTIME_DEPENDENCY_SET <set-name> [...])",
+      "install(TARGETS <target>... [...]) Install target :ref:`Output Artifacts` and associated files: install(TARGETS <target>... [EXPORT <export-name>] [RUNTIME_DEPENDENCIES <arg>...|RUNTIME_DEPENDENCY_SET <set-name>] [<artifact-option>...] [<artifact-kind> <artifact-option>...]... [INCLUDES DESTINATION [<dir> ...]]) where ``<artifact-option>...`` group may contain: [DESTINATION <dir>] [PERMISSIONS <permission>...] [CONFIGURATIONS <config>...] [COMPONENT <component>] [NAMELINK_COMPONENT <component>] [OPTIONAL] [EXCLUDE_FROM_ALL] [NAMELINK_ONLY|NAMELINK_SKIP] The first ``<artifact-option>...`` group applies to target :ref:`Output Artifacts` that do not have a dedicated group specified later in the same call. .. _`<artifact-kind>`: Each ``<artifact-kind> <artifact-option>...`` group applies to :ref:`Output Artifacts` of the specified artifact kind: ``ARCHIVE`` Target artifacts of this kind include: * *Static libraries* (except on macOS when marked as ``FRAMEWORK``, see below); * *DLL import libraries* (on all Windows-based systems including Cygwin; they have extension ``.lib``, in contrast to the ``.dll`` libraries that go to ``RUNTIME``); * On AIX, the *linker import file* created for executables with :prop_tgt:`ENABLE_EXPORTS` enabled. * On macOS, the *linker import file* created for shared libraries with :prop_tgt:`ENABLE_EXPORTS` enabled (except when marked as ``FRAMEWORK``, see below). ``LIBRARY`` Target artifacts of this kind include: * *Shared libraries*, except - DLLs (these go to ``RUNTIME``, see below), - on macOS when marked as ``FRAMEWORK`` (see below). ``RUNTIME`` Target artifacts of this kind include: * *Executables* (except on macOS when marked as ``MACOSX_BUNDLE``, see ``BUNDLE`` below); * DLLs (on all Windows-based systems including Cygwin; note that the accompanying import libraries are of kind ``ARCHIVE``). ``OBJECTS`` .. versionadded:: 3.9 Object files associated with *object libraries*. ``FRAMEWORK`` Both static and shared libraries marked with the ``FRAMEWORK`` property are treated as ``FRAMEWORK`` targets on macOS. ``BUNDLE`` Executables marked with the :prop_tgt:`MACOSX_BUNDLE` property are treated as ``BUNDLE`` targets on macOS. ``PUBLIC_HEADER`` Any :prop_tgt:`PUBLIC_HEADER` files associated with a library are installed in the destination specified by the ``PUBLIC_HEADER`` argument on non-Apple platforms. Rules defined by this argument are ignored for :prop_tgt:`FRAMEWORK` libraries on Apple platforms because the associated files are installed into the appropriate locations inside the framework folder. See :prop_tgt:`PUBLIC_HEADER` for details. ``PRIVATE_HEADER`` Similar to ``PUBLIC_HEADER``, but for ``PRIVATE_HEADER`` files. See :prop_tgt:`PRIVATE_HEADER` for details. ``RESOURCE`` Similar to ``PUBLIC_HEADER`` and ``PRIVATE_HEADER``, but for ``RESOURCE`` files. See :prop_tgt:`RESOURCE` for details. ``FILE_SET <set-name>`` .. versionadded:: 3.23 File sets are defined by the :command:`target_sources(FILE_SET)` command. If the file set ``<set-name>`` exists and is ``PUBLIC`` or ``INTERFACE``, any files in the set are installed under the destination (see below). The directory structure relative to the file set's base directories is preserved. For example, a file added to the file set as ``/blah/include/myproj/here.h`` with a base directory ``/blah/include`` would be installed to ``myproj/here.h`` below the destination. ``CXX_MODULES_BMI`` .. versionadded:: 3.28 Any module files from C++ modules from ``PUBLIC`` sources in a file set of type ``CXX_MODULES`` will be installed to the given ``DESTINATION``. All modules are placed directly in the destination as no directory structure is derived from the names of the modules. An empty ``DESTINATION`` may be used to suppress installing these files (for use in generic code). For regular executables, static libraries and shared libraries, the ``DESTINATION`` argument is not required. For these target types, when ``DESTINATION`` is omitted, a default destination will be taken from the appropriate variable from :module:`GNUInstallDirs`, or set to a built-in default value if that variable is not defined. The same is true for file sets, and the public and private headers associated with the installed targets through the :prop_tgt:`PUBLIC_HEADER` and :prop_tgt:`PRIVATE_HEADER` target properties. A destination must always be provided for module libraries, Apple bundles and frameworks. A destination can be omitted for interface and object libraries, but they are handled differently (see the discussion of this topic toward the end of this section). For shared libraries on DLL platforms, if neither ``RUNTIME`` nor ``ARCHIVE`` destinations are specified, both the ``RUNTIME`` and ``ARCHIVE`` components are installed to their default destinations. If either a ``RUNTIME`` or ``ARCHIVE`` destination is specified, the component is installed to that destination, and the other component is not installed. If both ``RUNTIME`` and ``ARCHIVE`` destinations are specified, then both components are installed to their respective destinations. The following table shows the target types with their associated variables and built-in defaults that apply when no destination is given: =============================== =============================== ====================== Target Type GNUInstallDirs Variable Built-In Default =============================== =============================== ====================== ``RUNTIME`` ``${CMAKE_INSTALL_BINDIR}`` ``bin`` ``LIBRARY`` ``${CMAKE_INSTALL_LIBDIR}`` ``lib`` ``ARCHIVE`` ``${CMAKE_INSTALL_LIBDIR}`` ``lib`` ``PRIVATE_HEADER`` ``${CMAKE_INSTALL_INCLUDEDIR}`` ``include`` ``PUBLIC_HEADER`` ``${CMAKE_INSTALL_INCLUDEDIR}`` ``include`` ``FILE_SET`` (type ``HEADERS``) ``${CMAKE_INSTALL_INCLUDEDIR}`` ``include`` =============================== =============================== ====================== Projects wishing to follow the common practice of installing headers into a project-specific subdirectory may prefer using file sets with appropriate paths and base directories. Otherwise, they must provide a ``DESTINATION`` instead of being able to rely on the above (see next example below). To make packages compliant with distribution filesystem layout policies, if projects must specify a ``DESTINATION``, it is strongly recommended that they use a path that begins with the appropriate relative :module:`GNUInstallDirs` variable. This allows package maintainers to control the install destination by setting the appropriate cache variables. The following example shows a static library being installed to the default destination provided by :module:`GNUInstallDirs`, but with its headers installed to a project-specific subdirectory without using file sets: add_library(mylib STATIC ...) set_target_properties(mylib PROPERTIES PUBLIC_HEADER mylib.h) include(GNUInstallDirs) install(TARGETS mylib PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/myproj ) In addition to the `common options`_ listed above, each target can accept the following additional arguments: ``NAMELINK_COMPONENT`` .. versionadded:: 3.12 On some platforms a versioned shared library has a symbolic link such as:: lib<name>.so -> lib<name>.so.1 where ``lib<name>.so.1`` is the soname of the library and ``lib<name>.so`` is a \"namelink\" allowing linkers to find the library when given ``-l<name>``. The ``NAMELINK_COMPONENT`` option is similar to the ``COMPONENT`` option, but it changes the installation component of a shared library namelink if one is generated. If not specified, this defaults to the value of ``COMPONENT``. It is an error to use this parameter outside of a ``LIBRARY`` block. .. versionchanged:: 3.27 This parameter is also usable for an ``ARCHIVE`` block to manage the linker import file created, on macOS, for shared libraries with :prop_tgt:`ENABLE_EXPORTS` enabled. See the `Example: Install Targets with Per-Artifact Components`_ for an example using ``NAMELINK_COMPONENT``. This option is typically used for package managers that have separate runtime and development packages. For example, on Debian systems, the library is expected to be in the runtime package, and the headers and namelink are expected to be in the development package. See the :prop_tgt:`VERSION` and :prop_tgt:`SOVERSION` target properties for details on creating versioned shared libraries. ``NAMELINK_ONLY`` This option causes the installation of only the namelink when a library target is installed. On platforms where versioned shared libraries do not have namelinks or when a library is not versioned, the ``NAMELINK_ONLY`` option installs nothing. It is an error to use this parameter outside of a ``LIBRARY`` block. .. versionchanged:: 3.27 This parameter is also usable for an ``ARCHIVE`` block to manage the linker import file created, on macOS, for shared libraries with :prop_tgt:`ENABLE_EXPORTS` enabled. When ``NAMELINK_ONLY`` is given, either ``NAMELINK_COMPONENT`` or ``COMPONENT`` may be used to specify the installation component of the namelink, but ``COMPONENT`` should generally be preferred. ``NAMELINK_SKIP`` Similar to ``NAMELINK_ONLY``, but it has the opposite effect: it causes the installation of library files other than the namelink when a library target is installed. When neither ``NAMELINK_ONLY`` or ``NAMELINK_SKIP`` are given, both portions are installed. On platforms where versioned shared libraries do not have symlinks or when a library is not versioned, ``NAMELINK_SKIP`` installs the library. It is an error to use this parameter outside of a ``LIBRARY`` block. .. versionchanged:: 3.27 This parameter is also usable for an ``ARCHIVE`` block to manage the linker import file created, on macOS, for shared libraries with :prop_tgt:`ENABLE_EXPORTS` enabled. If ``NAMELINK_SKIP`` is specified, ``NAMELINK_COMPONENT`` has no effect. It is not recommended to use ``NAMELINK_SKIP`` in conjunction with ``NAMELINK_COMPONENT``. The :command:`install(TARGETS)` command can also accept the following options at the top level: ``EXPORT`` This option associates the installed target files with an export called ``<export-name>``. It must appear before any target options. To actually install the export file itself, call :command:`install(EXPORT)`, documented below. See documentation of the :prop_tgt:`EXPORT_NAME` target property to change the name of the exported target. If ``EXPORT`` is used and the targets include ``PUBLIC`` or ``INTERFACE`` file sets, all of them must be specified with ``FILE_SET`` arguments. All ``PUBLIC`` or ``INTERFACE`` file sets associated with a target are included in the export. ``INCLUDES DESTINATION`` This option specifies a list of directories which will be added to the :prop_tgt:`INTERFACE_INCLUDE_DIRECTORIES` target property of the ``<targets>`` when exported by the :command:`install(EXPORT)` command. If a relative path is specified, it is treated as relative to the :genex:`$<INSTALL_PREFIX>`. ``RUNTIME_DEPENDENCY_SET <set-name>`` .. versionadded:: 3.21 This option causes all runtime dependencies of installed executable, shared library, and module targets to be added to the specified runtime dependency set. This set can then be installed with an :command:`install(RUNTIME_DEPENDENCY_SET)` command. This keyword and the ``RUNTIME_DEPENDENCIES`` keyword are mutually exclusive. ``RUNTIME_DEPENDENCIES <arg>...`` .. versionadded:: 3.21 This option causes all runtime dependencies of installed executable, shared library, and module targets to be installed along with the targets themselves. The ``RUNTIME``, ``LIBRARY``, ``FRAMEWORK``, and generic arguments are used to determine the properties (``DESTINATION``, ``COMPONENT``, etc.) of the installation of these dependencies. ``RUNTIME_DEPENDENCIES`` is semantically equivalent to the following pair of calls: install(TARGETS ... RUNTIME_DEPENDENCY_SET <set-name>) install(RUNTIME_DEPENDENCY_SET <set-name> <arg>...) where ``<set-name>`` will be a randomly generated set name. ``<arg>...`` may include any of the following keywords supported by the :command:`install(RUNTIME_DEPENDENCY_SET)` command: * ``DIRECTORIES`` * ``PRE_INCLUDE_REGEXES`` * ``PRE_EXCLUDE_REGEXES`` * ``POST_INCLUDE_REGEXES`` * ``POST_EXCLUDE_REGEXES`` * ``POST_INCLUDE_FILES`` * ``POST_EXCLUDE_FILES`` The ``RUNTIME_DEPENDENCIES`` and ``RUNTIME_DEPENDENCY_SET`` keywords are mutually exclusive. :ref:`Interface Libraries` may be listed among the targets to install. They install no artifacts but will be included in an associated ``EXPORT``. If :ref:`Object Libraries` are listed but given no destination for their object files, they will be exported as :ref:`Interface Libraries`. This is sufficient to satisfy transitive usage requirements of other targets that link to the object libraries in their implementation. Installing a target with the :prop_tgt:`EXCLUDE_FROM_ALL` target property set to ``TRUE`` has undefined behavior. .. versionadded:: 3.3 An install destination given as a ``DESTINATION`` argument may use \"generator expressions\" with the syntax ``$<...>``. See the :manual:`cmake-generator-expressions(7)` manual for available expressions. .. versionadded:: 3.13 :command:`install(TARGETS)` can install targets that were created in other directories. When using such cross-directory install rules, running ``make install`` (or similar) from a subdirectory will not guarantee that targets from other directories are up-to-date. You can use :command:`target_link_libraries` or :command:`add_dependencies` to ensure that such out-of-directory targets are built before the subdirectory-specific install rules are run.",
+      "install(IMPORTED_RUNTIME_ARTIFACTS <target>... [...]) .. versionadded:: 3.21 Install runtime artifacts of imported targets: install(IMPORTED_RUNTIME_ARTIFACTS <target>... [RUNTIME_DEPENDENCY_SET <set-name>] [[LIBRARY|RUNTIME|FRAMEWORK|BUNDLE] [DESTINATION <dir>] [PERMISSIONS <permission>...] [CONFIGURATIONS <config>...] [COMPONENT <component>] [OPTIONAL] [EXCLUDE_FROM_ALL]] [...]) The ``IMPORTED_RUNTIME_ARTIFACTS`` form specifies rules for installing the runtime artifacts of imported targets. Projects may do this if they want to bundle outside executables or modules inside their installation. The ``LIBRARY``, ``RUNTIME``, ``FRAMEWORK``, and ``BUNDLE`` arguments have the same semantics that they do in the `TARGETS`_ mode. Only the runtime artifacts of imported targets are installed (except in the case of :prop_tgt:`FRAMEWORK` libraries, :prop_tgt:`MACOSX_BUNDLE` executables, and :prop_tgt:`BUNDLE` CFBundles.) For example, headers and import libraries associated with DLLs are not installed. In the case of :prop_tgt:`FRAMEWORK` libraries, :prop_tgt:`MACOSX_BUNDLE` executables, and :prop_tgt:`BUNDLE` CFBundles, the entire directory is installed. The ``RUNTIME_DEPENDENCY_SET`` option causes the runtime artifacts of the imported executable, shared library, and module library ``targets`` to be added to the ``<set-name>`` runtime dependency set. This set can then be installed with an :command:`install(RUNTIME_DEPENDENCY_SET)` command.",
+      "install(FILES <file>... [...]) install(PROGRAMS <program>... [...]) .. note:: If installing header files, consider using file sets defined by :command:`target_sources(FILE_SET)` instead. File sets associate headers with a target and they install as part of the target. Install files or programs: install(<FILES|PROGRAMS> <file>... TYPE <type> | DESTINATION <dir> [PERMISSIONS <permission>...] [CONFIGURATIONS <config>...] [COMPONENT <component>] [RENAME <name>] [OPTIONAL] [EXCLUDE_FROM_ALL]) The ``FILES`` form specifies rules for installing files for a project. File names given as relative paths are interpreted with respect to the current source directory. Files installed by this form are by default given permissions ``OWNER_WRITE``, ``OWNER_READ``, ``GROUP_READ``, and ``WORLD_READ`` if no ``PERMISSIONS`` argument is given. The ``PROGRAMS`` form is identical to the ``FILES`` form except that the default permissions for the installed file also include ``OWNER_EXECUTE``, ``GROUP_EXECUTE``, and ``WORLD_EXECUTE``. This form is intended to install programs that are not targets, such as shell scripts. Use the ``TARGETS`` form to install targets built within the project. The list of ``files...`` given to ``FILES`` or ``PROGRAMS`` may use \"generator expressions\" with the syntax ``$<...>``. See the :manual:`cmake-generator-expressions(7)` manual for available expressions. However, if any item begins in a generator expression it must evaluate to a full path. Either a ``TYPE`` or a ``DESTINATION`` must be provided, but not both. A ``TYPE`` argument specifies the generic file type of the files being installed. A destination will then be set automatically by taking the corresponding variable from :module:`GNUInstallDirs`, or by using a built-in default if that variable is not defined. See the table below for the supported file types and their corresponding variables and built-in defaults. Projects can provide a ``DESTINATION`` argument instead of a file type if they wish to explicitly define the install destination. ======================= ================================== ========================= ``TYPE`` Argument GNUInstallDirs Variable Built-In Default ======================= ================================== ========================= ``BIN`` ``${CMAKE_INSTALL_BINDIR}`` ``bin`` ``SBIN`` ``${CMAKE_INSTALL_SBINDIR}`` ``sbin`` ``LIB`` ``${CMAKE_INSTALL_LIBDIR}`` ``lib`` ``INCLUDE`` ``${CMAKE_INSTALL_INCLUDEDIR}`` ``include`` ``SYSCONF`` ``${CMAKE_INSTALL_SYSCONFDIR}`` ``etc`` ``SHAREDSTATE`` ``${CMAKE_INSTALL_SHARESTATEDIR}`` ``com`` ``LOCALSTATE`` ``${CMAKE_INSTALL_LOCALSTATEDIR}`` ``var`` ``RUNSTATE`` ``${CMAKE_INSTALL_RUNSTATEDIR}`` ``<LOCALSTATE dir>/run`` ``DATA`` ``${CMAKE_INSTALL_DATADIR}`` ``<DATAROOT dir>`` ``INFO`` ``${CMAKE_INSTALL_INFODIR}`` ``<DATAROOT dir>/info`` ``LOCALE`` ``${CMAKE_INSTALL_LOCALEDIR}`` ``<DATAROOT dir>/locale`` ``MAN`` ``${CMAKE_INSTALL_MANDIR}`` ``<DATAROOT dir>/man`` ``DOC`` ``${CMAKE_INSTALL_DOCDIR}`` ``<DATAROOT dir>/doc`` ======================= ================================== ========================= Projects wishing to follow the common practice of installing headers into a project-specific subdirectory will need to provide a destination rather than rely on the above. Using file sets for headers instead of ``install(FILES)`` would be even better (see :command:`target_sources(FILE_SET)`). Note that some of the types' built-in defaults use the ``DATAROOT`` directory as a prefix. The ``DATAROOT`` prefix is calculated similarly to the types, with ``CMAKE_INSTALL_DATAROOTDIR`` as the variable and ``share`` as the built-in default. You cannot use ``DATAROOT`` as a ``TYPE`` parameter; please use ``DATA`` instead. To make packages compliant with distribution filesystem layout policies, if projects must specify a ``DESTINATION``, it is strongly recommended that they use a path that begins with the appropriate relative :module:`GNUInstallDirs` variable. This allows package maintainers to control the install destination by setting the appropriate cache variables. The following example shows how to follow this advice while installing an image to a project-specific documentation subdirectory: include(GNUInstallDirs) install(FILES logo.png DESTINATION ${CMAKE_INSTALL_DOCDIR}/myproj ) .. versionadded:: 3.4 An install destination given as a ``DESTINATION`` argument may use \"generator expressions\" with the syntax ``$<...>``. See the :manual:`cmake-generator-expressions(7)` manual for available expressions. .. versionadded:: 3.20 An install rename given as a ``RENAME`` argument may use \"generator expressions\" with the syntax ``$<...>``. See the :manual:`cmake-generator-expressions(7)` manual for available expressions.",
+      "install(DIRECTORY <dir>... [...]) .. note:: To install a directory sub-tree of headers, consider using file sets defined by :command:`target_sources(FILE_SET)` instead. File sets not only preserve directory structure, they also associate headers with a target and install as part of the target. Install the contents of one or more directories: install(DIRECTORY dirs... TYPE <type> | DESTINATION <dir> [FILE_PERMISSIONS <permission>...] [DIRECTORY_PERMISSIONS <permission>...] [USE_SOURCE_PERMISSIONS] [OPTIONAL] [MESSAGE_NEVER] [CONFIGURATIONS <config>...] [COMPONENT <component>] [EXCLUDE_FROM_ALL] [FILES_MATCHING] [[PATTERN <pattern> | REGEX <regex>] [EXCLUDE] [PERMISSIONS <permission>...]] [...]) The ``DIRECTORY`` form installs contents of one or more directories to a given destination. The directory structure is copied verbatim to the destination. The last component of each directory name is appended to the destination directory but a trailing slash may be used to avoid this because it leaves the last component empty. Directory names given as relative paths are interpreted with respect to the current source directory. If no input directory names are given the destination directory will be created but nothing will be installed into it. The ``FILE_PERMISSIONS`` and ``DIRECTORY_PERMISSIONS`` options specify permissions given to files and directories in the destination. If ``USE_SOURCE_PERMISSIONS`` is specified and ``FILE_PERMISSIONS`` is not, file permissions will be copied from the source directory structure. If no permissions are specified files will be given the default permissions specified in the ``FILES`` form of the command, and the directories will be given the default permissions specified in the ``PROGRAMS`` form of the command. .. versionadded:: 3.1 The ``MESSAGE_NEVER`` option disables file installation status output. Installation of directories may be controlled with fine granularity using the ``PATTERN`` or ``REGEX`` options. These \"match\" options specify a globbing pattern or regular expression to match directories or files encountered within input directories. They may be used to apply certain options (see below) to a subset of the files and directories encountered. The full path to each input file or directory (with forward slashes) is matched against the expression. A ``PATTERN`` will match only complete file names: the portion of the full path matching the pattern must occur at the end of the file name and be preceded by a slash. A ``REGEX`` will match any portion of the full path but it may use ``/`` and ``$`` to simulate the ``PATTERN`` behavior. By default all files and directories are installed whether or not they are matched. The ``FILES_MATCHING`` option may be given before the first match option to disable installation of files (but not directories) not matched by any expression. For example, the code install(DIRECTORY src/ DESTINATION doc/myproj FILES_MATCHING PATTERN \"*.png\") will extract and install images from a source tree. Some options may follow a ``PATTERN`` or ``REGEX`` expression as described under :ref:`string(REGEX) <Regex Specification>` and are applied only to files or directories matching them. The ``EXCLUDE`` option will skip the matched file or directory. The ``PERMISSIONS`` option overrides the permissions setting for the matched file or directory. For example the code install(DIRECTORY icons scripts/ DESTINATION share/myproj PATTERN \"CVS\" EXCLUDE PATTERN \"scripts/*\" PERMISSIONS OWNER_EXECUTE OWNER_WRITE OWNER_READ GROUP_EXECUTE GROUP_READ) will install the ``icons`` directory to ``share/myproj/icons`` and the ``scripts`` directory to ``share/myproj``. The icons will get default file permissions, the scripts will be given specific permissions, and any ``CVS`` directories will be excluded. Either a ``TYPE`` or a ``DESTINATION`` must be provided, but not both. A ``TYPE`` argument specifies the generic file type of the files within the listed directories being installed. A destination will then be set automatically by taking the corresponding variable from :module:`GNUInstallDirs`, or by using a built-in default if that variable is not defined. See the table below for the supported file types and their corresponding variables and built-in defaults. Projects can provide a ``DESTINATION`` argument instead of a file type if they wish to explicitly define the install destination. ======================= ================================== ========================= ``TYPE`` Argument GNUInstallDirs Variable Built-In Default ======================= ================================== ========================= ``BIN`` ``${CMAKE_INSTALL_BINDIR}`` ``bin`` ``SBIN`` ``${CMAKE_INSTALL_SBINDIR}`` ``sbin`` ``LIB`` ``${CMAKE_INSTALL_LIBDIR}`` ``lib`` ``INCLUDE`` ``${CMAKE_INSTALL_INCLUDEDIR}`` ``include`` ``SYSCONF`` ``${CMAKE_INSTALL_SYSCONFDIR}`` ``etc`` ``SHAREDSTATE`` ``${CMAKE_INSTALL_SHARESTATEDIR}`` ``com`` ``LOCALSTATE`` ``${CMAKE_INSTALL_LOCALSTATEDIR}`` ``var`` ``RUNSTATE`` ``${CMAKE_INSTALL_RUNSTATEDIR}`` ``<LOCALSTATE dir>/run`` ``DATA`` ``${CMAKE_INSTALL_DATADIR}`` ``<DATAROOT dir>`` ``INFO`` ``${CMAKE_INSTALL_INFODIR}`` ``<DATAROOT dir>/info`` ``LOCALE`` ``${CMAKE_INSTALL_LOCALEDIR}`` ``<DATAROOT dir>/locale`` ``MAN`` ``${CMAKE_INSTALL_MANDIR}`` ``<DATAROOT dir>/man`` ``DOC`` ``${CMAKE_INSTALL_DOCDIR}`` ``<DATAROOT dir>/doc`` ======================= ================================== ========================= Note that some of the types' built-in defaults use the ``DATAROOT`` directory as a prefix. The ``DATAROOT`` prefix is calculated similarly to the types, with ``CMAKE_INSTALL_DATAROOTDIR`` as the variable and ``share`` as the built-in default. You cannot use ``DATAROOT`` as a ``TYPE`` parameter; please use ``DATA`` instead. To make packages compliant with distribution filesystem layout policies, if projects must specify a ``DESTINATION``, it is strongly recommended that they use a path that begins with the appropriate relative :module:`GNUInstallDirs` variable. This allows package maintainers to control the install destination by setting the appropriate cache variables. .. versionadded:: 3.4 An install destination given as a ``DESTINATION`` argument may use \"generator expressions\" with the syntax ``$<...>``. See the :manual:`cmake-generator-expressions(7)` manual for available expressions. .. versionadded:: 3.5 The list of ``dirs...`` given to ``DIRECTORY`` may use \"generator expressions\" too.",
+      "install(SCRIPT <file> [...]) install(CODE <code> [...]) Invoke CMake scripts or code during installation: install([[SCRIPT <file>] [CODE <code>]] [ALL_COMPONENTS | COMPONENT <component>] [EXCLUDE_FROM_ALL] [...]) The ``SCRIPT`` form will invoke the given CMake script files during installation. If the script file name is a relative path it will be interpreted with respect to the current source directory. The ``CODE`` form will invoke the given CMake code during installation. Code is specified as a single argument inside a double-quoted string. For example, the code install(CODE \"MESSAGE(\\\"Sample install message.\\\")\") will print a message during installation. .. versionadded:: 3.21 When the ``ALL_COMPONENTS`` option is given, the custom installation script code will be executed for every component of a component-specific installation. This option is mutually exclusive with the ``COMPONENT`` option. .. versionadded:: 3.14 ``<file>`` or ``<code>`` may use \"generator expressions\" with the syntax ``$<...>`` (in the case of ``<file>``, this refers to their use in the file name, not the file's contents). See the :manual:`cmake-generator-expressions(7)` manual for available expressions.",
+      "install(EXPORT <export-name> [...]) Install a CMake file exporting targets for dependent projects: install(EXPORT <export-name> DESTINATION <dir> [NAMESPACE <namespace>] [FILE <name>.cmake] [PERMISSIONS <permission>...] [CONFIGURATIONS <config>...] [CXX_MODULES_DIRECTORY <directory>] [EXPORT_LINK_INTERFACE_LIBRARIES] [COMPONENT <component>] [EXCLUDE_FROM_ALL] [EXPORT_PACKAGE_DEPENDENCIES]) install(EXPORT_ANDROID_MK <export-name> DESTINATION <dir> [...]) The ``EXPORT`` form generates and installs a CMake file containing code to import targets from the installation tree into another project. Target installations are associated with the export ``<export-name>`` using the ``EXPORT`` option of the :command:`install(TARGETS)` signature documented above. The ``NAMESPACE`` option will prepend ``<namespace>`` to the target names as they are written to the import file. By default the generated file will be called ``<export-name>.cmake`` but the ``FILE`` option may be used to specify a different name. The value given to the ``FILE`` option must be a file name with the ``.cmake`` extension. If a ``CONFIGURATIONS`` option is given then the file will only be installed when one of the named configurations is installed. Additionally, the generated import file will reference only the matching target configurations. See the :variable:`CMAKE_MAP_IMPORTED_CONFIG_<CONFIG>` variable to map configurations of dependent projects to the installed configurations. The ``EXPORT_LINK_INTERFACE_LIBRARIES`` keyword, if present, causes the contents of the properties matching ``(IMPORTED_)?LINK_INTERFACE_LIBRARIES(_<CONFIG>)?`` to be exported, when policy :policy:`CMP0022` is ``NEW``. .. note:: The installed ``<export-name>.cmake`` file may come with additional per-configuration ``<export-name>-*.cmake`` files to be loaded by globbing. Do not use an export name that is the same as the package name in combination with installing a ``<package-name>-config.cmake`` file or the latter may be incorrectly matched by the glob and loaded. When a ``COMPONENT`` option is given, the listed ``<component>`` implicitly depends on all components mentioned in the export set. The exported ``<name>.cmake`` file will require each of the exported components to be present in order for dependent projects to build properly. For example, a project may define components ``Runtime`` and ``Development``, with shared libraries going into the ``Runtime`` component and static libraries and headers going into the ``Development`` component. The export set would also typically be part of the ``Development`` component, but it would export targets from both the ``Runtime`` and ``Development`` components. Therefore, the ``Runtime`` component would need to be installed if the ``Development`` component was installed, but not vice versa. If the ``Development`` component was installed without the ``Runtime`` component, dependent projects that try to link against it would have build errors. Package managers, such as APT and RPM, typically handle this by listing the ``Runtime`` component as a dependency of the ``Development`` component in the package metadata, ensuring that the library is always installed if the headers and CMake export file are present. .. versionadded:: 3.7 In addition to cmake language files, the ``EXPORT_ANDROID_MK`` mode may be used to specify an export to the android ndk build system. This mode accepts the same options as the normal export mode. The Android NDK supports the use of prebuilt libraries, both static and shared. This allows cmake to build the libraries of a project and make them available to an ndk build system complete with transitive dependencies, include flags and defines required to use the libraries. ``CXX_MODULES_DIRECTORY`` .. versionadded:: 3.28 Specify a subdirectory to store C++ module information for targets in the export set. This directory will be populated with files which add the necessary target property information to the relevant targets. Note that without this information, none of the C++ modules which are part of the targets in the export set will support being imported in consuming targets. ``EXPORT_PACKAGE_DEPENDENCIES`` .. note:: Experimental. Gated by ``CMAKE_EXPERIMENTAL_EXPORT_PACKAGE_DEPENDENCIES``. Specify that :command:`find_dependency` calls should be exported. If this argument is specified, CMake examines all targets in the export set and gathers their ``INTERFACE`` link targets. If any such targets either were found with :command:`find_package` or have the :prop_tgt:`EXPORT_FIND_PACKAGE_NAME` property set, and such package dependency was not disabled by passing ``ENABLED OFF`` to :command:`export(SETUP)`, then a :command:`find_dependency` call is written with the target's corresponding package name, a ``REQUIRED`` argument, and any additional arguments specified by the ``EXTRA_ARGS`` argument of :command:`export(SETUP)`. Any package dependencies that were manually specified by passing ``ENABLED ON`` to :command:`export(SETUP)` are also added, even if the exported targets don't depend on any targets from them. The :command:`find_dependency` calls are written in the following order: 1. Any package dependencies that were listed in :command:`export(SETUP)` are written in the order they were first specified, regardless of whether or not they contain ``INTERFACE`` dependencies of the exported targets. 2. Any package dependencies that contain ``INTERFACE`` link dependencies of the exported targets and that were never specified in :command:`export(SETUP)` are written in the order they were first found. The ``EXPORT`` form is useful to help outside projects use targets built and installed by the current project. For example, the code install(TARGETS myexe EXPORT myproj DESTINATION bin) install(EXPORT myproj NAMESPACE mp_ DESTINATION lib/myproj) install(EXPORT_ANDROID_MK myproj DESTINATION share/ndk-modules) will install the executable ``myexe`` to ``<prefix>/bin`` and code to import it in the file ``<prefix>/lib/myproj/myproj.cmake`` and ``<prefix>/share/ndk-modules/Android.mk``. An outside project may load this file with the include command and reference the ``myexe`` executable from the installation tree using the imported target name ``mp_myexe`` as if the target were built in its own tree.",
+      "install(RUNTIME_DEPENDENCY_SET <set-name> [...]) .. versionadded:: 3.21 Installs a runtime dependency set: install(RUNTIME_DEPENDENCY_SET <set-name> [[LIBRARY|RUNTIME|FRAMEWORK] [DESTINATION <dir>] [PERMISSIONS <permission>...] [CONFIGURATIONS <config>...] [COMPONENT <component>] [NAMELINK_COMPONENT <component>] [OPTIONAL] [EXCLUDE_FROM_ALL]] [...] [PRE_INCLUDE_REGEXES <regex>...] [PRE_EXCLUDE_REGEXES <regex>...] [POST_INCLUDE_REGEXES <regex>...] [POST_EXCLUDE_REGEXES <regex>...] [POST_INCLUDE_FILES <file>...] [POST_EXCLUDE_FILES <file>...] [DIRECTORIES <dir>...]) Installs a runtime dependency set previously created by one or more :command:`install(TARGETS)` or :command:`install(IMPORTED_RUNTIME_ARTIFACTS)` commands. The dependencies of targets belonging to a runtime dependency set are installed in the ``RUNTIME`` destination and component on DLL platforms, and in the ``LIBRARY`` destination and component on non-DLL platforms. macOS frameworks are installed in the ``FRAMEWORK`` destination and component. Targets built within the build tree will never be installed as runtime dependencies, nor will their own dependencies, unless the targets themselves are installed with :command:`install(TARGETS)`. The generated install script calls :command:`file(GET_RUNTIME_DEPENDENCIES)` on the build-tree files to calculate the runtime dependencies. The build-tree executable files are passed as the ``EXECUTABLES`` argument, the build-tree shared libraries as the ``LIBRARIES`` argument, and the build-tree modules as the ``MODULES`` argument. On macOS, if one of the executables is a :prop_tgt:`MACOSX_BUNDLE`, that executable is passed as the ``BUNDLE_EXECUTABLE`` argument. At most one such bundle executable may be in the runtime dependency set on macOS. The :prop_tgt:`MACOSX_BUNDLE` property has no effect on other platforms. Note that :command:`file(GET_RUNTIME_DEPENDENCIES)` only supports collecting the runtime dependencies for Windows, Linux and macOS platforms, so ``install(RUNTIME_DEPENDENCY_SET)`` has the same limitation. The following sub-arguments are forwarded through as the corresponding arguments to :command:`file(GET_RUNTIME_DEPENDENCIES)` (for those that provide a non-empty list of directories, regular expressions or files). They all support :manual:`generator expressions <cmake-generator-expressions(7)>`. * ``DIRECTORIES <dir>...`` * ``PRE_INCLUDE_REGEXES <regex>...`` * ``PRE_EXCLUDE_REGEXES <regex>...`` * ``POST_INCLUDE_REGEXES <regex>...`` * ``POST_EXCLUDE_REGEXES <regex>...`` * ``POST_INCLUDE_FILES <file>...`` * ``POST_EXCLUDE_FILES <file>...``",
+      "install(TARGETS myExe mySharedLib myStaticLib RUNTIME COMPONENT Runtime LIBRARY COMPONENT Runtime NAMELINK_COMPONENT Development ARCHIVE COMPONENT Development DESTINATION lib/static FILE_SET HEADERS COMPONENT Development )",
+      "install(TARGETS myExe CONFIGURATIONS Debug RUNTIME DESTINATION Debug/bin ) install(TARGETS myExe CONFIGURATIONS Release RUNTIME DESTINATION Release/bin )"
+    ]
+  },
+  "install_files": {
+    "name": "install_files",
+    "description": "This command has been superseded by the install command. It is provided for compatibility with older CMake code. The FILES form is directly replaced by the FILES form of the install command. The regexp form can be expressed more clearly using the GLOB form of the file command.",
+    "syntax_examples": [
+      "install_files(<dir> extension file file ...)",
+      "install_files(<dir> regexp)",
+      "install_files(<dir> FILES file file ...)"
+    ]
+  },
+  "install_programs": {
+    "name": "install_programs",
+    "description": "This command has been superseded by the install command. It is provided for compatibility with older CMake code. The FILES form is directly replaced by the PROGRAMS form of the install command. The regexp form can be expressed more clearly using the GLOB form of the file command.",
+    "syntax_examples": [
+      "install_programs(<dir> file1 file2 [file3 ...]) install_programs(<dir> FILES file1 [file2 ...])",
+      "install_programs(<dir> regexp)"
+    ]
+  },
+  "install_targets": {
+    "name": "install_targets",
+    "description": "This command has been superseded by the install command. It is provided for compatibility with older CMake code.",
+    "syntax_examples": [
+      "install_targets(<dir> [RUNTIME_DIRECTORY dir] target target)"
+    ]
+  },
+  "link_directories": {
+    "name": "link_directories",
+    "description": "Add directories in which the linker will look for libraries.",
+    "syntax_examples": [
+      "link_directories([AFTER|BEFORE] directory1 [directory2 ...])"
+    ]
+  },
+  "link_libraries": {
+    "name": "link_libraries",
+    "description": "Link libraries to all targets added later.",
+    "syntax_examples": [
+      "link_libraries([item1 [item2 [...]]] [[debug|optimized|general] <item>] ...)"
+    ]
+  },
+  "list": {
+    "name": "list",
+    "description": "Operations on semicolon-separated lists .",
+    "syntax_examples": [
+      "list(LENGTH <list> <output variable>) Returns the list's length.",
+      "list(GET <list> <element index> [<element index> ...] <output variable>) Returns the list of elements specified by indices from the list.",
+      "list(JOIN <list> <glue> <output variable>) .. versionadded:: 3.12 Returns a string joining all list's elements using the glue string. To join multiple strings, which are not part of a list, use :command:`string(JOIN)`.",
+      "list(SUBLIST <list> <begin> <length> <output variable>) .. versionadded:: 3.12 Returns a sublist of the given list. If ``<length>`` is 0, an empty list will be returned. If ``<length>`` is -1 or the list is smaller than ``<begin>+<length>`` then the remaining elements of the list starting at ``<begin>`` will be returned.",
+      "list(FIND <list> <value> <output variable>) Returns the index of the element specified in the list or ``-1`` if it wasn't found.",
+      "list(APPEND <list> [<element> ...]) Appends elements to the list. If no variable named ``<list>`` exists in the current scope its value is treated as empty and the elements are appended to that empty list.",
+      "list(FILTER <list> <INCLUDE|EXCLUDE> REGEX <regular_expression>)",
+      "list(INSERT <list> <element_index> <element> [<element> ...]) Inserts elements to the list to the specified index. It is an error to specify an out-of-range index. Valid indexes are 0 to `N` where `N` is the length of the list, inclusive. An empty list has length 0. If no variable named ``<list>`` exists in the current scope its value is treated as empty and the elements are inserted in that empty list.",
+      "list(POP_BACK <list> [<out-var>...]) .. versionadded:: 3.15 If no variable name is given, removes exactly one element. Otherwise, with `N` variable names provided, assign the last `N` elements' values to the given variables and then remove the last `N` values from ``<list>``.",
+      "list(POP_FRONT <list> [<out-var>...]) .. versionadded:: 3.15 If no variable name is given, removes exactly one element. Otherwise, with `N` variable names provided, assign the first `N` elements' values to the given variables and then remove the first `N` values from ``<list>``.",
+      "list(PREPEND <list> [<element> ...]) .. versionadded:: 3.15 Insert elements to the 0th position in the list. If no variable named ``<list>`` exists in the current scope its value is treated as empty and the elements are prepended to that empty list.",
+      "list(REMOVE_ITEM <list> <value> [<value> ...]) Removes all instances of the given items from the list.",
+      "list(REMOVE_AT <list> <index> [<index> ...]) Removes items at given indices from the list.",
+      "list(REMOVE_DUPLICATES <list>) Removes duplicated items in the list. The relative order of items is preserved, but if duplicates are encountered, only the first instance is preserved.",
+      "list(TRANSFORM <list> <ACTION> [<SELECTOR>] [OUTPUT_VARIABLE <output variable>]) .. versionadded:: 3.12 Transforms the list by applying an ``<ACTION>`` to all or, by specifying a ``<SELECTOR>``, to the selected elements of the list, storing the result in-place or in the specified output variable. .. note:: The ``TRANSFORM`` sub-command does not change the number of elements in the list. If a ``<SELECTOR>`` is specified, only some elements will be changed, the other ones will remain the same as before the transformation. ``<ACTION>`` specifies the action to apply to the elements of the list. The actions have exactly the same semantics as sub-commands of the :command:`string` command. ``<ACTION>`` must be one of the following: :command:`APPEND <string(APPEND)>`, :command:`PREPEND <string(PREPEND)>` Append, prepend specified value to each element of the list. list(TRANSFORM <list> (APPEND|PREPEND) <value> ...) :target: TRANSFORM_APPEND :command:`TOLOWER <string(TOLOWER)>`, :command:`TOUPPER <string(TOUPPER)>` Convert each element of the list to lower, upper characters. list(TRANSFORM <list> (TOLOWER|TOUPPER) ...) :target: TRANSFORM_TOLOWER :command:`STRIP <string(STRIP)>` Remove leading and trailing spaces from each element of the list. list(TRANSFORM <list> STRIP ...) :target: TRANSFORM_STRIP :command:`GENEX_STRIP <string(GENEX_STRIP)>` Strip any :manual:`generator expressions <cmake-generator-expressions(7)>` from each element of the list. list(TRANSFORM <list> GENEX_STRIP ...) :target: TRANSFORM_GENEX_STRIP :command:`REPLACE <string(REGEX REPLACE)>`: Match the regular expression as many times as possible and substitute the replacement expression for the match for each element of the list (same semantic as :command:`string(REGEX REPLACE)`). list(TRANSFORM <list> REPLACE <regular_expression> <replace_expression> ...) :target: TRANSFORM_REPLACE ``<SELECTOR>`` determines which elements of the list will be transformed. Only one type of selector can be specified at a time. When given, ``<SELECTOR>`` must be one of the following: ``AT`` Specify a list of indexes. list(TRANSFORM <list> <ACTION> AT <index> [<index> ...] ...) ``FOR`` Specify a range with, optionally, an increment used to iterate over the range. list(TRANSFORM <list> <ACTION> FOR <start> <stop> [<step>] ...) ``REGEX`` Specify a regular expression. Only elements matching the regular expression will be transformed. list(TRANSFORM <list> <ACTION> REGEX <regular_expression> ...)",
+      "list(REVERSE <list>) Reverses the contents of the list in-place.",
+      "list(SORT <list> [COMPARE <compare>] [CASE <case>] [ORDER <order>]) Sorts the list in-place alphabetically. .. versionadded:: 3.13 Added the ``COMPARE``, ``CASE``, and ``ORDER`` options. .. versionadded:: 3.18 Added the ``COMPARE NATURAL`` option. Use the ``COMPARE`` keyword to select the comparison method for sorting. The ``<compare>`` option should be one of: ``STRING`` Sorts a list of strings alphabetically. This is the default behavior if the ``COMPARE`` option is not given. ``FILE_BASENAME`` Sorts a list of pathnames of files by their basenames. ``NATURAL`` Sorts a list of strings using natural order (see ``strverscmp(3)`` manual), i.e. such that contiguous digits are compared as whole numbers. For example: the following list `10.0 1.1 2.1 8.0 2.0 3.1` will be sorted as `1.1 2.0 2.1 3.1 8.0 10.0` if the ``NATURAL`` comparison is selected where it will be sorted as `1.1 10.0 2.0 2.1 3.1 8.0` with the ``STRING`` comparison. Use the ``CASE`` keyword to select a case sensitive or case insensitive sort mode. The ``<case>`` option should be one of: ``SENSITIVE`` List items are sorted in a case-sensitive manner. This is the default behavior if the ``CASE`` option is not given. ``INSENSITIVE`` List items are sorted case insensitively. The order of items which differ only by upper/lowercase is not specified. To control the sort order, the ``ORDER`` keyword can be given. The ``<order>`` option should be one of: ``ASCENDING`` Sorts the list in ascending order. This is the default behavior when the ``ORDER`` option is not given. ``DESCENDING`` Sorts the list in descending order."
+    ]
+  },
+  "load_cache": {
+    "name": "load_cache",
+    "description": "Load in the values from another project's CMake cache.",
+    "syntax_examples": [
+      "load_cache(pathToBuildDirectory READ_WITH_PREFIX prefix entry1...)",
+      "load_cache(pathToBuildDirectory [EXCLUDE entry1...] [INCLUDE_INTERNALS entry1...])"
+    ]
+  },
+  "load_command": {
+    "name": "load_command",
+    "description": "Disallowed since version 3.0. See CMake Policy CMP0031.",
+    "syntax_examples": ["load_command(COMMAND_NAME <loc1> [loc2 ...])"]
+  },
+  "macro": {
+    "name": "macro",
+    "description": "Start recording a macro for later invocation as a command",
+    "syntax_examples": [
+      "macro(<name> [<arg1> ...]) <commands> endmacro()",
+      "macro(foo) <commands> endmacro()",
+      "macro(bar) foreach(arg IN LISTS ARGN) <commands> endforeach() endmacro() function(foo) bar(x y z) endfunction() foo(a b c)"
+    ]
+  },
+  "make_directory": {
+    "name": "make_directory",
+    "description": "Creates the specified directory. Full paths should be given. Any parent directories that do not exist will also be created. Use with care.",
+    "syntax_examples": ["make_directory(directory)"]
+  },
+  "mark_as_advanced": {
+    "name": "mark_as_advanced",
+    "description": "Mark cmake cached variables as advanced.",
+    "syntax_examples": ["mark_as_advanced([CLEAR|FORCE] <var1> ...)"]
+  },
+  "math": {
+    "name": "math",
+    "description": "Evaluate a mathematical expression.",
+    "syntax_examples": [
+      "math(EXPR <variable> \"<expression>\" [OUTPUT_FORMAT <format>])",
+      "math(EXPR value \"100 * 0xA\" OUTPUT_FORMAT DECIMAL) math(EXPR value \"100 * 0xA\" OUTPUT_FORMAT HEXADECIMAL)"
+    ]
+  },
+  "message": {
+    "name": "message",
+    "description": "Log a message.",
+    "syntax_examples": [
+      "message([<mode>] \"message text\" ...)",
+      "message(STATUS \"Looking for someheader.h\") if(checkSuccess) message(STATUS \"Looking for someheader.h - found\") else() message(STATUS \"Looking for someheader.h - not found\") endif()",
+      "message(<checkState> \"message\" ...)",
+      "message(CHECK_START \"Finding my things\") list(APPEND CMAKE_MESSAGE_INDENT \" \") unset(missingComponents) message(CHECK_START \"Finding partA\") message(CHECK_PASS \"found\") message(CHECK_START \"Finding partB\") list(APPEND missingComponents B) message(CHECK_FAIL \"not found\") list(POP_BACK CMAKE_MESSAGE_INDENT) if(missingComponents) message(CHECK_FAIL \"missing components: ${missingComponents}\") else() message(CHECK_PASS \"all components found\") endif()",
+      "message(CONFIGURE_LOG <text>...)"
+    ]
+  },
+  "option": {
+    "name": "option",
+    "description": "Provide a boolean option that the user can optionally select.",
+    "syntax_examples": ["option(<variable> \"<help_text>\" [value])"]
+  },
+  "output_required_files": {
+    "name": "output_required_files",
+    "description": "Disallowed since version 3.0. See CMake Policy CMP0032.",
+    "syntax_examples": ["output_required_files(srcfile outputfile)"]
+  },
+  "project": {
+    "name": "project",
+    "description": "Set the name of the project.",
+    "syntax_examples": [
+      "project(<PROJECT-NAME> [<language-name>...]) project(<PROJECT-NAME> [VERSION <major>[.<minor>[.<patch>[.<tweak>]]]] [DESCRIPTION <project-description-string>] [HOMEPAGE_URL <url-string>] [LANGUAGES <language-name>...])"
+    ]
+  },
+  "qt_wrap_cpp": {
+    "name": "qt_wrap_cpp",
+    "description": "Manually create Qt Wrappers.",
+    "syntax_examples": [
+      "qt_wrap_cpp(resultingLibraryName DestName SourceLists ...)"
+    ]
+  },
+  "qt_wrap_ui": {
+    "name": "qt_wrap_ui",
+    "description": "Manually create Qt user interfaces Wrappers.",
+    "syntax_examples": [
+      "qt_wrap_ui(resultingLibraryName HeadersDestName SourcesDestName SourceLists ...)"
+    ]
+  },
+  "remove": {
+    "name": "remove",
+    "description": "Removes VALUE from the variable VAR. This is typically used to remove entries from a vector (e.g. semicolon separated list). VALUE is expanded.",
+    "syntax_examples": ["remove(VAR VALUE VALUE ...)"]
+  },
+  "remove_definitions": {
+    "name": "remove_definitions",
+    "description": "Remove -D define flags added by add_definitions.",
+    "syntax_examples": ["remove_definitions(-DFOO -DBAR ...)"]
+  },
+  "return": {
+    "name": "return",
+    "description": "Return from a file, directory or function.",
+    "syntax_examples": ["return([PROPAGATE <var-name>...])"]
+  },
+  "separate_arguments": {
+    "name": "separate_arguments",
+    "description": "Parse command-line arguments into a semicolon-separated list.",
+    "syntax_examples": [
+      "separate_arguments(<variable> <mode> [PROGRAM [SEPARATE_ARGS]] <args>)",
+      "separate_arguments (out UNIX_COMMAND PROGRAM \"cc -c main.c\")",
+      "separate_arguments (out UNIX_COMMAND PROGRAM SEPARATE_ARGS \"cc -c main.c\")",
+      "separate_arguments(<var>)"
+    ]
+  },
+  "set": {
+    "name": "set",
+    "description": "Set a normal, cache, or environment variable to a given value. See the cmake-language(7) variables  documentation for the scopes and interaction of normal variables and cache entries.",
+    "syntax_examples": [
+      "set(<variable> <value>... [PARENT_SCOPE]) :target: normal Set or unset ``<variable>`` in the current function or directory scope: * If at least one ``<value>...`` is given, set the variable to that value. * If no value is given, unset the variable. This is equivalent to :command:`unset(<variable>) <unset>`. If the ``PARENT_SCOPE`` option is given the variable will be set in the scope above the current scope. Each new directory or :command:`function` command creates a new scope. A scope can also be created with the :command:`block` command. ``set(PARENT_SCOPE)`` will set the value of a variable into the parent directory, calling function, or encompassing scope (whichever is applicable to the case at hand). The previous state of the variable's value stays the same in the current scope (e.g., if it was undefined before, it is still undefined and if it had a value, it is still that value). The :command:`block(PROPAGATE)` and :command:`return(PROPAGATE)` commands can be used as an alternate method to the :command:`set(PARENT_SCOPE)` and :command:`unset(PARENT_SCOPE)` commands to update the parent scope.",
+      "set(<variable> <value>... CACHE <type> <docstring> [FORCE]) :target: CACHE Sets the given cache ``<variable>`` (cache entry). Since cache entries are meant to provide user-settable values this does not overwrite existing cache entries by default. Use the ``FORCE`` option to overwrite existing entries. The ``<type>`` must be specified as one of: ``BOOL`` Boolean ``ON/OFF`` value. :manual:`cmake-gui(1)` offers a checkbox. ``FILEPATH`` Path to a file on disk. :manual:`cmake-gui(1)` offers a file dialog. ``PATH`` Path to a directory on disk. :manual:`cmake-gui(1)` offers a file dialog. ``STRING`` A line of text. :manual:`cmake-gui(1)` offers a text field or a drop-down selection if the :prop_cache:`STRINGS` cache entry property is set. ``INTERNAL`` A line of text. :manual:`cmake-gui(1)` does not show internal entries. They may be used to store variables persistently across runs. Use of this type implies ``FORCE``. The ``<docstring>`` must be specified as a line of text providing a quick summary of the option for presentation to :manual:`cmake-gui(1)` users. If the cache entry does not exist prior to the call or the ``FORCE`` option is given then the cache entry will be set to the given value. .. note:: The content of the cache variable will not be directly accessible if a normal variable of the same name already exists (see :ref:`rules of variable evaluation <CMake Language Variables>`). If policy :policy:`CMP0126` is set to ``OLD``, any normal variable binding in the current scope will be removed. It is possible for the cache entry to exist prior to the call but have no type set if it was created on the :manual:`cmake(1)` command line by a user through the :option:`-D\\<var\\>=\\<value\\> <cmake -D>` option without specifying a type. In this case the ``set`` command will add the type. Furthermore, if the ``<type>`` is ``PATH`` or ``FILEPATH`` and the ``<value>`` provided on the command line is a relative path, then the ``set`` command will treat the path as relative to the current working directory and convert it to an absolute path.",
+      "set(ENV{<variable>} [<value>]) :target: ENV Sets an :manual:`Environment Variable <cmake-env-variables(7)>` to the given value. Subsequent calls of ``$ENV{<variable>}`` will return this new value. This command affects only the current CMake process, not the process from which CMake was called, nor the system environment at large, nor the environment of subsequent build or test processes. If no argument is given after ``ENV{<variable>}`` or if ``<value>`` is an empty string, then this command will clear any existing value of the environment variable. Arguments after ``<value>`` are ignored. If extra arguments are found, then an author warning is issued."
+    ]
+  },
+  "set_directory_properties": {
+    "name": "set_directory_properties",
+    "description": "Set properties of the current directory and subdirectories.",
+    "syntax_examples": [
+      "set_directory_properties(PROPERTIES <prop1> <value1> [<prop2> <value2>] ...)"
+    ]
+  },
+  "set_property": {
+    "name": "set_property",
+    "description": "Set a named property in a given scope.",
+    "syntax_examples": [
+      "set_property(<GLOBAL | DIRECTORY [<dir>] | TARGET [<target1> ...] | SOURCE [<src1> ...] [DIRECTORY <dirs> ...] [TARGET_DIRECTORY <targets> ...] | INSTALL [<file1> ...] | TEST [<test1> ...] [DIRECTORY <dir>] | CACHE [<entry1> ...]> [APPEND] [APPEND_STRING] PROPERTY <name> [<value1> ...])"
+    ]
+  },
+  "set_source_files_properties": {
+    "name": "set_source_files_properties",
+    "description": "Source files can have properties that affect how they are built.",
+    "syntax_examples": [
+      "set_source_files_properties(<files> ... [DIRECTORY <dirs> ...] [TARGET_DIRECTORY <targets> ...] PROPERTIES <prop1> <value1> [<prop2> <value2>] ...)"
+    ]
+  },
+  "set_target_properties": {
+    "name": "set_target_properties",
+    "description": "Targets can have properties that affect how they are built.",
+    "syntax_examples": [
+      "set_target_properties(<targets> ... PROPERTIES <prop1> <value1> [<prop2> <value2>] ...)"
+    ]
+  },
+  "set_tests_properties": {
+    "name": "set_tests_properties",
+    "description": "Set a property of the tests.",
+    "syntax_examples": [
+      "set_tests_properties(<tests>... [DIRECTORY <dir>] PROPERTIES <prop1> <value1> [<prop2> <value2>]...)"
+    ]
+  },
+  "site_name": {
+    "name": "site_name",
+    "description": "Set the given variable to the name of the computer.",
+    "syntax_examples": ["site_name(variable)"]
+  },
+  "source_group": {
+    "name": "source_group",
+    "description": "Define a grouping for source files in IDE project generation. There are two different signatures to create source groups.",
+    "syntax_examples": [
+      "source_group(<name> [FILES <src>...] [REGULAR_EXPRESSION <regex>]) source_group(TREE <root> [PREFIX <prefix>] [FILES <src>...])",
+      "source_group(base/subdir ...) source_group(outer\\\\inner ...) source_group(TREE <root> PREFIX sources\\\\inc ...)",
+      "source_group(<name> <regex>)",
+      "source_group(<name> REGULAR_EXPRESSION <regex>)"
+    ]
+  },
+  "string": {
+    "name": "string",
+    "description": "String operations.",
+    "syntax_examples": [
+      "string(FIND <string> <substring> <output_variable> [REVERSE]) Return the position where the given ``<substring>`` was found in the supplied ``<string>``. If the ``REVERSE`` flag was used, the command will search for the position of the last occurrence of the specified ``<substring>``. If the ``<substring>`` is not found, a position of -1 is returned. The ``string(FIND)`` subcommand treats all strings as ASCII-only characters. The index stored in ``<output_variable>`` will also be counted in bytes, so strings containing multi-byte characters may lead to unexpected results.",
+      "string(REPLACE <match_string> <replace_string> <output_variable> <input> [<input>...]) Replace all occurrences of ``<match_string>`` in the ``<input>`` with ``<replace_string>`` and store the result in the ``<output_variable>``.",
+      "string(REGEX MATCH <regular_expression> <output_variable> <input> [<input>...]) Match the ``<regular_expression>`` once and store the match in the ``<output_variable>``. All ``<input>`` arguments are concatenated before matching. Regular expressions are specified in the subsection just below.",
+      "string(REGEX MATCHALL <regular_expression> <output_variable> <input> [<input>...]) Match the ``<regular_expression>`` as many times as possible and store the matches in the ``<output_variable>`` as a list. All ``<input>`` arguments are concatenated before matching.",
+      "string(REGEX REPLACE <regular_expression> <replacement_expression> <output_variable> <input> [<input>...]) Match the ``<regular_expression>`` as many times as possible and substitute the ``<replacement_expression>`` for the match in the output. All ``<input>`` arguments are concatenated before matching. The ``<replacement_expression>`` may refer to parenthesis-delimited subexpressions of the match using ``\\1``, ``\\2``, ..., ``\\9``. Note that two backslashes (``\\\\1``) are required in CMake code to get a backslash through argument parsing.",
+      "string(APPEND <string_variable> [<input>...]) .. versionadded:: 3.4 Append all the ``<input>`` arguments to the string.",
+      "string(PREPEND <string_variable> [<input>...]) .. versionadded:: 3.10 Prepend all the ``<input>`` arguments to the string.",
+      "string(CONCAT <output_variable> [<input>...]) Concatenate all the ``<input>`` arguments together and store the result in the named ``<output_variable>``.",
+      "string(JOIN <glue> <output_variable> [<input>...]) .. versionadded:: 3.12 Join all the ``<input>`` arguments together using the ``<glue>`` string and store the result in the named ``<output_variable>``. To join a list's elements, prefer to use the ``JOIN`` operator from the :command:`list` command. This allows for the elements to have special characters like ``;`` in them.",
+      "string(TOLOWER <string> <output_variable>) Convert ``<string>`` to lower characters.",
+      "string(TOUPPER <string> <output_variable>) Convert ``<string>`` to upper characters.",
+      "string(LENGTH <string> <output_variable>) Store in an ``<output_variable>`` a given string's length in bytes. Note that this means if ``<string>`` contains multi-byte characters, the result stored in ``<output_variable>`` will *not* be the number of characters.",
+      "string(SUBSTRING <string> <begin> <length> <output_variable>) Store in an ``<output_variable>`` a substring of a given ``<string>``. If ``<length>`` is ``-1`` the remainder of the string starting at ``<begin>`` will be returned. .. versionchanged:: 3.2 If ``<string>`` is shorter than ``<length>`` then the end of the string is used instead. Previous versions of CMake reported an error in this case. Both ``<begin>`` and ``<length>`` are counted in bytes, so care must be exercised if ``<string>`` could contain multi-byte characters.",
+      "string(STRIP <string> <output_variable>) Store in an ``<output_variable>`` a substring of a given ``<string>`` with leading and trailing spaces removed.",
+      "string(GENEX_STRIP <string> <output_variable>) .. versionadded:: 3.1 Strip any :manual:`generator expressions <cmake-generator-expressions(7)>` from the input ``<string>`` and store the result in the ``<output_variable>``.",
+      "string(REPEAT <string> <count> <output_variable>) .. versionadded:: 3.15 Produce the output string as the input ``<string>`` repeated ``<count>`` times.",
+      "string(COMPARE LESS <string1> <string2> <output_variable>) string(COMPARE GREATER <string1> <string2> <output_variable>) string(COMPARE EQUAL <string1> <string2> <output_variable>) string(COMPARE NOTEQUAL <string1> <string2> <output_variable>) string(COMPARE LESS_EQUAL <string1> <string2> <output_variable>) string(COMPARE GREATER_EQUAL <string1> <string2> <output_variable>) Compare the strings and store true or false in the ``<output_variable>``. .. versionadded:: 3.7 Added the ``LESS_EQUAL`` and ``GREATER_EQUAL`` options.",
+      "string(<HASH> <output_variable> <input>) :target: <HASH> Compute a cryptographic hash of the ``<input>`` string. The supported ``<HASH>`` algorithm names are: ``MD5`` Message-Digest Algorithm 5, RFC 1321. ``SHA1`` US Secure Hash Algorithm 1, RFC 3174. ``SHA224`` US Secure Hash Algorithms, RFC 4634. ``SHA256`` US Secure Hash Algorithms, RFC 4634. ``SHA384`` US Secure Hash Algorithms, RFC 4634. ``SHA512`` US Secure Hash Algorithms, RFC 4634. ``SHA3_224`` Keccak SHA-3. ``SHA3_256`` Keccak SHA-3. ``SHA3_384`` Keccak SHA-3. ``SHA3_512`` Keccak SHA-3. .. versionadded:: 3.8 Added the ``SHA3_*`` hash algorithms.",
+      "string(ASCII <number> [<number> ...] <output_variable>) Convert all numbers into corresponding ASCII characters.",
+      "string(HEX <string> <output_variable>) .. versionadded:: 3.18 Convert each byte in the input ``<string>`` to its hexadecimal representation and store the concatenated hex digits in the ``<output_variable>``. Letters in the output (``a`` through ``f``) are in lowercase.",
+      "string(CONFIGURE <string> <output_variable> [@ONLY] [ESCAPE_QUOTES]) Transform a ``<string>`` like :command:`configure_file` transforms a file.",
+      "string(MAKE_C_IDENTIFIER <string> <output_variable>) Convert each non-alphanumeric character in the input ``<string>`` to an underscore and store the result in the ``<output_variable>``. If the first character of the ``<string>`` is a digit, an underscore will also be prepended to the result.",
+      "string(RANDOM [LENGTH <length>] [ALPHABET <alphabet>] [RANDOM_SEED <seed>] <output_variable>) Return a random string of given ``<length>`` consisting of characters from the given ``<alphabet>``. Default length is 5 characters and default alphabet is all numbers and upper and lower case letters. If an integer ``RANDOM_SEED`` is given, its value will be used to seed the random number generator.",
+      "string(TIMESTAMP <output_variable> [<format_string>] [UTC]) Write a string representation of the current date and/or time to the ``<output_variable>``. If the command is unable to obtain a timestamp, the ``<output_variable>`` will be set to the empty string ``\"\"``. The optional ``UTC`` flag requests the current date/time representation to be in Coordinated Universal Time (UTC) rather than local time. The optional ``<format_string>`` may contain the following format specifiers: ``%%`` .. versionadded:: 3.8 A literal percent sign (%). ``%d`` The day of the current month (01-31). ``%H`` The hour on a 24-hour clock (00-23). ``%I`` The hour on a 12-hour clock (01-12). ``%j`` The day of the current year (001-366). ``%m`` The month of the current year (01-12). ``%b`` .. versionadded:: 3.7 Abbreviated month name (e.g. Oct). ``%B`` .. versionadded:: 3.10 Full month name (e.g. October). ``%M`` The minute of the current hour (00-59). ``%s`` .. versionadded:: 3.6 Seconds since midnight (UTC) 1-Jan-1970 (UNIX time). ``%S`` The second of the current minute. 60 represents a leap second. (00-60) ``%f`` .. versionadded:: 3.23 The microsecond of the current second (000000-999999). ``%U`` The week number of the current year (00-53). ``%V`` .. versionadded:: 3.22 The ISO 8601 week number of the current year (01-53). ``%w`` The day of the current week. 0 is Sunday. (0-6) ``%a`` .. versionadded:: 3.7 Abbreviated weekday name (e.g. Fri). ``%A`` .. versionadded:: 3.10 Full weekday name (e.g. Friday). ``%y`` The last two digits of the current year (00-99). ``%Y`` The current year. ``%z`` .. versionadded:: 3.26 The offset of the time zone from UTC, in hours and minutes, with format ``+hhmm`` or ``-hhmm``. ``%Z`` .. versionadded:: 3.26 The time zone name. Unknown format specifiers will be ignored and copied to the output as-is. If no explicit ``<format_string>`` is given, it will default to: :: %Y-%m-%dT%H:%M:%S for local time. %Y-%m-%dT%H:%M:%SZ for UTC. .. versionadded:: 3.8 If the ``SOURCE_DATE_EPOCH`` environment variable is set, its value will be used instead of the current time. See https://reproducible-builds.org/specs/source-date-epoch/ for details.",
+      "string(UUID <output_variable> NAMESPACE <namespace> NAME <name> TYPE <MD5|SHA1> [UPPER]) .. versionadded:: 3.1 Create a universally unique identifier (aka GUID) as per RFC4122 based on the hash of the combined values of ``<namespace>`` (which itself has to be a valid UUID) and ``<name>``. The hash algorithm can be either ``MD5`` (Version 3 UUID) or ``SHA1`` (Version 5 UUID). A UUID has the format ``xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx`` where each ``x`` represents a lower case hexadecimal character. Where required, an uppercase representation can be requested with the optional ``UPPER`` flag.",
+      "string(JSON <out-var> [ERROR_VARIABLE <error-variable>] GET <json-string> <member|index> [<member|index> ...]) :target: JSON GET Get an element from ``<json-string>`` at the location given by the list of ``<member|index>`` arguments. Array and object elements will be returned as a JSON string. Boolean elements will be returned as ``ON`` or ``OFF``. Null elements will be returned as an empty string. Number and string types will be returned as strings.",
+      "string(JSON <out-var> [ERROR_VARIABLE <error-variable>] TYPE <json-string> <member|index> [<member|index> ...]) :target: JSON TYPE Get the type of an element in ``<json-string>`` at the location given by the list of ``<member|index>`` arguments. The ``<out-var>`` will be set to one of ``NULL``, ``NUMBER``, ``STRING``, ``BOOLEAN``, ``ARRAY``, or ``OBJECT``.",
+      "string(JSON <out-var> [ERROR_VARIABLE <error-var>] MEMBER <json-string> [<member|index> ...] <index>) :target: JSON MEMBER Get the name of the ``<index>``-th member in ``<json-string>`` at the location given by the list of ``<member|index>`` arguments. Requires an element of object type.",
+      "string(JSON <out-var> [ERROR_VARIABLE <error-variable>] LENGTH <json-string> [<member|index> ...]) :target: JSON LENGTH Get the length of an element in ``<json-string>`` at the location given by the list of ``<member|index>`` arguments. Requires an element of array or object type.",
+      "string(JSON <out-var> [ERROR_VARIABLE <error-variable>] REMOVE <json-string> <member|index> [<member|index> ...]) :target: JSON REMOVE Remove an element from ``<json-string>`` at the location given by the list of ``<member|index>`` arguments. The JSON string without the removed element will be stored in ``<out-var>``.",
+      "string(JSON <out-var> [ERROR_VARIABLE <error-variable>] SET <json-string> <member|index> [<member|index> ...] <value>) :target: JSON SET Set an element in ``<json-string>`` at the location given by the list of ``<member|index>`` arguments to ``<value>``. The contents of ``<value>`` should be valid JSON. If ``<json-string>`` is an array, ``<value>`` can be appended to the end of the array by using a number greater or equal to the array length as the ``<member|index>`` argument.",
+      "string(JSON <out-var> [ERROR_VARIABLE <error-var>] EQUAL <json-string1> <json-string2>) :target: JSON EQUAL Compare the two JSON objects given by ``<json-string1>`` and ``<json-string2>`` for equality. The contents of ``<json-string1>`` and ``<json-string2>`` should be valid JSON. The ``<out-var>`` will be set to a true value if the JSON objects are considered equal, or a false value otherwise."
+    ]
+  },
+  "subdirs": {
+    "name": "subdirs",
+    "description": "Add a list of subdirectories to the build.",
+    "syntax_examples": [
+      "subdirs(dir1 dir2 ...[EXCLUDE_FROM_ALL exclude_dir1 exclude_dir2 ...] [PREORDER])"
+    ]
+  },
+  "subdir_depends": {
+    "name": "subdir_depends",
+    "description": "Disallowed since version 3.0. See CMake Policy CMP0029.",
+    "syntax_examples": ["subdir_depends(subdir dep1 dep2 ...)"]
+  },
+  "target_compile_definitions": {
+    "name": "target_compile_definitions",
+    "description": "Add compile definitions to a target.",
+    "syntax_examples": [
+      "target_compile_definitions(<target> <INTERFACE|PUBLIC|PRIVATE> [items1...] [<INTERFACE|PUBLIC|PRIVATE> [items2...] ...])",
+      "target_compile_definitions(foo PUBLIC FOO) target_compile_definitions(foo PUBLIC -DFOO) target_compile_definitions(foo PUBLIC \"\" FOO) target_compile_definitions(foo PUBLIC -D FOO)",
+      "target_compile_definitions(foo PUBLIC FOO=1)"
+    ]
+  },
+  "target_compile_features": {
+    "name": "target_compile_features",
+    "description": "Add expected compiler features to a target.",
+    "syntax_examples": [
+      "target_compile_features(<target> <PRIVATE|PUBLIC|INTERFACE> <feature> [...])"
+    ]
+  },
+  "target_compile_options": {
+    "name": "target_compile_options",
+    "description": "Add compile options to a target.",
+    "syntax_examples": [
+      "target_compile_options(<target> [BEFORE] <INTERFACE|PUBLIC|PRIVATE> [items1...] [<INTERFACE|PUBLIC|PRIVATE> [items2...] ...])"
+    ]
+  },
+  "target_include_directories": {
+    "name": "target_include_directories",
+    "description": "Add include directories to a target.",
+    "syntax_examples": [
+      "target_include_directories(<target> [SYSTEM] [BEFORE] <INTERFACE|PUBLIC|PRIVATE> [items1...] [<INTERFACE|PUBLIC|PRIVATE> [items2...] ...])",
+      "target_include_directories(mylib PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/mylib> $<INSTALL_INTERFACE:include/mylib>)"
+    ]
+  },
+  "target_link_directories": {
+    "name": "target_link_directories",
+    "description": "Add link directories to a target.",
+    "syntax_examples": [
+      "target_link_directories(<target> [BEFORE] <INTERFACE|PUBLIC|PRIVATE> [items1...] [<INTERFACE|PUBLIC|PRIVATE> [items2...] ...])"
+    ]
+  },
+  "target_link_libraries": {
+    "name": "target_link_libraries",
+    "description": "Specify libraries or flags to use when linking a given target and/or its dependents. Usage requirements  from linked library targets will be propagated. Usage requirements of a target's dependencies affect compilation of its own sources.",
+    "syntax_examples": [
+      "target_link_libraries(<target> ... <item>... ...)",
+      "target_link_libraries(<target> <PRIVATE|PUBLIC|INTERFACE> <item>... [<PRIVATE|PUBLIC|INTERFACE> <item>...]...)",
+      "target_link_libraries(<target> <item>...)",
+      "target_link_libraries(<target> <LINK_PRIVATE|LINK_PUBLIC> <lib>... [<LINK_PRIVATE|LINK_PUBLIC> <lib>...]...)",
+      "target_link_libraries(<target> LINK_INTERFACE_LIBRARIES <item>...)"
+    ]
+  },
+  "target_link_options": {
+    "name": "target_link_options",
+    "description": "Add options to the link step for an executable, shared library or module library target.",
+    "syntax_examples": [
+      "target_link_options(<target> [BEFORE] <INTERFACE|PUBLIC|PRIVATE> [items1...] [<INTERFACE|PUBLIC|PRIVATE> [items2...] ...])"
+    ]
+  },
+  "target_precompile_headers": {
+    "name": "target_precompile_headers",
+    "description": "Add a list of header files to precompile.",
+    "syntax_examples": [
+      "target_precompile_headers(<target> <INTERFACE|PUBLIC|PRIVATE> [header1...] [<INTERFACE|PUBLIC|PRIVATE> [header2...] ...])",
+      "target_precompile_headers(myTarget PUBLIC project_header.h PRIVATE [[\"other_header.h\"]] <unordered_map>)",
+      "target_precompile_headers(mylib PRIVATE \"$<$<COMPILE_LANGUAGE:CXX>:${CMAKE_CURRENT_SOURCE_DIR}/cxx_only.h>\" \"$<$<COMPILE_LANGUAGE:C>:<stddef.h$<ANGLE-R>>\" \"$<$<COMPILE_LANGUAGE:CXX>:<cstddef$<ANGLE-R>>\" )",
+      "target_precompile_headers(<target> REUSE_FROM <other_target>)"
+    ]
+  },
+  "target_sources": {
+    "name": "target_sources",
+    "description": "Add sources to a target.",
+    "syntax_examples": [
+      "target_sources(<target> <INTERFACE|PUBLIC|PRIVATE> [items1...] [<INTERFACE|PUBLIC|PRIVATE> [items2...] ...])",
+      "target_sources(MyTarget PRIVATE \"$<$<CONFIG:Debug>:dbgsrc.cpp>\") target_sources(MyTarget PRIVATE \"$<$<CONFIG:Debug>:${CMAKE_CURRENT_SOURCE_DIR}/dbgsrc.cpp>\")",
+      "target_sources(<target> [<INTERFACE|PUBLIC|PRIVATE> [FILE_SET <set> [TYPE <type>] [BASE_DIRS <dirs>...] [FILES <files>...]]... ]...)"
+    ]
+  },
+  "try_compile": {
+    "name": "try_compile",
+    "description": "Try building some code.",
+    "syntax_examples": [
+      "try_compile(<compileResultVar> PROJECT <projectName> SOURCE_DIR <srcdir> [BINARY_DIR <bindir>] [TARGET <targetName>] [LOG_DESCRIPTION <text>] [NO_CACHE] [NO_LOG] [CMAKE_FLAGS <flags>...] [OUTPUT_VARIABLE <var>])",
+      "try_compile(<compileResultVar> <bindir> <srcdir> <projectName> [<targetName>] [CMAKE_FLAGS <flags>...] [OUTPUT_VARIABLE <var>])",
+      "try_compile(<compileResultVar> [SOURCES_TYPE <type>] <SOURCES <srcfile...> | SOURCE_FROM_CONTENT <name> <content> | SOURCE_FROM_VAR <name> <var> | SOURCE_FROM_FILE <name> <path>>... [LOG_DESCRIPTION <text>] [NO_CACHE] [NO_LOG] [CMAKE_FLAGS <flags>...] [COMPILE_DEFINITIONS <defs>...] [LINK_OPTIONS <options>...] [LINK_LIBRARIES <libs>...] [LINKER_LANGUAGE <lang>] [OUTPUT_VARIABLE <var>] [COPY_FILE <fileName> [COPY_FILE_ERROR <var>]] [<LANG>_STANDARD <std>] [<LANG>_STANDARD_REQUIRED <bool>] [<LANG>_EXTENSIONS <bool>])",
+      "try_compile(<compileResultVar> <bindir> <srcfile|SOURCES srcfile...> [CMAKE_FLAGS <flags>...] [COMPILE_DEFINITIONS <defs>...] [LINK_OPTIONS <options>...] [LINK_LIBRARIES <libs>...] [OUTPUT_VARIABLE <var>] [COPY_FILE <fileName> [COPY_FILE_ERROR <var>]] [<LANG>_STANDARD <std>] [<LANG>_STANDARD_REQUIRED <bool>] [<LANG>_EXTENSIONS <bool>])"
+    ]
+  },
+  "try_run": {
+    "name": "try_run",
+    "description": "Try compiling and then running some code.",
+    "syntax_examples": [
+      "try_run(<runResultVar> <compileResultVar> [SOURCES_TYPE <type>] <SOURCES <srcfile...> | SOURCE_FROM_CONTENT <name> <content> | SOURCE_FROM_VAR <name> <var> | SOURCE_FROM_FILE <name> <path>>... [LOG_DESCRIPTION <text>] [NO_CACHE] [NO_LOG] [CMAKE_FLAGS <flags>...] [COMPILE_DEFINITIONS <defs>...] [LINK_OPTIONS <options>...] [LINK_LIBRARIES <libs>...] [COMPILE_OUTPUT_VARIABLE <var>] [COPY_FILE <fileName> [COPY_FILE_ERROR <var>]] [<LANG>_STANDARD <std>] [<LANG>_STANDARD_REQUIRED <bool>] [<LANG>_EXTENSIONS <bool>] [RUN_OUTPUT_VARIABLE <var>] [RUN_OUTPUT_STDOUT_VARIABLE <var>] [RUN_OUTPUT_STDERR_VARIABLE <var>] [WORKING_DIRECTORY <var>] [ARGS <args>...])",
+      "try_run(<runResultVar> <compileResultVar> <bindir> <srcfile|SOURCES srcfile...> [CMAKE_FLAGS <flags>...] [COMPILE_DEFINITIONS <defs>...] [LINK_OPTIONS <options>...] [LINK_LIBRARIES <libs>...] [LINKER_LANGUAGE <lang>] [COMPILE_OUTPUT_VARIABLE <var>] [COPY_FILE <fileName> [COPY_FILE_ERROR <var>]] [<LANG>_STANDARD <std>] [<LANG>_STANDARD_REQUIRED <bool>] [<LANG>_EXTENSIONS <bool>] [RUN_OUTPUT_VARIABLE <var>] [OUTPUT_VARIABLE <var>] [WORKING_DIRECTORY <var>] [ARGS <args>...])"
+    ]
+  },
+  "unset": {
+    "name": "unset",
+    "description": "Unset a variable, cache variable, or environment variable.",
+    "syntax_examples": [
+      "unset(<variable> [CACHE | PARENT_SCOPE])",
+      "unset(ENV{<variable>})"
+    ]
+  },
+  "use_mangled_mesa": {
+    "name": "use_mangled_mesa",
+    "description": "Disallowed since version 3.0. See CMake Policy CMP0030.",
+    "syntax_examples": ["use_mangled_mesa(PATH_TO_MESA OUTPUT_DIRECTORY)"]
+  },
+  "utility_source": {
+    "name": "utility_source",
+    "description": "Disallowed since version 3.0. See CMake Policy CMP0034.",
+    "syntax_examples": [
+      "utility_source(cache_entry executable_name path_to_source [file1 file2 ...])"
+    ]
+  },
+  "variable_requires": {
+    "name": "variable_requires",
+    "description": "Disallowed since version 3.0. See CMake Policy CMP0035.",
+    "syntax_examples": [
+      "variable_requires(TEST_VARIABLE RESULT_VARIABLE REQUIRED_VARIABLE1 REQUIRED_VARIABLE2 ...)"
+    ]
+  },
+  "variable_watch": {
+    "name": "variable_watch",
+    "description": "Watch the CMake variable for change.",
+    "syntax_examples": ["variable_watch(<variable> [<command>])"]
+  },
+  "while": {
+    "name": "while",
+    "description": "Evaluate a group of commands while a condition is true",
+    "syntax_examples": ["while(<condition>) <commands> endwhile()"]
+  },
+  "write_file": {
+    "name": "write_file",
+    "description": "The first argument is the file name, the rest of the arguments are messages to write. If the argument APPEND is specified, then the message will be appended.",
+    "syntax_examples": ["write_file(filename \"message to write\"... [APPEND])"]
+  }
+}

--- a/assets/modules.json
+++ b/assets/modules.json
@@ -1,0 +1,1015 @@
+{
+    "AddFileDependencies": {
+        "name": "AddFileDependencies",
+        "description": "Add dependencies to a source file."
+    },
+    "AndroidTestUtilities": {
+        "name": "AndroidTestUtilities",
+        "description": "Create a test that automatically loads specified data onto an Android device."
+    },
+    "BundleUtilities": {
+        "name": "BundleUtilities",
+        "description": "Functions to help assemble a standalone bundle application."
+    },
+    "CheckCCompilerFlag": {
+        "name": "CheckCCompilerFlag",
+        "description": "Check whether the C compiler supports a given flag."
+    },
+    "CheckCompilerFlag": {
+        "name": "CheckCompilerFlag",
+        "description": "Check whether the compiler supports a given flag."
+    },
+    "CheckCSourceCompiles": {
+        "name": "CheckCSourceCompiles",
+        "description": "Check if given C source compiles and links into an executable."
+    },
+    "CheckCSourceRuns": {
+        "name": "CheckCSourceRuns",
+        "description": "Check if given C source compiles and links into an executable and can subsequently be run."
+    },
+    "CheckCXXCompilerFlag": {
+        "name": "CheckCXXCompilerFlag",
+        "description": "Check whether the CXX compiler supports a given flag."
+    },
+    "CheckCXXSourceCompiles": {
+        "name": "CheckCXXSourceCompiles",
+        "description": "Check if given C++ source compiles and links into an executable."
+    },
+    "CheckCXXSourceRuns": {
+        "name": "CheckCXXSourceRuns",
+        "description": "Check if given C++ source compiles and links into an executable and can subsequently be run."
+    },
+    "CheckCXXSymbolExists": {
+        "name": "CheckCXXSymbolExists",
+        "description": "Check if a symbol exists as a function, variable, or macro in C++."
+    },
+    "CheckFortranCompilerFlag": {
+        "name": "CheckFortranCompilerFlag",
+        "description": "Check whether the Fortran compiler supports a given flag."
+    },
+    "CheckFortranFunctionExists": {
+        "name": "CheckFortranFunctionExists",
+        "description": "Check if a Fortran function exists."
+    },
+    "CheckFortranSourceCompiles": {
+        "name": "CheckFortranSourceCompiles",
+        "description": "Check if given Fortran source compiles and links into an executable."
+    },
+    "CheckFortranSourceRuns": {
+        "name": "CheckFortranSourceRuns",
+        "description": "Check if given Fortran source compiles and links into an executable and can subsequently be run."
+    },
+    "CheckFunctionExists": {
+        "name": "CheckFunctionExists",
+        "description": "Check if a C function can be linked"
+    },
+    "CheckIncludeFile": {
+        "name": "CheckIncludeFile",
+        "description": "Provides a macro to check if a header file can be included in C."
+    },
+    "CheckIncludeFileCXX": {
+        "name": "CheckIncludeFileCXX",
+        "description": "Provides a macro to check if a header file can be included in CXX."
+    },
+    "CheckIncludeFiles": {
+        "name": "CheckIncludeFiles",
+        "description": "Provides a macro to check if a list of one or more header files can be included together."
+    },
+    "CheckIPOSupported": {
+        "name": "CheckIPOSupported",
+        "description": "Check whether the compiler supports an interprocedural optimization (IPO/LTO). Use this before enabling the INTERPROCEDURAL_OPTIMIZATION target property."
+    },
+    "CheckLanguage": {
+        "name": "CheckLanguage",
+        "description": "Check whether a language can be enabled by the enable_language or project commands:"
+    },
+    "CheckLibraryExists": {
+        "name": "CheckLibraryExists",
+        "description": "Check if the function exists."
+    },
+    "CheckLinkerFlag": {
+        "name": "CheckLinkerFlag",
+        "description": "Check whether the compiler supports a given link flag."
+    },
+    "CheckOBJCCompilerFlag": {
+        "name": "CheckOBJCCompilerFlag",
+        "description": "Check whether the Objective-C compiler supports a given flag."
+    },
+    "CheckOBJCSourceCompiles": {
+        "name": "CheckOBJCSourceCompiles",
+        "description": "Check if given Objective-C source compiles and links into an executable."
+    },
+    "CheckOBJCSourceRuns": {
+        "name": "CheckOBJCSourceRuns",
+        "description": "Check if given Objective-C source compiles and links into an executable and can subsequently be run."
+    },
+    "CheckOBJCXXCompilerFlag": {
+        "name": "CheckOBJCXXCompilerFlag",
+        "description": "Check whether the Objective-C++ compiler supports a given flag."
+    },
+    "CheckOBJCXXSourceCompiles": {
+        "name": "CheckOBJCXXSourceCompiles",
+        "description": "Check if given Objective-C++ source compiles and links into an executable."
+    },
+    "CheckOBJCXXSourceRuns": {
+        "name": "CheckOBJCXXSourceRuns",
+        "description": "Check if given Objective-C++ source compiles and links into an executable and can subsequently be run."
+    },
+    "CheckPIESupported": {
+        "name": "CheckPIESupported",
+        "description": "Check whether the linker supports Position Independent Code (PIE) or No Position Independent Code (NO_PIE) for executables. Use this to ensure that the POSITION_INDEPENDENT_CODE target property for executables will be honored at link time."
+    },
+    "CheckPrototypeDefinition": {
+        "name": "CheckPrototypeDefinition",
+        "description": "Check if the prototype we expect is correct."
+    },
+    "CheckSourceCompiles": {
+        "name": "CheckSourceCompiles",
+        "description": "Check if given source compiles and links into an executable."
+    },
+    "CheckSourceRuns": {
+        "name": "CheckSourceRuns",
+        "description": "Check if given source compiles and links into an executable and can subsequently be run."
+    },
+    "CheckStructHasMember": {
+        "name": "CheckStructHasMember",
+        "description": "Check if the given struct or class has the specified member variable"
+    },
+    "CheckSymbolExists": {
+        "name": "CheckSymbolExists",
+        "description": "Provides a macro to check if a symbol exists as a function, variable, or macro in C."
+    },
+    "CheckTypeSize": {
+        "name": "CheckTypeSize",
+        "description": "Check sizeof a type"
+    },
+    "CheckVariableExists": {
+        "name": "CheckVariableExists",
+        "description": "Check if the variable exists."
+    },
+    "CMakeAddFortranSubdirectory": {
+        "name": "CMakeAddFortranSubdirectory",
+        "description": "Add a fortran-only subdirectory, find a fortran compiler, and build."
+    },
+    "CMakeBackwardCompatibilityCXX": {
+        "name": "CMakeBackwardCompatibilityCXX",
+        "description": "define a bunch of backwards compatibility variables"
+    },
+    "CMakeDependentOption": {
+        "name": "CMakeDependentOption",
+        "description": "Macro to provide an option dependent on other options."
+    },
+    "CMakeDetermineVSServicePack": {
+        "name": "CMakeDetermineVSServicePack",
+        "description": "The functionality of this module has been superseded by the CMAKE_<LANG>_COMPILER_VERSION variable that contains the compiler version number."
+    },
+    "CMakeExpandImportedTargets": {
+        "name": "CMakeExpandImportedTargets",
+        "description": "This module was once needed to expand imported targets to the underlying libraries they reference on disk for use with the try_compile and try_run commands. These commands now support imported libraries in their LINK_LIBRARIES options (since CMake 2.8.11 for try_compile and since CMake 3.2 for try_run)."
+    },
+    "CMakeFindDependencyMacro": {
+        "name": "CMakeFindDependencyMacro",
+        "description": "TODO: Document me."
+    },
+    "CMakeFindFrameworks": {
+        "name": "CMakeFindFrameworks",
+        "description": "helper module to find OSX frameworks"
+    },
+    "CMakeFindPackageMode": {
+        "name": "CMakeFindPackageMode",
+        "description": "This file is executed by cmake when invoked with --find-package <Find-Package Tool Mode>. It expects that the following variables are set using -D:"
+    },
+    "CMakeForceCompiler": {
+        "name": "CMakeForceCompiler",
+        "description": "The macros provided by this module were once intended for use by cross-compiling toolchain files when CMake was not able to automatically detect the compiler identification. Since the introduction of this module, CMake's compiler identification capabilities have improved and can now be taught to recognize any compiler. Furthermore, the suite of information CMake detects from a compiler is now too extensive to be provided by toolchain files using these macros."
+    },
+    "CMakeGraphVizOptions": {
+        "name": "CMakeGraphVizOptions",
+        "description": "The builtin Graphviz support of CMake."
+    },
+    "CMakePackageConfigHelpers": {
+        "name": "CMakePackageConfigHelpers",
+        "description": "Helper functions for creating config files that can be included by other projects to find and use a package."
+    },
+    "CMakeParseArguments": {
+        "name": "CMakeParseArguments",
+        "description": "This module once implemented the cmake_parse_arguments command that is now implemented natively by CMake. It is now an empty placeholder for compatibility with projects that include it to get the command from CMake 3.4 and lower."
+    },
+    "CMakePrintHelpers": {
+        "name": "CMakePrintHelpers",
+        "description": "Convenience functions for printing properties and variables, useful e.g. for debugging."
+    },
+    "CMakePrintSystemInformation": {
+        "name": "CMakePrintSystemInformation",
+        "description": "Print system information."
+    },
+    "CMakePushCheckState": {
+        "name": "CMakePushCheckState",
+        "description": "This module defines three macros: CMAKE_PUSH_CHECK_STATE() CMAKE_POP_CHECK_STATE() and CMAKE_RESET_CHECK_STATE() These macros can be used to save, restore and reset (i.e., clear contents) the state of the variables CMAKE_REQUIRED_FLAGS, CMAKE_REQUIRED_DEFINITIONS, CMAKE_REQUIRED_LINK_OPTIONS, CMAKE_REQUIRED_LIBRARIES, CMAKE_REQUIRED_INCLUDES and CMAKE_EXTRA_INCLUDE_FILES used by the various Check-files coming with CMake, like e.g. check_function_exists() etc. The variable contents are pushed on a stack, pushing multiple times is supported. This is useful e.g. when executing such tests in a Find-module, where they have to be set, but after the Find-module has been executed they should have the same value as they had before."
+    },
+    "CMakeVerifyManifest": {
+        "name": "CMakeVerifyManifest",
+        "description": "CMakeVerifyManifest.cmake"
+    },
+    "CPack": {
+        "name": "CPack",
+        "description": "Configure generators for binary installers and source packages."
+    },
+    "CPackArchive": {
+        "name": "CPackArchive",
+        "description": "The documentation for the CPack Archive generator has moved here: CPack Archive Generator"
+    },
+    "CPackBundle": {
+        "name": "CPackBundle",
+        "description": "The documentation for the CPack Bundle generator has moved here: CPack Bundle Generator"
+    },
+    "CPackComponent": {
+        "name": "CPackComponent",
+        "description": "Configure components for binary installers and source packages."
+    },
+    "CPackCygwin": {
+        "name": "CPackCygwin",
+        "description": "The documentation for the CPack Cygwin generator has moved here: CPack Cygwin Generator"
+    },
+    "CPackDeb": {
+        "name": "CPackDeb",
+        "description": "The documentation for the CPack DEB generator has moved here: CPack DEB Generator"
+    },
+    "CPackDMG": {
+        "name": "CPackDMG",
+        "description": "The documentation for the CPack DragNDrop generator has moved here: CPack DragNDrop Generator"
+    },
+    "CPackFreeBSD": {
+        "name": "CPackFreeBSD",
+        "description": "The documentation for the CPack FreeBSD generator has moved here: CPack FreeBSD Generator"
+    },
+    "CPackIFW": {
+        "name": "CPackIFW",
+        "description": "This module looks for the location of the command-line utilities supplied with the Qt Installer Framework (QtIFW)."
+    },
+    "CPackIFWConfigureFile": {
+        "name": "CPackIFWConfigureFile",
+        "description": "The module defines configure_file similar command to configure file templates prepared in QtIFW/SDK/Creator style."
+    },
+    "CPackNSIS": {
+        "name": "CPackNSIS",
+        "description": "The documentation for the CPack NSIS generator has moved here: CPack NSIS Generator"
+    },
+    "CPackNuGet": {
+        "name": "CPackNuGet",
+        "description": "The documentation for the CPack NuGet generator has moved here: CPack NuGet Generator"
+    },
+    "CPackProductBuild": {
+        "name": "CPackProductBuild",
+        "description": "The documentation for the CPack productbuild generator has moved here: CPack productbuild Generator"
+    },
+    "CPackRPM": {
+        "name": "CPackRPM",
+        "description": "The documentation for the CPack RPM generator has moved here: CPack RPM Generator"
+    },
+    "CPackWIX": {
+        "name": "CPackWIX",
+        "description": "The documentation for the CPack WIX generator has moved here: CPack WIX Generator"
+    },
+    "CSharpUtilities": {
+        "name": "CSharpUtilities",
+        "description": "Functions to make configuration of CSharp/.NET targets easier."
+    },
+    "CTest": {
+        "name": "CTest",
+        "description": "Configure a project for testing with CTest/CDash"
+    },
+    "CTestCoverageCollectGCOV": {
+        "name": "CTestCoverageCollectGCOV",
+        "description": "This module provides the ctest_coverage_collect_gcov function."
+    },
+    "CTestScriptMode": {
+        "name": "CTestScriptMode",
+        "description": "This file is read by ctest in script mode (-S)"
+    },
+    "CTestUseLaunchers": {
+        "name": "CTestUseLaunchers",
+        "description": "Set the RULE_LAUNCH_* global properties when CTEST_USE_LAUNCHERS is on."
+    },
+    "Dart": {
+        "name": "Dart",
+        "description": "Configure a project for testing with CTest or old Dart Tcl Client"
+    },
+    "DeployQt4": {
+        "name": "DeployQt4",
+        "description": "Functions to help assemble a standalone Qt4 executable."
+    },
+    "Documentation": {
+        "name": "Documentation",
+        "description": "This module provides support for the VTK documentation framework. It relies on several tools (Doxygen, Perl, etc)."
+    },
+    "ExternalData": {
+        "name": "ExternalData",
+        "description": "Manage data files stored outside source tree"
+    },
+    "ExternalProject": {
+        "name": "ExternalProject",
+        "description": "TODO: Document me."
+    },
+    "FeatureSummary": {
+        "name": "FeatureSummary",
+        "description": "Functions for generating a summary of enabled/disabled features."
+    },
+    "FetchContent": {
+        "name": "FetchContent",
+        "description": "TODO: Document me."
+    },
+    "FindALSA": {
+        "name": "FindALSA",
+        "description": "Find Advanced Linux Sound Architecture (ALSA)"
+    },
+    "FindArmadillo": {
+        "name": "FindArmadillo",
+        "description": "Find the Armadillo C++ library. Armadillo is a library for linear algebra & scientific computing."
+    },
+    "FindASPELL": { "name": "FindASPELL", "description": "Try to find ASPELL" },
+    "FindAVIFile": {
+        "name": "FindAVIFile",
+        "description": "Locate AVIFILE library and include paths"
+    },
+    "FindBacktrace": {
+        "name": "FindBacktrace",
+        "description": "Find provider for backtrace(3)."
+    },
+    "FindBISON": {
+        "name": "FindBISON",
+        "description": "Find bison executable and provide a macro to generate custom build rules."
+    },
+    "FindBLAS": {
+        "name": "FindBLAS",
+        "description": "Find Basic Linear Algebra Subprograms (BLAS) library"
+    },
+    "FindBoost": {
+        "name": "FindBoost",
+        "description": "Find Boost include dirs and libraries"
+    },
+    "FindBullet": {
+        "name": "FindBullet",
+        "description": "Try to find the Bullet physics engine"
+    },
+    "FindBZip2": { "name": "FindBZip2", "description": "Try to find BZip2" },
+    "FindCABLE": { "name": "FindCABLE", "description": "Find CABLE" },
+    "FindCoin3D": {
+        "name": "FindCoin3D",
+        "description": "Find Coin3D (Open Inventor)"
+    },
+    "FindCUDA": {
+        "name": "FindCUDA",
+        "description": "It is no longer necessary to use this module or call find_package(CUDA) for compiling CUDA code. Instead, list CUDA among the languages named in the top-level call to the project command, or call the enable_language command with CUDA. Then one can add CUDA (.cu) sources directly to targets similar to other languages."
+    },
+    "FindCUDAToolkit": {
+        "name": "FindCUDAToolkit",
+        "description": "This script locates the NVIDIA CUDA toolkit and the associated libraries, but does not require the CUDA language be enabled for a given project. This module does not search for the NVIDIA CUDA Samples."
+    },
+    "FindCups": {
+        "name": "FindCups",
+        "description": "Find the Common UNIX Printing System (CUPS)."
+    },
+    "FindCURL": {
+        "name": "FindCURL",
+        "description": "Find the native CURL headers and libraries."
+    },
+    "FindCurses": {
+        "name": "FindCurses",
+        "description": "Find the curses or ncurses include file and library."
+    },
+    "FindCVS": {
+        "name": "FindCVS",
+        "description": "Find the Concurrent Versions System (CVS)."
+    },
+    "FindCxxTest": {
+        "name": "FindCxxTest",
+        "description": "Find CxxTest unit testing framework."
+    },
+    "FindCygwin": {
+        "name": "FindCygwin",
+        "description": "Find Cygwin, a POSIX-compatible environment that runs natively on Microsoft Windows"
+    },
+    "FindDart": { "name": "FindDart", "description": "Find DART" },
+    "FindDCMTK": {
+        "name": "FindDCMTK",
+        "description": "Find DICOM ToolKit (DCMTK) libraries and applications"
+    },
+    "FindDevIL": {
+        "name": "FindDevIL",
+        "description": "This module locates the developer's image library. https://openil.sourceforge.net/"
+    },
+    "FindDoxygen": {
+        "name": "FindDoxygen",
+        "description": "Doxygen is a documentation generation tool (see https://www.doxygen.nl). This module looks for Doxygen and some optional tools it supports:"
+    },
+    "FindEnvModules": {
+        "name": "FindEnvModules",
+        "description": "Locate an environment module implementation and make commands available to CMake scripts to use them. This is compatible with both Lua-based Lmod and TCL-based EnvironmentModules."
+    },
+    "FindEXPAT": {
+        "name": "FindEXPAT",
+        "description": "Find the native Expat headers and library. Expat is a stream-oriented XML parser library written in C."
+    },
+    "FindFLEX": {
+        "name": "FindFLEX",
+        "description": "Find Fast Lexical Analyzer (Flex) executable and provides a macro to generate custom build rules"
+    },
+    "FindFLTK": {
+        "name": "FindFLTK",
+        "description": "Find the Fast Light Toolkit (FLTK) library"
+    },
+    "FindFLTK2": {
+        "name": "FindFLTK2",
+        "description": "Find the native FLTK 2.0 includes and library"
+    },
+    "FindFontconfig": {
+        "name": "FindFontconfig",
+        "description": "Find Fontconfig headers and library."
+    },
+    "FindFreetype": {
+        "name": "FindFreetype",
+        "description": "Find the FreeType font renderer includes and library."
+    },
+    "FindGCCXML": {
+        "name": "FindGCCXML",
+        "description": "Find the GCC-XML front-end executable."
+    },
+    "FindGDAL": {
+        "name": "FindGDAL",
+        "description": "Find Geospatial Data Abstraction Library (GDAL)."
+    },
+    "FindGettext": {
+        "name": "FindGettext",
+        "description": "Find GNU gettext tools"
+    },
+    "FindGIF": {
+        "name": "FindGIF",
+        "description": "This finds the Graphics Interchange Format (GIF) library (giflib)"
+    },
+    "FindGit": {
+        "name": "FindGit",
+        "description": "The module defines the following variables:"
+    },
+    "FindGLEW": {
+        "name": "FindGLEW",
+        "description": "Find the OpenGL Extension Wrangler Library (GLEW)"
+    },
+    "FindGLUT": {
+        "name": "FindGLUT",
+        "description": "Find OpenGL Utility Toolkit (GLUT) library and include files."
+    },
+    "FindGnuplot": {
+        "name": "FindGnuplot",
+        "description": "this module looks for gnuplot"
+    },
+    "FindGnuTLS": {
+        "name": "FindGnuTLS",
+        "description": "Find the GNU Transport Layer Security library (gnutls)"
+    },
+    "FindGSL": {
+        "name": "FindGSL",
+        "description": "Find the native GNU Scientific Library (GSL) includes and libraries."
+    },
+    "FindGTest": {
+        "name": "FindGTest",
+        "description": "Locate the Google C++ Testing Framework."
+    },
+    "FindGTK": {
+        "name": "FindGTK",
+        "description": "Find GTK, glib and GTKGLArea"
+    },
+    "FindGTK2": {
+        "name": "FindGTK2",
+        "description": "Find the GTK2 widget libraries and several of its other optional components like gtkmm, glade, and glademm."
+    },
+    "FindHDF5": {
+        "name": "FindHDF5",
+        "description": "Find Hierarchical Data Format (HDF5), a library for reading and writing self describing array data."
+    },
+    "FindHg": {
+        "name": "FindHg",
+        "description": "Extract information from a mercurial working copy."
+    },
+    "FindHSPELL": {
+        "name": "FindHSPELL",
+        "description": "Try to find Hebrew spell-checker (Hspell) and morphology engine."
+    },
+    "FindHTMLHelp": {
+        "name": "FindHTMLHelp",
+        "description": "This module looks for Microsoft HTML Help Compiler"
+    },
+    "FindIce": {
+        "name": "FindIce",
+        "description": "Find the ZeroC Internet Communication Engine (ICE) programs, libraries and datafiles."
+    },
+    "FindIconv": {
+        "name": "FindIconv",
+        "description": "This module finds the iconv() POSIX.1 functions on the system. These functions might be provided in the regular C library or externally in the form of an additional library."
+    },
+    "FindIcotool": { "name": "FindIcotool", "description": "Find icotool" },
+    "FindICU": {
+        "name": "FindICU",
+        "description": "Find the International Components for Unicode (ICU) libraries and programs."
+    },
+    "FindImageMagick": {
+        "name": "FindImageMagick",
+        "description": "Find ImageMagick, software suite for displaying, converting and manipulating raster images."
+    },
+    "FindIntl": {
+        "name": "FindIntl",
+        "description": "Find the Gettext libintl headers and libraries."
+    },
+    "FindITK": {
+        "name": "FindITK",
+        "description": "This module no longer exists."
+    },
+    "FindJasper": {
+        "name": "FindJasper",
+        "description": "Find the Jasper JPEG2000 library."
+    },
+    "FindJava": { "name": "FindJava", "description": "Find Java" },
+    "FindJNI": {
+        "name": "FindJNI",
+        "description": "Find Java Native Interface (JNI) headers and libraries."
+    },
+    "FindJPEG": {
+        "name": "FindJPEG",
+        "description": "Find the Joint Photographic Experts Group (JPEG) library (libjpeg)"
+    },
+    "FindKDE3": {
+        "name": "FindKDE3",
+        "description": "Find the KDE3 include and library dirs, KDE preprocessors and define a some macros"
+    },
+    "FindKDE4": {
+        "name": "FindKDE4",
+        "description": "Find KDE4 and provide all necessary variables and macros to compile software for it. It looks for KDE 4 in the following directories in the given order:"
+    },
+    "FindLAPACK": {
+        "name": "FindLAPACK",
+        "description": "Find Linear Algebra PACKage (LAPACK) library"
+    },
+    "FindLATEX": { "name": "FindLATEX", "description": "Find LaTeX" },
+    "FindLibArchive": {
+        "name": "FindLibArchive",
+        "description": "Find libarchive library and headers. Libarchive is multi-format archive and compression library."
+    },
+    "FindLibinput": {
+        "name": "FindLibinput",
+        "description": "Find libinput headers and library."
+    },
+    "FindLibLZMA": {
+        "name": "FindLibLZMA",
+        "description": "Find LZMA compression algorithm headers and library."
+    },
+    "FindLibXml2": {
+        "name": "FindLibXml2",
+        "description": "Find the XML processing library (libxml2)."
+    },
+    "FindLibXslt": {
+        "name": "FindLibXslt",
+        "description": "Find the XSL Transformations, Extensible Stylesheet Language Transformations (XSLT) library (LibXslt)"
+    },
+    "FindLTTngUST": {
+        "name": "FindLTTngUST",
+        "description": "Find Linux Trace Toolkit Next Generation (LTTng-UST) library."
+    },
+    "FindLua": { "name": "FindLua", "description": "Locate Lua library." },
+    "FindLua50": { "name": "FindLua50", "description": "Locate Lua library." },
+    "FindLua51": {
+        "name": "FindLua51",
+        "description": "Locate Lua library. This module defines:"
+    },
+    "FindMatlab": {
+        "name": "FindMatlab",
+        "description": "Finds Matlab or Matlab Compiler Runtime (MCR) and provides Matlab tools, libraries and compilers to CMake."
+    },
+    "FindMFC": {
+        "name": "FindMFC",
+        "description": "Find Microsoft Foundation Class Library (MFC) on Windows"
+    },
+    "FindMotif": {
+        "name": "FindMotif",
+        "description": "Try to find Motif (or lesstif)"
+    },
+    "FindMPEG": {
+        "name": "FindMPEG",
+        "description": "Find the native MPEG includes and library"
+    },
+    "FindMPEG2": {
+        "name": "FindMPEG2",
+        "description": "Find the native MPEG2 includes and library"
+    },
+    "FindMPI": {
+        "name": "FindMPI",
+        "description": "Find a Message Passing Interface (MPI) implementation."
+    },
+    "FindMsys": {
+        "name": "FindMsys",
+        "description": "Find MSYS, a POSIX-compatible environment that runs natively on Microsoft Windows"
+    },
+    "FindODBC": {
+        "name": "FindODBC",
+        "description": "Find an Open Database Connectivity (ODBC) include directory and library."
+    },
+    "FindOpenACC": {
+        "name": "FindOpenACC",
+        "description": "Detect OpenACC support by the compiler."
+    },
+    "FindOpenAL": {
+        "name": "FindOpenAL",
+        "description": "Finds Open Audio Library (OpenAL)."
+    },
+    "FindOpenCL": {
+        "name": "FindOpenCL",
+        "description": "Finds Open Computing Language (OpenCL)"
+    },
+    "FindOpenGL": {
+        "name": "FindOpenGL",
+        "description": "FindModule for OpenGL and OpenGL Utility Library (GLU)."
+    },
+    "FindOpenMP": {
+        "name": "FindOpenMP",
+        "description": "Finds Open Multi-Processing (OpenMP) support."
+    },
+    "FindOpenSceneGraph": {
+        "name": "FindOpenSceneGraph",
+        "description": "Find OpenSceneGraph (3D graphics application programming interface)"
+    },
+    "FindOpenSP": {
+        "name": "FindOpenSP",
+        "description": "Try to find the OpenSP library."
+    },
+    "FindOpenSSL": {
+        "name": "FindOpenSSL",
+        "description": "Find the OpenSSL encryption library."
+    },
+    "FindOpenThreads": {
+        "name": "FindOpenThreads",
+        "description": "OpenThreads is a C++ based threading library. Its largest userbase seems to OpenSceneGraph so you might notice I accept OSGDIR as an environment path. I consider this part of the Findosg* suite used to find OpenSceneGraph components. Each component is separate and you must opt in to each module."
+    },
+    "Findosg": {
+        "name": "Findosg",
+        "description": "This is part of the Findosg* suite used to find OpenSceneGraph components. Each component is separate and you must opt in to each module. You must also opt into OpenGL and OpenThreads (and Producer if needed) as these modules won't do it for you. This is to allow you control over your own system piece by piece in case you need to opt out of certain components or change the Find behavior for a particular module (perhaps because the default FindOpenGL module doesn't work with your system as an example). If you want to use a more convenient module that includes everything, use the FindOpenSceneGraph instead of the Findosg*.cmake modules."
+    },
+    "FindosgAnimation": {
+        "name": "FindosgAnimation",
+        "description": "This is part of the Findosg* suite used to find OpenSceneGraph components. Each component is separate and you must opt in to each module. You must also opt into OpenGL and OpenThreads (and Producer if needed) as these modules won't do it for you. This is to allow you control over your own system piece by piece in case you need to opt out of certain components or change the Find behavior for a particular module (perhaps because the default FindOpenGL module doesn't work with your system as an example). If you want to use a more convenient module that includes everything, use the FindOpenSceneGraph instead of the Findosg*.cmake modules."
+    },
+    "FindosgDB": {
+        "name": "FindosgDB",
+        "description": "This is part of the Findosg* suite used to find OpenSceneGraph components. Each component is separate and you must opt in to each module. You must also opt into OpenGL and OpenThreads (and Producer if needed) as these modules won't do it for you. This is to allow you control over your own system piece by piece in case you need to opt out of certain components or change the Find behavior for a particular module (perhaps because the default FindOpenGL module doesn't work with your system as an example). If you want to use a more convenient module that includes everything, use the FindOpenSceneGraph instead of the Findosg*.cmake modules."
+    },
+    "FindosgFX": {
+        "name": "FindosgFX",
+        "description": "This is part of the Findosg* suite used to find OpenSceneGraph components. Each component is separate and you must opt in to each module. You must also opt into OpenGL and OpenThreads (and Producer if needed) as these modules won't do it for you. This is to allow you control over your own system piece by piece in case you need to opt out of certain components or change the Find behavior for a particular module (perhaps because the default FindOpenGL module doesn't work with your system as an example). If you want to use a more convenient module that includes everything, use the FindOpenSceneGraph instead of the Findosg*.cmake modules."
+    },
+    "FindosgGA": {
+        "name": "FindosgGA",
+        "description": "This is part of the Findosg* suite used to find OpenSceneGraph components. Each component is separate and you must opt in to each module. You must also opt into OpenGL and OpenThreads (and Producer if needed) as these modules won't do it for you. This is to allow you control over your own system piece by piece in case you need to opt out of certain components or change the Find behavior for a particular module (perhaps because the default FindOpenGL module doesn't work with your system as an example). If you want to use a more convenient module that includes everything, use the FindOpenSceneGraph instead of the Findosg*.cmake modules."
+    },
+    "FindosgIntrospection": {
+        "name": "FindosgIntrospection",
+        "description": "This is part of the Findosg* suite used to find OpenSceneGraph components. Each component is separate and you must opt in to each module. You must also opt into OpenGL and OpenThreads (and Producer if needed) as these modules won't do it for you. This is to allow you control over your own system piece by piece in case you need to opt out of certain components or change the Find behavior for a particular module (perhaps because the default FindOpenGL module doesn't work with your system as an example). If you want to use a more convenient module that includes everything, use the FindOpenSceneGraph instead of the Findosg*.cmake modules."
+    },
+    "FindosgManipulator": {
+        "name": "FindosgManipulator",
+        "description": "This is part of the Findosg* suite used to find OpenSceneGraph components. Each component is separate and you must opt in to each module. You must also opt into OpenGL and OpenThreads (and Producer if needed) as these modules won't do it for you. This is to allow you control over your own system piece by piece in case you need to opt out of certain components or change the Find behavior for a particular module (perhaps because the default FindOpenGL module doesn't work with your system as an example). If you want to use a more convenient module that includes everything, use the FindOpenSceneGraph instead of the Findosg*.cmake modules."
+    },
+    "FindosgParticle": {
+        "name": "FindosgParticle",
+        "description": "This is part of the Findosg* suite used to find OpenSceneGraph components. Each component is separate and you must opt in to each module. You must also opt into OpenGL and OpenThreads (and Producer if needed) as these modules won't do it for you. This is to allow you control over your own system piece by piece in case you need to opt out of certain components or change the Find behavior for a particular module (perhaps because the default FindOpenGL module doesn't work with your system as an example). If you want to use a more convenient module that includes everything, use the FindOpenSceneGraph instead of the Findosg*.cmake modules."
+    },
+    "FindosgPresentation": {
+        "name": "FindosgPresentation",
+        "description": "This is part of the Findosg* suite used to find OpenSceneGraph components. Each component is separate and you must opt in to each module. You must also opt into OpenGL and OpenThreads (and Producer if needed) as these modules won't do it for you. This is to allow you control over your own system piece by piece in case you need to opt out of certain components or change the Find behavior for a particular module (perhaps because the default FindOpenGL module doesn't work with your system as an example). If you want to use a more convenient module that includes everything, use the FindOpenSceneGraph instead of the Findosg*.cmake modules."
+    },
+    "FindosgProducer": {
+        "name": "FindosgProducer",
+        "description": "This is part of the Findosg* suite used to find OpenSceneGraph components. Each component is separate and you must opt in to each module. You must also opt into OpenGL and OpenThreads (and Producer if needed) as these modules won't do it for you. This is to allow you control over your own system piece by piece in case you need to opt out of certain components or change the Find behavior for a particular module (perhaps because the default FindOpenGL module doesn't work with your system as an example). If you want to use a more convenient module that includes everything, use the FindOpenSceneGraph instead of the Findosg*.cmake modules."
+    },
+    "FindosgQt": {
+        "name": "FindosgQt",
+        "description": "This is part of the Findosg* suite used to find OpenSceneGraph components. Each component is separate and you must opt in to each module. You must also opt into OpenGL and OpenThreads (and Producer if needed) as these modules won't do it for you. This is to allow you control over your own system piece by piece in case you need to opt out of certain components or change the Find behavior for a particular module (perhaps because the default FindOpenGL module doesn't work with your system as an example). If you want to use a more convenient module that includes everything, use the FindOpenSceneGraph instead of the Findosg*.cmake modules."
+    },
+    "FindosgShadow": {
+        "name": "FindosgShadow",
+        "description": "This is part of the Findosg* suite used to find OpenSceneGraph components. Each component is separate and you must opt in to each module. You must also opt into OpenGL and OpenThreads (and Producer if needed) as these modules won't do it for you. This is to allow you control over your own system piece by piece in case you need to opt out of certain components or change the Find behavior for a particular module (perhaps because the default FindOpenGL module doesn't work with your system as an example). If you want to use a more convenient module that includes everything, use the FindOpenSceneGraph instead of the Findosg*.cmake modules."
+    },
+    "FindosgSim": {
+        "name": "FindosgSim",
+        "description": "This is part of the Findosg* suite used to find OpenSceneGraph components. Each component is separate and you must opt in to each module. You must also opt into OpenGL and OpenThreads (and Producer if needed) as these modules won't do it for you. This is to allow you control over your own system piece by piece in case you need to opt out of certain components or change the Find behavior for a particular module (perhaps because the default FindOpenGL module doesn't work with your system as an example). If you want to use a more convenient module that includes everything, use the FindOpenSceneGraph instead of the Findosg*.cmake modules."
+    },
+    "FindosgTerrain": {
+        "name": "FindosgTerrain",
+        "description": "This is part of the Findosg* suite used to find OpenSceneGraph components. Each component is separate and you must opt in to each module. You must also opt into OpenGL and OpenThreads (and Producer if needed) as these modules won't do it for you. This is to allow you control over your own system piece by piece in case you need to opt out of certain components or change the Find behavior for a particular module (perhaps because the default FindOpenGL module doesn't work with your system as an example). If you want to use a more convenient module that includes everything, use the FindOpenSceneGraph instead of the Findosg*.cmake modules."
+    },
+    "FindosgText": {
+        "name": "FindosgText",
+        "description": "This is part of the Findosg* suite used to find OpenSceneGraph components. Each component is separate and you must opt in to each module. You must also opt into OpenGL and OpenThreads (and Producer if needed) as these modules won't do it for you. This is to allow you control over your own system piece by piece in case you need to opt out of certain components or change the Find behavior for a particular module (perhaps because the default FindOpenGL module doesn't work with your system as an example). If you want to use a more convenient module that includes everything, use the FindOpenSceneGraph instead of the Findosg*.cmake modules."
+    },
+    "FindosgUtil": {
+        "name": "FindosgUtil",
+        "description": "This is part of the Findosg* suite used to find OpenSceneGraph components. Each component is separate and you must opt in to each module. You must also opt into OpenGL and OpenThreads (and Producer if needed) as these modules won't do it for you. This is to allow you control over your own system piece by piece in case you need to opt out of certain components or change the Find behavior for a particular module (perhaps because the default FindOpenGL module doesn't work with your system as an example). If you want to use a more convenient module that includes everything, use the FindOpenSceneGraph instead of the Findosg*.cmake modules."
+    },
+    "FindosgViewer": {
+        "name": "FindosgViewer",
+        "description": "This is part of the Findosg* suite used to find OpenSceneGraph components. Each component is separate and you must opt in to each module. You must also opt into OpenGL and OpenThreads (and Producer if needed) as these modules won't do it for you. This is to allow you control over your own system piece by piece in case you need to opt out of certain components or change the Find behavior for a particular module (perhaps because the default FindOpenGL module doesn't work with your system as an example). If you want to use a more convenient module that includes everything, use the FindOpenSceneGraph instead of the Findosg*.cmake modules."
+    },
+    "FindosgVolume": {
+        "name": "FindosgVolume",
+        "description": "This is part of the Findosg* suite used to find OpenSceneGraph components. Each component is separate and you must opt in to each module. You must also opt into OpenGL and OpenThreads (and Producer if needed) as these modules won't do it for you. This is to allow you control over your own system piece by piece in case you need to opt out of certain components or change the Find behavior for a particular module (perhaps because the default FindOpenGL module doesn't work with your system as an example). If you want to use a more convenient module that includes everything, use the FindOpenSceneGraph instead of the Findosg*.cmake modules."
+    },
+    "FindosgWidget": {
+        "name": "FindosgWidget",
+        "description": "This is part of the Findosg* suite used to find OpenSceneGraph components. Each component is separate and you must opt in to each module. You must also opt into OpenGL and OpenThreads (and Producer if needed) as these modules won't do it for you. This is to allow you control over your own system piece by piece in case you need to opt out of certain components or change the Find behavior for a particular module (perhaps because the default FindOpenGL module doesn't work with your system as an example). If you want to use a more convenient module that includes everything, use the FindOpenSceneGraph instead of the Findosg*.cmake modules."
+    },
+    "Findosg_functions": {
+        "name": "Findosg_functions",
+        "description": "This CMake file contains two macros to assist with searching for OSG libraries and nodekits. Please see FindOpenSceneGraph for full documentation."
+    },
+    "FindPackageHandleStandardArgs": {
+        "name": "FindPackageHandleStandardArgs",
+        "description": "This module provides functions intended to be used in Find Modules implementing find_package(<PackageName>) calls."
+    },
+    "FindPackageMessage": {
+        "name": "FindPackageMessage",
+        "description": "This function is intended to be used in FindXXX.cmake modules files. It will print a message once for each unique find result. This is useful for telling the user where a package was found. The first argument specifies the name (XXX) of the package. The second argument specifies the message to display. The third argument lists details about the find result so that if they change the message will be displayed again. The macro also obeys the QUIET argument to the find_package command."
+    },
+    "FindPatch": {
+        "name": "FindPatch",
+        "description": "The module defines the following variables:"
+    },
+    "FindPerl": {
+        "name": "FindPerl",
+        "description": "Find a Perl interpreter."
+    },
+    "FindPerlLibs": {
+        "name": "FindPerlLibs",
+        "description": "Find Perl libraries"
+    },
+    "FindPHP4": { "name": "FindPHP4", "description": "Find PHP4" },
+    "FindPhysFS": {
+        "name": "FindPhysFS",
+        "description": "Locate PhysFS library This module defines:"
+    },
+    "FindPike": { "name": "FindPike", "description": "Find Pike" },
+    "FindPkgConfig": {
+        "name": "FindPkgConfig",
+        "description": "A pkg-config module for CMake."
+    },
+    "FindPNG": {
+        "name": "FindPNG",
+        "description": "Find libpng, the official reference library for the PNG image format."
+    },
+    "FindPostgreSQL": {
+        "name": "FindPostgreSQL",
+        "description": "Find the PostgreSQL installation."
+    },
+    "FindProducer": {
+        "name": "FindProducer",
+        "description": "Though Producer isn't directly part of OpenSceneGraph, its primary user is OSG so I consider this part of the Findosg* suite used to find OpenSceneGraph components. You'll notice that I accept OSGDIR as an environment path."
+    },
+    "FindProtobuf": {
+        "name": "FindProtobuf",
+        "description": "Locate and configure the Google Protocol Buffers library."
+    },
+    "FindPython": {
+        "name": "FindPython",
+        "description": "Find Python interpreter, compiler and development environment (include directories and libraries)."
+    },
+    "FindPython2": {
+        "name": "FindPython2",
+        "description": "Find Python 2 interpreter, compiler and development environment (include directories and libraries)."
+    },
+    "FindPython3": {
+        "name": "FindPython3",
+        "description": "Find Python 3 interpreter, compiler and development environment (include directories and libraries)."
+    },
+    "FindPythonInterp": {
+        "name": "FindPythonInterp",
+        "description": "Find python interpreter"
+    },
+    "FindPythonLibs": {
+        "name": "FindPythonLibs",
+        "description": "Find python libraries"
+    },
+    "FindQt": {
+        "name": "FindQt",
+        "description": "Searches for all installed versions of Qt3 or Qt4."
+    },
+    "FindQt3": {
+        "name": "FindQt3",
+        "description": "Locate Qt include paths and libraries"
+    },
+    "FindQt4": { "name": "FindQt4", "description": "TODO: Document me." },
+    "FindQuickTime": {
+        "name": "FindQuickTime",
+        "description": "Locate QuickTime This module defines:"
+    },
+    "FindRTI": {
+        "name": "FindRTI",
+        "description": "Try to find M&S HLA RTI libraries"
+    },
+    "FindRuby": { "name": "FindRuby", "description": "Find Ruby" },
+    "FindSDL": { "name": "FindSDL", "description": "Locate the SDL library" },
+    "FindSDL_gfx": {
+        "name": "FindSDL_gfx",
+        "description": "Locate SDL_gfx library"
+    },
+    "FindSDL_image": {
+        "name": "FindSDL_image",
+        "description": "Locate SDL_image library"
+    },
+    "FindSDL_mixer": {
+        "name": "FindSDL_mixer",
+        "description": "Locate SDL_mixer library"
+    },
+    "FindSDL_net": {
+        "name": "FindSDL_net",
+        "description": "Locate SDL_net library"
+    },
+    "FindSDL_sound": {
+        "name": "FindSDL_sound",
+        "description": "Locates the SDL_sound library"
+    },
+    "FindSDL_ttf": {
+        "name": "FindSDL_ttf",
+        "description": "Locate SDL_ttf library"
+    },
+    "FindSelfPackers": { "name": "FindSelfPackers", "description": "Find upx" },
+    "FindSQLite3": {
+        "name": "FindSQLite3",
+        "description": "Find the SQLite libraries, v3"
+    },
+    "FindSquish": { "name": "FindSquish", "description": "-- Typical Use" },
+    "FindSubversion": {
+        "name": "FindSubversion",
+        "description": "Extract information from a subversion working copy"
+    },
+    "FindSWIG": {
+        "name": "FindSWIG",
+        "description": "Find the Simplified Wrapper and Interface Generator (SWIG) executable."
+    },
+    "FindTCL": {
+        "name": "FindTCL",
+        "description": "TK_INTERNAL_PATH was removed."
+    },
+    "FindTclsh": { "name": "FindTclsh", "description": "Find tclsh" },
+    "FindTclStub": {
+        "name": "FindTclStub",
+        "description": "TCL_STUB_LIBRARY_DEBUG and TK_STUB_LIBRARY_DEBUG were removed."
+    },
+    "FindThreads": {
+        "name": "FindThreads",
+        "description": "This module determines the thread library of the system."
+    },
+    "FindTIFF": {
+        "name": "FindTIFF",
+        "description": "Find the TIFF library (libtiff, https://libtiff.gitlab.io/libtiff/)."
+    },
+    "FindUnixCommands": {
+        "name": "FindUnixCommands",
+        "description": "Find Unix commands, including the ones from Cygwin"
+    },
+    "FindVTK": {
+        "name": "FindVTK",
+        "description": "This module no longer exists."
+    },
+    "FindVulkan": {
+        "name": "FindVulkan",
+        "description": "Find Vulkan, which is a low-overhead, cross-platform 3D graphics and computing API."
+    },
+    "FindWget": { "name": "FindWget", "description": "Find wget" },
+    "FindWish": { "name": "FindWish", "description": "Find wish installation" },
+    "FindwxWidgets": {
+        "name": "FindwxWidgets",
+        "description": "Find a wxWidgets (a.k.a., wxWindows) installation."
+    },
+    "FindwxWindows": {
+        "name": "FindwxWindows",
+        "description": "Find wxWindows (wxWidgets) installation"
+    },
+    "FindX11": { "name": "FindX11", "description": "Find X11 installation" },
+    "FindXalanC": {
+        "name": "FindXalanC",
+        "description": "Find the Apache Xalan-C++ XSL transform processor headers and libraries."
+    },
+    "FindXCTest": {
+        "name": "FindXCTest",
+        "description": "Functions to help creating and executing XCTest bundles."
+    },
+    "FindXercesC": {
+        "name": "FindXercesC",
+        "description": "Find the Apache Xerces-C++ validating XML parser headers and libraries."
+    },
+    "FindXMLRPC": { "name": "FindXMLRPC", "description": "Find xmlrpc" },
+    "FindZLIB": {
+        "name": "FindZLIB",
+        "description": "Find the native ZLIB includes and library."
+    },
+    "FortranCInterface": {
+        "name": "FortranCInterface",
+        "description": "Fortran/C Interface Detection"
+    },
+    "GenerateExportHeader": {
+        "name": "GenerateExportHeader",
+        "description": "Function for generation of export macros for libraries"
+    },
+    "GetPrerequisites": {
+        "name": "GetPrerequisites",
+        "description": "Functions to analyze and list executable file prerequisites."
+    },
+    "GNUInstallDirs": {
+        "name": "GNUInstallDirs",
+        "description": "Define GNU standard installation directories"
+    },
+    "GoogleTest": {
+        "name": "GoogleTest",
+        "description": "This module defines functions to help use the Google Test infrastructure. Two mechanisms for adding tests are provided. gtest_add_tests has been around for some time, originally via find_package(GTest). gtest_discover_tests was introduced in CMake 3.10."
+    },
+    "InstallRequiredSystemLibraries": {
+        "name": "InstallRequiredSystemLibraries",
+        "description": "Include this module to search for compiler-provided system runtime libraries and add install rules for them. Some optional variables may be set prior to including the module to adjust behavior:"
+    },
+    "MacroAddFileDependencies": {
+        "name": "MacroAddFileDependencies",
+        "description": "Do not use this command in new code. It is just a wrapper around:"
+    },
+    "ProcessorCount": {
+        "name": "ProcessorCount",
+        "description": "ProcessorCount(var)"
+    },
+    "SelectLibraryConfigurations": {
+        "name": "SelectLibraryConfigurations",
+        "description": "This macro takes a library base name as an argument, and will choose good values for the variables"
+    },
+    "SquishTestScript": {
+        "name": "SquishTestScript",
+        "description": "This script launches a GUI test using Squish. You should not call the script directly; instead, you should access it via the SQUISH_ADD_TEST macro that is defined in FindSquish.cmake."
+    },
+    "TestBigEndian": {
+        "name": "TestBigEndian",
+        "description": "Check if the target architecture is big endian or little endian."
+    },
+    "TestCXXAcceptsFlag": {
+        "name": "TestCXXAcceptsFlag",
+        "description": "Check if the CXX compiler accepts a flag."
+    },
+    "TestForANSIForScope": {
+        "name": "TestForANSIForScope",
+        "description": "Check for ANSI for scope support"
+    },
+    "TestForANSIStreamHeaders": {
+        "name": "TestForANSIStreamHeaders",
+        "description": "Test for compiler support of ANSI stream headers iostream, etc."
+    },
+    "TestForSSTREAM": {
+        "name": "TestForSSTREAM",
+        "description": "Test for compiler support of ANSI sstream header"
+    },
+    "TestForSTDNamespace": {
+        "name": "TestForSTDNamespace",
+        "description": "Test for std:: namespace support"
+    },
+    "UseEcos": {
+        "name": "UseEcos",
+        "description": "This module defines variables and macros required to build eCos application."
+    },
+    "UseJava": {
+        "name": "UseJava",
+        "description": "This file provides support for Java. It is assumed that FindJava has already been loaded. See FindJava for information on how to load Java into your CMake project."
+    },
+    "UseJavaClassFilelist": {
+        "name": "UseJavaClassFilelist",
+        "description": "This module was previously documented by mistake and was never meant for direct inclusion by project code.  See the :module:`UseJava` module."
+    },
+    "UseJavaSymlinks": {
+        "name": "UseJavaSymlinks",
+        "description": "This module was previously documented by mistake and was never meant for direct inclusion by project code.  See the :module:`UseJava` module."
+    },
+    "UsePkgConfig": {
+        "name": "UsePkgConfig",
+        "description": "Obsolete pkg-config module for CMake, use FindPkgConfig instead."
+    },
+    "UseSWIG": {
+        "name": "UseSWIG",
+        "description": "This file provides support for SWIG. It is assumed that FindSWIG module has already been loaded."
+    },
+    "UsewxWidgets": {
+        "name": "UsewxWidgets",
+        "description": "Convenience include for using wxWidgets library."
+    },
+    "Use_wxWindows": {
+        "name": "Use_wxWindows",
+        "description": "This convenience include finds if wxWindows is installed and set the appropriate libs, incdirs, flags etc. author Jan Woetzel <jw -at- mip.informatik.uni-kiel.de> (07/2003)"
+    },
+    "WriteBasicConfigVersionFile": {
+        "name": "WriteBasicConfigVersionFile",
+        "description": "TODO: Document me."
+    },
+    "WriteCompilerDetectionHeader": {
+        "name": "WriteCompilerDetectionHeader",
+        "description": "This module provides the function write_compiler_detection_header()."
+    }
+}

--- a/assets/variables.json
+++ b/assets/variables.json
@@ -1,0 +1,5035 @@
+{
+  "ANDROID": {
+    "name": "ANDROID",
+    "description": "Set to 1 when the target system (CMAKE_SYSTEM_NAME) is Android."
+  },
+  "APPLE": {
+    "name": "APPLE",
+    "description": "Set to True when the target system is an Apple platform (macOS, iOS, tvOS, visionOS or watchOS)."
+  },
+  "BORLAND": {
+    "name": "BORLAND",
+    "description": "True if the Borland compiler is being used."
+  },
+  "BSD": {
+    "name": "BSD",
+    "description": "Set to a string value when the target system is BSD. This value can be one of the following: DragonFlyBSD, FreeBSD, OpenBSD, or NetBSD."
+  },
+  "BUILD_SHARED_LIBS": {
+    "name": "BUILD_SHARED_LIBS",
+    "description": "Tell add_library to default to SHARED libraries, instead of STATIC libraries, when called with no explicit library type."
+  },
+  "CACHE": {
+    "name": "CACHE",
+    "description": "Operator to read cache variables."
+  },
+  "CMAKE_ABSOLUTE_DESTINATION_FILES": {
+    "name": "CMAKE_ABSOLUTE_DESTINATION_FILES",
+    "description": "List of files which have been installed using an ABSOLUTE DESTINATION path."
+  },
+  "CMAKE_ADD_CUSTOM_COMMAND_DEPENDS_EXPLICIT_ONLY": {
+    "name": "CMAKE_ADD_CUSTOM_COMMAND_DEPENDS_EXPLICIT_ONLY",
+    "description": "Whether to enable the DEPENDS_EXPLICIT_ONLY option by default in add_custom_command."
+  },
+  "CMAKE_ADSP_ROOT": {
+    "name": "CMAKE_ADSP_ROOT",
+    "description": "When :ref:`Cross Compiling for ADSP SHARC/Blackfin`, this variable holds the absolute path to the latest CCES or VDSP++ install. The directory is expected to contain the cc21k.exe and ccblkfn.exe compilers. This will be set automatically if a default install of CCES or VDSP++ can be found."
+  },
+  "CMAKE_AIX_EXPORT_ALL_SYMBOLS": {
+    "name": "CMAKE_AIX_EXPORT_ALL_SYMBOLS",
+    "description": "Default value for AIX_EXPORT_ALL_SYMBOLS target property. This variable is used to initialize the property on each target as it is created."
+  },
+  "CMAKE_ANDROID_ANT_ADDITIONAL_OPTIONS": {
+    "name": "CMAKE_ANDROID_ANT_ADDITIONAL_OPTIONS",
+    "description": "Default value for the ANDROID_ANT_ADDITIONAL_OPTIONS target property. See that target property for additional information."
+  },
+  "CMAKE_ANDROID_API": {
+    "name": "CMAKE_ANDROID_API",
+    "description": "When Cross Compiling for Android with NVIDIA Nsight Tegra Visual Studio Edition, this variable may be set to specify the default value for the ANDROID_API target property. See that target property for additional information."
+  },
+  "CMAKE_ANDROID_API_MIN": {
+    "name": "CMAKE_ANDROID_API_MIN",
+    "description": "Default value for the ANDROID_API_MIN target property. See that target property for additional information."
+  },
+  "CMAKE_ANDROID_ARCH": {
+    "name": "CMAKE_ANDROID_ARCH",
+    "description": "When Cross Compiling for Android with NVIDIA Nsight Tegra Visual Studio Edition, this variable may be set to specify the default value for the ANDROID_ARCH target property. See that target property for additional information."
+  },
+  "CMAKE_ANDROID_ARCH_ABI": {
+    "name": "CMAKE_ANDROID_ARCH_ABI",
+    "description": "When Cross Compiling for Android, this variable specifies the target architecture and ABI to be used. Valid values are:"
+  },
+  "CMAKE_ANDROID_ARM_MODE": {
+    "name": "CMAKE_ANDROID_ARM_MODE",
+    "description": "When Cross Compiling for Android and CMAKE_ANDROID_ARCH_ABI is set to one of the armeabi architectures, set CMAKE_ANDROID_ARM_MODE to ON to target 32-bit ARM processors (-marm). Otherwise, the default is to target the 16-bit Thumb processors (-mthumb)."
+  },
+  "CMAKE_ANDROID_ARM_NEON": {
+    "name": "CMAKE_ANDROID_ARM_NEON",
+    "description": "When Cross Compiling for Android and CMAKE_ANDROID_ARCH_ABI is set to armeabi-v7a set CMAKE_ANDROID_ARM_NEON to ON to target ARM NEON devices."
+  },
+  "CMAKE_ANDROID_ASSETS_DIRECTORIES": {
+    "name": "CMAKE_ANDROID_ASSETS_DIRECTORIES",
+    "description": "Default value for the ANDROID_ASSETS_DIRECTORIES target property. See that target property for additional information."
+  },
+  "CMAKE_ANDROID_EXCEPTIONS": {
+    "name": "CMAKE_ANDROID_EXCEPTIONS",
+    "description": "When Cross Compiling for Android with the NDK, this variable may be set to specify whether exceptions are enabled."
+  },
+  "CMAKE_ANDROID_GUI": {
+    "name": "CMAKE_ANDROID_GUI",
+    "description": "Default value for the ANDROID_GUI target property of executables. See that target property for additional information."
+  },
+  "CMAKE_ANDROID_JAR_DEPENDENCIES": {
+    "name": "CMAKE_ANDROID_JAR_DEPENDENCIES",
+    "description": "Default value for the ANDROID_JAR_DEPENDENCIES target property. See that target property for additional information."
+  },
+  "CMAKE_ANDROID_JAR_DIRECTORIES": {
+    "name": "CMAKE_ANDROID_JAR_DIRECTORIES",
+    "description": "Default value for the ANDROID_JAR_DIRECTORIES target property. See that target property for additional information."
+  },
+  "CMAKE_ANDROID_JAVA_SOURCE_DIR": {
+    "name": "CMAKE_ANDROID_JAVA_SOURCE_DIR",
+    "description": "Default value for the ANDROID_JAVA_SOURCE_DIR target property. See that target property for additional information."
+  },
+  "CMAKE_ANDROID_NATIVE_LIB_DEPENDENCIES": {
+    "name": "CMAKE_ANDROID_NATIVE_LIB_DEPENDENCIES",
+    "description": "Default value for the ANDROID_NATIVE_LIB_DEPENDENCIES target property. See that target property for additional information."
+  },
+  "CMAKE_ANDROID_NATIVE_LIB_DIRECTORIES": {
+    "name": "CMAKE_ANDROID_NATIVE_LIB_DIRECTORIES",
+    "description": "Default value for the ANDROID_NATIVE_LIB_DIRECTORIES target property. See that target property for additional information."
+  },
+  "CMAKE_ANDROID_NDK": {
+    "name": "CMAKE_ANDROID_NDK",
+    "description": "When Cross Compiling for Android with the NDK, this variable holds the absolute path to the root directory of the NDK. The directory must contain a platforms subdirectory holding the android-<api> directories."
+  },
+  "CMAKE_ANDROID_NDK_DEPRECATED_HEADERS": {
+    "name": "CMAKE_ANDROID_NDK_DEPRECATED_HEADERS",
+    "description": "When Cross Compiling for Android with the NDK, this variable may be set to specify whether to use the deprecated per-api-level headers instead of the unified headers."
+  },
+  "CMAKE_ANDROID_NDK_TOOLCHAIN_HOST_TAG": {
+    "name": "CMAKE_ANDROID_NDK_TOOLCHAIN_HOST_TAG",
+    "description": "When Cross Compiling for Android with the NDK, this variable provides the NDK's \"host tag\" used to construct the path to prebuilt toolchains that run on the host."
+  },
+  "CMAKE_ANDROID_NDK_TOOLCHAIN_VERSION": {
+    "name": "CMAKE_ANDROID_NDK_TOOLCHAIN_VERSION",
+    "description": "When Cross Compiling for Android with the NDK, this variable may be set to specify the version of the toolchain to be used as the compiler."
+  },
+  "CMAKE_ANDROID_NDK_VERSION": {
+    "name": "CMAKE_ANDROID_NDK_VERSION",
+    "description": "When Cross Compiling for Android with the NDK and using an Android NDK version 11 or higher, this variable is provided by CMake to report the NDK version number."
+  },
+  "CMAKE_ANDROID_PROCESS_MAX": {
+    "name": "CMAKE_ANDROID_PROCESS_MAX",
+    "description": "Default value for the ANDROID_PROCESS_MAX target property. See that target property for additional information."
+  },
+  "CMAKE_ANDROID_PROGUARD": {
+    "name": "CMAKE_ANDROID_PROGUARD",
+    "description": "Default value for the ANDROID_PROGUARD target property. See that target property for additional information."
+  },
+  "CMAKE_ANDROID_PROGUARD_CONFIG_PATH": {
+    "name": "CMAKE_ANDROID_PROGUARD_CONFIG_PATH",
+    "description": "Default value for the ANDROID_PROGUARD_CONFIG_PATH target property. See that target property for additional information."
+  },
+  "CMAKE_ANDROID_RTTI": {
+    "name": "CMAKE_ANDROID_RTTI",
+    "description": "When Cross Compiling for Android with the NDK, this variable may be set to specify whether RTTI is enabled."
+  },
+  "CMAKE_ANDROID_SECURE_PROPS_PATH": {
+    "name": "CMAKE_ANDROID_SECURE_PROPS_PATH",
+    "description": "Default value for the ANDROID_SECURE_PROPS_PATH target property. See that target property for additional information."
+  },
+  "CMAKE_ANDROID_SKIP_ANT_STEP": {
+    "name": "CMAKE_ANDROID_SKIP_ANT_STEP",
+    "description": "Default value for the ANDROID_SKIP_ANT_STEP target property. See that target property for additional information."
+  },
+  "CMAKE_ANDROID_STANDALONE_TOOLCHAIN": {
+    "name": "CMAKE_ANDROID_STANDALONE_TOOLCHAIN",
+    "description": "When Cross Compiling for Android with a Standalone Toolchain, this variable holds the absolute path to the root directory of the toolchain. The specified directory must contain a sysroot subdirectory."
+  },
+  "CMAKE_ANDROID_STL_TYPE": {
+    "name": "CMAKE_ANDROID_STL_TYPE",
+    "description": "When Cross Compiling for Android with NVIDIA Nsight Tegra Visual Studio Edition, this variable may be set to specify the default value for the ANDROID_STL_TYPE target property. See that target property for additional information."
+  },
+  "CMAKE_APPBUNDLE_PATH": {
+    "name": "CMAKE_APPBUNDLE_PATH",
+    "description": "Semicolon-separated list  of directories specifying a search path for macOS application bundles used by the find_program, and find_package commands."
+  },
+  "CMAKE_APPLE_SILICON_PROCESSOR": {
+    "name": "CMAKE_APPLE_SILICON_PROCESSOR",
+    "description": "On Apple Silicon hosts running macOS, set this variable to tell CMake what architecture to use for CMAKE_HOST_SYSTEM_PROCESSOR. The value must be either arm64 or x86_64."
+  },
+  "CMAKE_AR": {
+    "name": "CMAKE_AR",
+    "description": "Name of archiving tool for static libraries."
+  },
+  "CMAKE_ARCHIVE_OUTPUT_DIRECTORY": {
+    "name": "CMAKE_ARCHIVE_OUTPUT_DIRECTORY",
+    "description": "Where to put all the ARCHIVE  target files when built."
+  },
+  "CMAKE_ARCHIVE_OUTPUT_DIRECTORY_<CONFIG>": {
+    "name": "CMAKE_ARCHIVE_OUTPUT_DIRECTORY_<CONFIG>",
+    "description": "Where to put all the ARCHIVE  target files when built for a specific configuration."
+  },
+  "CMAKE_ARGC": {
+    "name": "CMAKE_ARGC",
+    "description": "Number of command line arguments passed to CMake in script mode."
+  },
+  "CMAKE_ARGV0": {
+    "name": "CMAKE_ARGV0",
+    "description": "Command line argument passed to CMake in script mode."
+  },
+  "CMAKE_AUTOGEN_BETTER_GRAPH_MULTI_CONFIG": {
+    "name": "CMAKE_AUTOGEN_BETTER_GRAPH_MULTI_CONFIG",
+    "description": "This variable is used to initialize the AUTOGEN_BETTER_GRAPH_MULTI_CONFIG property on all targets as they are created. See that target property for additional information."
+  },
+  "CMAKE_AUTOGEN_COMMAND_LINE_LENGTH_MAX": {
+    "name": "CMAKE_AUTOGEN_COMMAND_LINE_LENGTH_MAX",
+    "description": "Command line length limit for autogen targets, i.e. moc or uic, that triggers the use of response files on Windows instead of passing all arguments to the command line."
+  },
+  "CMAKE_AUTOGEN_ORIGIN_DEPENDS": {
+    "name": "CMAKE_AUTOGEN_ORIGIN_DEPENDS",
+    "description": "Switch for forwarding origin target dependencies to the corresponding <ORIGIN>_autogen targets."
+  },
+  "CMAKE_AUTOGEN_PARALLEL": {
+    "name": "CMAKE_AUTOGEN_PARALLEL",
+    "description": "Number of parallel moc or uic processes to start when using AUTOMOC and AUTOUIC."
+  },
+  "CMAKE_AUTOGEN_USE_SYSTEM_INCLUDE": {
+    "name": "CMAKE_AUTOGEN_USE_SYSTEM_INCLUDE",
+    "description": "This variable is used to initialize the AUTOGEN_USE_SYSTEM_INCLUDE property on all targets as they are created. See that target property for additional information."
+  },
+  "CMAKE_AUTOGEN_VERBOSE": {
+    "name": "CMAKE_AUTOGEN_VERBOSE",
+    "description": "Sets the verbosity of AUTOMOC, AUTOUIC and AUTORCC. A positive integer value or a true boolean value lets the AUTO* generators output additional processing information."
+  },
+  "CMAKE_AUTOMOC": {
+    "name": "CMAKE_AUTOMOC",
+    "description": "Whether to handle moc automatically for Qt targets."
+  },
+  "CMAKE_AUTOMOC_COMPILER_PREDEFINES": {
+    "name": "CMAKE_AUTOMOC_COMPILER_PREDEFINES",
+    "description": "This variable is used to initialize the AUTOMOC_COMPILER_PREDEFINES property on all the targets. See that target property for additional information."
+  },
+  "CMAKE_AUTOMOC_DEPEND_FILTERS": {
+    "name": "CMAKE_AUTOMOC_DEPEND_FILTERS",
+    "description": "Filter definitions used by CMAKE_AUTOMOC to extract file names from source code as additional dependencies for the moc file."
+  },
+  "CMAKE_AUTOMOC_EXECUTABLE": {
+    "name": "CMAKE_AUTOMOC_EXECUTABLE",
+    "description": "This variable is used to initialize the AUTOMOC_EXECUTABLE property on all the targets. See that target property for additional information."
+  },
+  "CMAKE_AUTOMOC_MACRO_NAMES": {
+    "name": "CMAKE_AUTOMOC_MACRO_NAMES",
+    "description": "Semicolon-separated list  list of macro names used by CMAKE_AUTOMOC to determine if a C++ file needs to be processed by moc."
+  },
+  "CMAKE_AUTOMOC_MOC_OPTIONS": {
+    "name": "CMAKE_AUTOMOC_MOC_OPTIONS",
+    "description": "Additional options for moc when using CMAKE_AUTOMOC."
+  },
+  "CMAKE_AUTOMOC_PATH_PREFIX": {
+    "name": "CMAKE_AUTOMOC_PATH_PREFIX",
+    "description": "Whether to generate the -p path prefix option for moc on AUTOMOC enabled Qt targets."
+  },
+  "CMAKE_AUTOMOC_RELAXED_MODE": {
+    "name": "CMAKE_AUTOMOC_RELAXED_MODE",
+    "description": "Switch between strict and relaxed automoc mode."
+  },
+  "CMAKE_AUTORCC": {
+    "name": "CMAKE_AUTORCC",
+    "description": "Whether to handle rcc automatically for Qt targets."
+  },
+  "CMAKE_AUTORCC_EXECUTABLE": {
+    "name": "CMAKE_AUTORCC_EXECUTABLE",
+    "description": "This variable is used to initialize the AUTORCC_EXECUTABLE property on all the targets. See that target property for additional information."
+  },
+  "CMAKE_AUTORCC_OPTIONS": {
+    "name": "CMAKE_AUTORCC_OPTIONS",
+    "description": "Additional options for rcc when using CMAKE_AUTORCC."
+  },
+  "CMAKE_AUTOUIC": {
+    "name": "CMAKE_AUTOUIC",
+    "description": "Whether to handle uic automatically for Qt targets."
+  },
+  "CMAKE_AUTOUIC_EXECUTABLE": {
+    "name": "CMAKE_AUTOUIC_EXECUTABLE",
+    "description": "This variable is used to initialize the AUTOUIC_EXECUTABLE property on all the targets. See that target property for additional information."
+  },
+  "CMAKE_AUTOUIC_OPTIONS": {
+    "name": "CMAKE_AUTOUIC_OPTIONS",
+    "description": "Additional options for uic when using CMAKE_AUTOUIC."
+  },
+  "CMAKE_AUTOUIC_SEARCH_PATHS": {
+    "name": "CMAKE_AUTOUIC_SEARCH_PATHS",
+    "description": "Search path list used by CMAKE_AUTOUIC to find included .ui files."
+  },
+  "CMAKE_BACKWARDS_COMPATIBILITY": {
+    "name": "CMAKE_BACKWARDS_COMPATIBILITY",
+    "description": "Deprecated. See CMake Policy CMP0001 documentation."
+  },
+  "CMAKE_BINARY_DIR": {
+    "name": "CMAKE_BINARY_DIR",
+    "description": "The path to the top level of the build tree."
+  },
+  "CMAKE_BUILD_RPATH": {
+    "name": "CMAKE_BUILD_RPATH",
+    "description": "Semicolon-separated list  specifying runtime path (RPATH) entries to add to binaries linked in the build tree (for platforms that support it). The entries will not be used for binaries in the install tree. See also the CMAKE_INSTALL_RPATH variable."
+  },
+  "CMAKE_BUILD_RPATH_USE_ORIGIN": {
+    "name": "CMAKE_BUILD_RPATH_USE_ORIGIN",
+    "description": "Whether to use relative paths for the build RPATH."
+  },
+  "CMAKE_BUILD_TOOL": {
+    "name": "CMAKE_BUILD_TOOL",
+    "description": "This variable exists only for backwards compatibility. It contains the same value as CMAKE_MAKE_PROGRAM. Use that variable instead."
+  },
+  "CMAKE_BUILD_TYPE": {
+    "name": "CMAKE_BUILD_TYPE",
+    "description": "Specifies the build type on single-configuration generators (e.g. Makefile Generators or Ninja). Typical values include Debug, Release, RelWithDebInfo and MinSizeRel, but custom build types can also be defined."
+  },
+  "CMAKE_BUILD_WITH_INSTALL_NAME_DIR": {
+    "name": "CMAKE_BUILD_WITH_INSTALL_NAME_DIR",
+    "description": "Whether to use INSTALL_NAME_DIR on targets in the build tree."
+  },
+  "CMAKE_BUILD_WITH_INSTALL_RPATH": {
+    "name": "CMAKE_BUILD_WITH_INSTALL_RPATH",
+    "description": "Use the install path for the RPATH."
+  },
+  "CMAKE_CACHEFILE_DIR": {
+    "name": "CMAKE_CACHEFILE_DIR",
+    "description": "This variable is used internally by CMake, and may not be set during the first configuration of a build tree. When it is set, it has the same value as CMAKE_BINARY_DIR. Use that variable instead."
+  },
+  "CMAKE_CACHE_MAJOR_VERSION": {
+    "name": "CMAKE_CACHE_MAJOR_VERSION",
+    "description": "Major version of CMake used to create the CMakeCache.txt file"
+  },
+  "CMAKE_CACHE_MINOR_VERSION": {
+    "name": "CMAKE_CACHE_MINOR_VERSION",
+    "description": "Minor version of CMake used to create the CMakeCache.txt file"
+  },
+  "CMAKE_CACHE_PATCH_VERSION": {
+    "name": "CMAKE_CACHE_PATCH_VERSION",
+    "description": "Patch version of CMake used to create the CMakeCache.txt file"
+  },
+  "CMAKE_CFG_INTDIR": {
+    "name": "CMAKE_CFG_INTDIR",
+    "description": "Build-time reference to per-configuration output subdirectory."
+  },
+  "CMAKE_CLANG_VFS_OVERLAY": {
+    "name": "CMAKE_CLANG_VFS_OVERLAY",
+    "description": "When cross compiling for windows with clang-cl, this variable can be an absolute path pointing to a clang virtual file system yaml file, which will enable clang-cl to resolve windows header names on a case sensitive file system."
+  },
+  "CMAKE_CL_64": {
+    "name": "CMAKE_CL_64",
+    "description": "Discouraged. Use CMAKE_SIZEOF_VOID_P instead."
+  },
+  "CMAKE_CODEBLOCKS_COMPILER_ID": {
+    "name": "CMAKE_CODEBLOCKS_COMPILER_ID",
+    "description": "Change the compiler id in the generated CodeBlocks project files."
+  },
+  "CMAKE_CODEBLOCKS_EXCLUDE_EXTERNAL_FILES": {
+    "name": "CMAKE_CODEBLOCKS_EXCLUDE_EXTERNAL_FILES",
+    "description": "Change the way the CodeBlocks generator creates project files."
+  },
+  "CMAKE_CODELITE_USE_TARGETS": {
+    "name": "CMAKE_CODELITE_USE_TARGETS",
+    "description": "Change the way the CodeLite generator creates projectfiles."
+  },
+  "CMAKE_COLOR_DIAGNOSTICS": {
+    "name": "CMAKE_COLOR_DIAGNOSTICS",
+    "description": "Enable color diagnostics throughout."
+  },
+  "CMAKE_COLOR_MAKEFILE": {
+    "name": "CMAKE_COLOR_MAKEFILE",
+    "description": "Enables color output when using the Makefile Generators."
+  },
+  "CMAKE_COMMAND": {
+    "name": "CMAKE_COMMAND",
+    "description": "The full path to the cmake executable."
+  },
+  "CMAKE_COMPILER_2005": {
+    "name": "CMAKE_COMPILER_2005",
+    "description": "Using the Visual Studio 2005 compiler from Microsoft"
+  },
+  "CMAKE_COMPILER_IS_GNUCC": {
+    "name": "CMAKE_COMPILER_IS_GNUCC",
+    "description": "True if the C compiler is GNU."
+  },
+  "CMAKE_COMPILER_IS_GNUCXX": {
+    "name": "CMAKE_COMPILER_IS_GNUCXX",
+    "description": "True if the C++ (CXX) compiler is GNU."
+  },
+  "CMAKE_COMPILER_IS_GNUG77": {
+    "name": "CMAKE_COMPILER_IS_GNUG77",
+    "description": "True if the Fortran compiler is GNU."
+  },
+  "CMAKE_COMPILE_PDB_OUTPUT_DIRECTORY": {
+    "name": "CMAKE_COMPILE_PDB_OUTPUT_DIRECTORY",
+    "description": "Output directory for MS debug symbol .pdb files generated by the compiler while building source files."
+  },
+  "CMAKE_COMPILE_PDB_OUTPUT_DIRECTORY_<CONFIG>": {
+    "name": "CMAKE_COMPILE_PDB_OUTPUT_DIRECTORY_<CONFIG>",
+    "description": "Per-configuration output directory for MS debug symbol .pdb files generated by the compiler while building source files."
+  },
+  "CMAKE_COMPILE_WARNING_AS_ERROR": {
+    "name": "CMAKE_COMPILE_WARNING_AS_ERROR",
+    "description": "Specify whether to treat warnings on compile as errors."
+  },
+  "CMAKE_CONFIGURATION_TYPES": {
+    "name": "CMAKE_CONFIGURATION_TYPES",
+    "description": "Specifies the available build types (configurations) on multi-config generators (e.g. Visual Studio , Xcode, or Ninja Multi-Config) as a semicolon-separated list . Typical entries include Debug, Release, RelWithDebInfo and MinSizeRel, but custom build types can also be defined."
+  },
+  "CMAKE_<CONFIG>_POSTFIX": {
+    "name": "CMAKE_<CONFIG>_POSTFIX",
+    "description": "Default filename postfix for libraries under configuration <CONFIG>."
+  },
+  "CMAKE_CPACK_COMMAND": {
+    "name": "CMAKE_CPACK_COMMAND",
+    "description": "Full path to cpack command installed with CMake."
+  },
+  "CMAKE_CROSSCOMPILING": {
+    "name": "CMAKE_CROSSCOMPILING",
+    "description": "This variable is set by CMake to indicate whether it is cross compiling, but note limitations discussed below."
+  },
+  "CMAKE_CROSSCOMPILING_EMULATOR": {
+    "name": "CMAKE_CROSSCOMPILING_EMULATOR",
+    "description": "This variable is only used when CMAKE_CROSSCOMPILING is on. It should point to a command on the host system that can run executable built for the target system."
+  },
+  "CMAKE_CROSS_CONFIGS": {
+    "name": "CMAKE_CROSS_CONFIGS",
+    "description": "Specifies a semicolon-separated list  of configurations available from all build-<Config>.ninja files in the Ninja Multi-Config generator. This variable activates cross-config mode. Targets from each config specified in this variable can be built from any build-<Config>.ninja file. Custom commands will use the configuration native to build-<Config>.ninja. If it is set to all, all configurations from CMAKE_CONFIGURATION_TYPES are cross-configs. If it is not specified, or empty, each build-<Config>.ninja file will only contain build rules for its own configuration."
+  },
+  "CMAKE_CTEST_ARGUMENTS": {
+    "name": "CMAKE_CTEST_ARGUMENTS",
+    "description": "Set this to a semicolon-separated list  of command-line arguments to pass to ctest when running tests through the test (or RUN_TESTS) target of the generated build system."
+  },
+  "CMAKE_CTEST_COMMAND": {
+    "name": "CMAKE_CTEST_COMMAND",
+    "description": "Full path to ctest command installed with CMake."
+  },
+  "CMAKE_CUDA_ARCHITECTURES": {
+    "name": "CMAKE_CUDA_ARCHITECTURES",
+    "description": "Default value for CUDA_ARCHITECTURES property of targets."
+  },
+  "CMAKE_CUDA_COMPILE_FEATURES": {
+    "name": "CMAKE_CUDA_COMPILE_FEATURES",
+    "description": "List of features known to the CUDA compiler"
+  },
+  "CMAKE_CUDA_EXTENSIONS": {
+    "name": "CMAKE_CUDA_EXTENSIONS",
+    "description": "Default value for CUDA_EXTENSIONS target property if set when a target is created."
+  },
+  "CMAKE_CUDA_HOST_COMPILER": {
+    "name": "CMAKE_CUDA_HOST_COMPILER",
+    "description": "This is the original CUDA-specific name for the more general CMAKE_<LANG>_HOST_COMPILER variable. See the latter for details."
+  },
+  "CMAKE_CUDA_RESOLVE_DEVICE_SYMBOLS": {
+    "name": "CMAKE_CUDA_RESOLVE_DEVICE_SYMBOLS",
+    "description": "Default value for CUDA_RESOLVE_DEVICE_SYMBOLS target property when defined. By default this variable is not defined."
+  },
+  "CMAKE_CUDA_RUNTIME_LIBRARY": {
+    "name": "CMAKE_CUDA_RUNTIME_LIBRARY",
+    "description": "Select the CUDA runtime library for use when compiling and linking CUDA. This variable is used to initialize the CUDA_RUNTIME_LIBRARY property on all targets as they are created."
+  },
+  "CMAKE_CUDA_SEPARABLE_COMPILATION": {
+    "name": "CMAKE_CUDA_SEPARABLE_COMPILATION",
+    "description": "Default value for CUDA_SEPARABLE_COMPILATION target property. This variable is used to initialize the property on each target as it is created."
+  },
+  "CMAKE_CUDA_STANDARD": {
+    "name": "CMAKE_CUDA_STANDARD",
+    "description": "Default value for CUDA_STANDARD target property if set when a target is created."
+  },
+  "CMAKE_CUDA_STANDARD_REQUIRED": {
+    "name": "CMAKE_CUDA_STANDARD_REQUIRED",
+    "description": "Default value for CUDA_STANDARD_REQUIRED target property if set when a target is created."
+  },
+  "CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES": {
+    "name": "CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES",
+    "description": "When the CUDA language has been enabled, this provides a semicolon-separated list  of include directories provided by the CUDA Toolkit. The value may be useful for C++ source files to include CUDA headers."
+  },
+  "CMAKE_CURRENT_BINARY_DIR": {
+    "name": "CMAKE_CURRENT_BINARY_DIR",
+    "description": "The path to the binary directory currently being processed."
+  },
+  "CMAKE_CURRENT_FUNCTION": {
+    "name": "CMAKE_CURRENT_FUNCTION",
+    "description": "When executing code inside a function, this variable contains the name of the current function. It can be useful for diagnostic or debug messages."
+  },
+  "CMAKE_CURRENT_FUNCTION_LIST_DIR": {
+    "name": "CMAKE_CURRENT_FUNCTION_LIST_DIR",
+    "description": "When executing code inside a function, this variable contains the full directory of the listfile that defined the current function."
+  },
+  "CMAKE_CURRENT_FUNCTION_LIST_FILE": {
+    "name": "CMAKE_CURRENT_FUNCTION_LIST_FILE",
+    "description": "When executing code inside a function, this variable contains the full path to the listfile that defined the current function."
+  },
+  "CMAKE_CURRENT_FUNCTION_LIST_LINE": {
+    "name": "CMAKE_CURRENT_FUNCTION_LIST_LINE",
+    "description": "When executing code inside a function, this variable contains the line number in the listfile where the current function was defined."
+  },
+  "CMAKE_CURRENT_LIST_DIR": {
+    "name": "CMAKE_CURRENT_LIST_DIR",
+    "description": "Full directory of the listfile currently being processed."
+  },
+  "CMAKE_CURRENT_LIST_FILE": {
+    "name": "CMAKE_CURRENT_LIST_FILE",
+    "description": "Full path to the listfile currently being processed."
+  },
+  "CMAKE_CURRENT_LIST_LINE": {
+    "name": "CMAKE_CURRENT_LIST_LINE",
+    "description": "The line number of the current file being processed."
+  },
+  "CMAKE_CURRENT_SOURCE_DIR": {
+    "name": "CMAKE_CURRENT_SOURCE_DIR",
+    "description": "The path to the source directory currently being processed."
+  },
+  "CMAKE_CXX_COMPILER_IMPORT_STD": {
+    "name": "CMAKE_CXX_COMPILER_IMPORT_STD",
+    "description": "A list of C++ standard levels for which import std support exists for the current C++ toolchain. Support for C++<NN> may be detected using a <NN> IN_LIST CMAKE_CXX_COMPILER_IMPORT_STD predicate with the if command."
+  },
+  "CMAKE_CXX_COMPILE_FEATURES": {
+    "name": "CMAKE_CXX_COMPILE_FEATURES",
+    "description": "List of features known to the C++ compiler"
+  },
+  "CMAKE_CXX_EXTENSIONS": {
+    "name": "CMAKE_CXX_EXTENSIONS",
+    "description": "Default value for CXX_EXTENSIONS target property if set when a target is created."
+  },
+  "CMAKE_CXX_MODULE_STD": {
+    "name": "CMAKE_CXX_MODULE_STD",
+    "description": "Whether to add utility targets as dependencies to targets with at least cxx_std_23 or not."
+  },
+  "CMAKE_CXX_SCAN_FOR_MODULES": {
+    "name": "CMAKE_CXX_SCAN_FOR_MODULES",
+    "description": "Whether to scan C++ source files for module dependencies."
+  },
+  "CMAKE_CXX_STANDARD": {
+    "name": "CMAKE_CXX_STANDARD",
+    "description": "Default value for CXX_STANDARD target property if set when a target is created."
+  },
+  "CMAKE_CXX_STANDARD_REQUIRED": {
+    "name": "CMAKE_CXX_STANDARD_REQUIRED",
+    "description": "Default value for CXX_STANDARD_REQUIRED target property if set when a target is created."
+  },
+  "CMAKE_C_COMPILE_FEATURES": {
+    "name": "CMAKE_C_COMPILE_FEATURES",
+    "description": "List of features known to the C compiler"
+  },
+  "CMAKE_C_EXTENSIONS": {
+    "name": "CMAKE_C_EXTENSIONS",
+    "description": "Default value for C_EXTENSIONS target property if set when a target is created."
+  },
+  "CMAKE_C_STANDARD": {
+    "name": "CMAKE_C_STANDARD",
+    "description": "Default value for C_STANDARD target property if set when a target is created."
+  },
+  "CMAKE_C_STANDARD_REQUIRED": {
+    "name": "CMAKE_C_STANDARD_REQUIRED",
+    "description": "Default value for C_STANDARD_REQUIRED target property if set when a target is created."
+  },
+  "CMAKE_DEBUG_POSTFIX": {
+    "name": "CMAKE_DEBUG_POSTFIX",
+    "description": "See variable CMAKE_<CONFIG>_POSTFIX."
+  },
+  "CMAKE_DEBUG_TARGET_PROPERTIES": {
+    "name": "CMAKE_DEBUG_TARGET_PROPERTIES",
+    "description": "Enables tracing output for target properties."
+  },
+  "CMAKE_DEFAULT_BUILD_TYPE": {
+    "name": "CMAKE_DEFAULT_BUILD_TYPE",
+    "description": "Specifies the configuration to use by default in a build.ninja file in the Ninja Multi-Config generator. If this variable is specified, build.ninja uses build rules from build-<Config>.ninja by default. All custom commands are executed with this configuration. If the variable is not specified, the first item from CMAKE_CONFIGURATION_TYPES is used instead."
+  },
+  "CMAKE_DEFAULT_CONFIGS": {
+    "name": "CMAKE_DEFAULT_CONFIGS",
+    "description": "Specifies a semicolon-separated list  of configurations to build for a target in build.ninja if no :<Config> suffix is specified in the Ninja Multi-Config generator. If it is set to all, all configurations from CMAKE_CROSS_CONFIGS are used. If it is not specified, it defaults to CMAKE_DEFAULT_BUILD_TYPE."
+  },
+  "CMAKE_DEPENDS_IN_PROJECT_ONLY": {
+    "name": "CMAKE_DEPENDS_IN_PROJECT_ONLY",
+    "description": "When set to TRUE in a directory, the build system produced by the Makefile Generators is set up to only consider dependencies on source files that appear either in the source or in the binary directories. Changes to source files outside of these directories will not cause rebuilds."
+  },
+  "CMAKE_DEPENDS_USE_COMPILER": {
+    "name": "CMAKE_DEPENDS_USE_COMPILER",
+    "description": "For the Makefile Generators, source dependencies are now, for a selection of compilers, generated by the compiler itself. By defining this variable with value FALSE, you can restore the legacy behavior (i.e. using CMake for dependencies discovery)."
+  },
+  "CMAKE_DIRECTORY_LABELS": {
+    "name": "CMAKE_DIRECTORY_LABELS",
+    "description": "Specify labels for the current directory."
+  },
+  "CMAKE_DISABLE_FIND_PACKAGE_<PackageName>": {
+    "name": "CMAKE_DISABLE_FIND_PACKAGE_<PackageName>",
+    "description": "Variable for disabling find_package calls."
+  },
+  "CMAKE_DISABLE_PRECOMPILE_HEADERS": {
+    "name": "CMAKE_DISABLE_PRECOMPILE_HEADERS",
+    "description": "Default value for DISABLE_PRECOMPILE_HEADERS of targets."
+  },
+  "CMAKE_DLL_NAME_WITH_SOVERSION": {
+    "name": "CMAKE_DLL_NAME_WITH_SOVERSION",
+    "description": "This variable is used to initialize the DLL_NAME_WITH_SOVERSION property on shared library targets for the Windows platform, which is selected when the WIN32 variable is set."
+  },
+  "CMAKE_DL_LIBS": {
+    "name": "CMAKE_DL_LIBS",
+    "description": "Name of library containing dlopen and dlclose."
+  },
+  "CMAKE_DOTNET_SDK": {
+    "name": "CMAKE_DOTNET_SDK",
+    "description": "Default value for DOTNET_SDK property of targets."
+  },
+  "CMAKE_DOTNET_TARGET_FRAMEWORK": {
+    "name": "CMAKE_DOTNET_TARGET_FRAMEWORK",
+    "description": "Default value for DOTNET_TARGET_FRAMEWORK property of targets."
+  },
+  "CMAKE_DOTNET_TARGET_FRAMEWORK_VERSION": {
+    "name": "CMAKE_DOTNET_TARGET_FRAMEWORK_VERSION",
+    "description": "Default value for DOTNET_TARGET_FRAMEWORK_VERSION property of targets."
+  },
+  "CMAKE_ECLIPSE_GENERATE_LINKED_RESOURCES": {
+    "name": "CMAKE_ECLIPSE_GENERATE_LINKED_RESOURCES",
+    "description": "This cache variable is used by the Eclipse project generator. See cmake-generators."
+  },
+  "CMAKE_ECLIPSE_GENERATE_SOURCE_PROJECT": {
+    "name": "CMAKE_ECLIPSE_GENERATE_SOURCE_PROJECT",
+    "description": "This cache variable is used by the Eclipse project generator. See cmake-generators."
+  },
+  "CMAKE_ECLIPSE_MAKE_ARGUMENTS": {
+    "name": "CMAKE_ECLIPSE_MAKE_ARGUMENTS",
+    "description": "This cache variable is used by the Eclipse project generator. See cmake-generators."
+  },
+  "CMAKE_ECLIPSE_RESOURCE_ENCODING": {
+    "name": "CMAKE_ECLIPSE_RESOURCE_ENCODING",
+    "description": "This cache variable tells the Eclipse CDT4 project generator to set the resource encoding to the given value in generated project files. If no value is given, no encoding will be set."
+  },
+  "CMAKE_ECLIPSE_VERSION": {
+    "name": "CMAKE_ECLIPSE_VERSION",
+    "description": "This cache variable is used by the Eclipse project generator. See cmake-generators."
+  },
+  "CMAKE_EDIT_COMMAND": {
+    "name": "CMAKE_EDIT_COMMAND",
+    "description": "Full path to cmake-gui or ccmake. Defined only for Makefile Generators and Ninja Generators when not using any Extra Generators."
+  },
+  "CMAKE_ENABLE_EXPORTS": {
+    "name": "CMAKE_ENABLE_EXPORTS",
+    "description": "Specify whether executables export symbols for loadable modules."
+  },
+  "CMAKE_ERROR_DEPRECATED": {
+    "name": "CMAKE_ERROR_DEPRECATED",
+    "description": "Whether to issue errors for deprecated functionality."
+  },
+  "CMAKE_ERROR_ON_ABSOLUTE_INSTALL_DESTINATION": {
+    "name": "CMAKE_ERROR_ON_ABSOLUTE_INSTALL_DESTINATION",
+    "description": "Ask cmake_install.cmake script to error out as soon as a file with absolute INSTALL DESTINATION is encountered."
+  },
+  "CMAKE_EXECUTABLE_ENABLE_EXPORTS": {
+    "name": "CMAKE_EXECUTABLE_ENABLE_EXPORTS",
+    "description": "Specify whether executables export symbols for loadable modules."
+  },
+  "CMAKE_EXECUTABLE_SUFFIX": {
+    "name": "CMAKE_EXECUTABLE_SUFFIX",
+    "description": "The suffix for executables on this platform."
+  },
+  "CMAKE_EXECUTABLE_SUFFIX_<LANG>": {
+    "name": "CMAKE_EXECUTABLE_SUFFIX_<LANG>",
+    "description": "The suffix to use for the end of an executable filename of <LANG> compiler target architecture, if any."
+  },
+  "CMAKE_EXECUTE_PROCESS_COMMAND_ECHO": {
+    "name": "CMAKE_EXECUTE_PROCESS_COMMAND_ECHO",
+    "description": "If this variable is set to STDERR, STDOUT or NONE then commands in execute_process calls will be printed to either stderr or stdout or not at all."
+  },
+  "CMAKE_EXE_LINKER_FLAGS": {
+    "name": "CMAKE_EXE_LINKER_FLAGS",
+    "description": "Linker flags to be used to create executables."
+  },
+  "CMAKE_EXE_LINKER_FLAGS_<CONFIG>": {
+    "name": "CMAKE_EXE_LINKER_FLAGS_<CONFIG>",
+    "description": "Flags to be used when linking an executable."
+  },
+  "CMAKE_EXE_LINKER_FLAGS_<CONFIG>_INIT": {
+    "name": "CMAKE_EXE_LINKER_FLAGS_<CONFIG>_INIT",
+    "description": "Value used to initialize the CMAKE_EXE_LINKER_FLAGS_ cache entry the first time a build tree is configured. This variable is meant to be set by a toolchain file . CMake may prepend or append content to the value based on the environment and target platform."
+  },
+  "CMAKE_EXE_LINKER_FLAGS_INIT": {
+    "name": "CMAKE_EXE_LINKER_FLAGS_INIT",
+    "description": "Value used to initialize the CMAKE_EXE_LINKER_FLAGS cache entry the first time a build tree is configured. This variable is meant to be set by a toolchain file . CMake may prepend or append content to the value based on the environment and target platform."
+  },
+  "CMAKE_EXPORT_COMPILE_COMMANDS": {
+    "name": "CMAKE_EXPORT_COMPILE_COMMANDS",
+    "description": "Enable/Disable output of compile commands during generation."
+  },
+  "CMAKE_EXPORT_FIND_PACKAGE_NAME": {
+    "name": "CMAKE_EXPORT_FIND_PACKAGE_NAME",
+    "description": "Initializes the value of EXPORT_FIND_PACKAGE_NAME."
+  },
+  "CMAKE_EXPORT_NO_PACKAGE_REGISTRY": {
+    "name": "CMAKE_EXPORT_NO_PACKAGE_REGISTRY",
+    "description": "Disable the export command when CMP0090 is not set to NEW."
+  },
+  "CMAKE_EXPORT_PACKAGE_REGISTRY": {
+    "name": "CMAKE_EXPORT_PACKAGE_REGISTRY",
+    "description": "Enables the export command when CMP0090 is set to NEW."
+  },
+  "CMAKE_EXTRA_GENERATOR": {
+    "name": "CMAKE_EXTRA_GENERATOR",
+    "description": "The extra generator used to build the project. See cmake-generators."
+  },
+  "CMAKE_EXTRA_SHARED_LIBRARY_SUFFIXES": {
+    "name": "CMAKE_EXTRA_SHARED_LIBRARY_SUFFIXES",
+    "description": "Additional suffixes for shared libraries."
+  },
+  "CMAKE_FIND_APPBUNDLE": {
+    "name": "CMAKE_FIND_APPBUNDLE",
+    "description": "This variable affects how find_* commands choose between macOS Application Bundles and unix-style package components."
+  },
+  "CMAKE_FIND_DEBUG_MODE": {
+    "name": "CMAKE_FIND_DEBUG_MODE",
+    "description": "Print extra find call information for the following commands to standard error:"
+  },
+  "CMAKE_FIND_FRAMEWORK": {
+    "name": "CMAKE_FIND_FRAMEWORK",
+    "description": "This variable affects how find_* commands choose between macOS Frameworks and unix-style package components."
+  },
+  "CMAKE_FIND_LIBRARY_CUSTOM_LIB_SUFFIX": {
+    "name": "CMAKE_FIND_LIBRARY_CUSTOM_LIB_SUFFIX",
+    "description": "Specify a <suffix> to tell the find_library command to search in a lib<suffix> directory before each lib directory that would normally be searched."
+  },
+  "CMAKE_FIND_LIBRARY_PREFIXES": {
+    "name": "CMAKE_FIND_LIBRARY_PREFIXES",
+    "description": "Prefixes to prepend when looking for libraries."
+  },
+  "CMAKE_FIND_LIBRARY_SUFFIXES": {
+    "name": "CMAKE_FIND_LIBRARY_SUFFIXES",
+    "description": "Suffixes to append when looking for libraries."
+  },
+  "CMAKE_FIND_NO_INSTALL_PREFIX": {
+    "name": "CMAKE_FIND_NO_INSTALL_PREFIX",
+    "description": "Exclude the values of the CMAKE_INSTALL_PREFIX and CMAKE_STAGING_PREFIX variables from CMAKE_SYSTEM_PREFIX_PATH. CMake adds these project-destination prefixes to CMAKE_SYSTEM_PREFIX_PATH by default in order to support building a series of dependent packages and installing them into a common prefix. Set CMAKE_FIND_NO_INSTALL_PREFIX to TRUE to suppress this behavior."
+  },
+  "CMAKE_FIND_PACKAGE_NAME": {
+    "name": "CMAKE_FIND_PACKAGE_NAME",
+    "description": "Defined by the find_package command while loading a find module to record the caller-specified package name. See command documentation for details."
+  },
+  "CMAKE_FIND_PACKAGE_NO_PACKAGE_REGISTRY": {
+    "name": "CMAKE_FIND_PACKAGE_NO_PACKAGE_REGISTRY",
+    "description": "By default this variable is not set. If neither CMAKE_FIND_USE_PACKAGE_REGISTRY nor CMAKE_FIND_PACKAGE_NO_PACKAGE_REGISTRY is set, then find_package() will use the User Package Registry unless the NO_CMAKE_PACKAGE_REGISTRY option is provided."
+  },
+  "CMAKE_FIND_PACKAGE_NO_SYSTEM_PACKAGE_REGISTRY": {
+    "name": "CMAKE_FIND_PACKAGE_NO_SYSTEM_PACKAGE_REGISTRY",
+    "description": "By default this variable is not set. If neither CMAKE_FIND_USE_SYSTEM_PACKAGE_REGISTRY nor CMAKE_FIND_PACKAGE_NO_SYSTEM_PACKAGE_REGISTRY is set, then find_package() will use the System Package Registry unless the NO_CMAKE_SYSTEM_PACKAGE_REGISTRY option is provided."
+  },
+  "CMAKE_FIND_PACKAGE_PREFER_CONFIG": {
+    "name": "CMAKE_FIND_PACKAGE_PREFER_CONFIG",
+    "description": "Tell find_package to try \"Config\" mode before \"Module\" mode if no mode was specified."
+  },
+  "CMAKE_FIND_PACKAGE_REDIRECTS_DIR": {
+    "name": "CMAKE_FIND_PACKAGE_REDIRECTS_DIR",
+    "description": "This read-only variable specifies a directory that the find_package command will check first before searching anywhere else for a module or config package file. A config package file in this directory will always be found in preference to any other Find module file or config package file."
+  },
+  "CMAKE_FIND_PACKAGE_RESOLVE_SYMLINKS": {
+    "name": "CMAKE_FIND_PACKAGE_RESOLVE_SYMLINKS",
+    "description": "Set to TRUE to tell find_package calls to resolve symbolic links in the value of <PackageName>_DIR."
+  },
+  "CMAKE_FIND_PACKAGE_SORT_DIRECTION": {
+    "name": "CMAKE_FIND_PACKAGE_SORT_DIRECTION",
+    "description": "The sorting direction used by CMAKE_FIND_PACKAGE_SORT_ORDER. It can assume one of the following values:"
+  },
+  "CMAKE_FIND_PACKAGE_SORT_ORDER": {
+    "name": "CMAKE_FIND_PACKAGE_SORT_ORDER",
+    "description": "The default order for sorting packages found using find_package. It can assume one of the following values:"
+  },
+  "CMAKE_FIND_PACKAGE_TARGETS_GLOBAL": {
+    "name": "CMAKE_FIND_PACKAGE_TARGETS_GLOBAL",
+    "description": "Setting to TRUE promotes all IMPORTED targets discoverd by find_package to a GLOBAL scope."
+  },
+  "CMAKE_FIND_PACKAGE_WARN_NO_MODULE": {
+    "name": "CMAKE_FIND_PACKAGE_WARN_NO_MODULE",
+    "description": "Tell find_package to warn if called without an explicit mode."
+  },
+  "CMAKE_FIND_ROOT_PATH": {
+    "name": "CMAKE_FIND_ROOT_PATH",
+    "description": "Semicolon-separated list  of root paths to search on the filesystem."
+  },
+  "CMAKE_FIND_ROOT_PATH_MODE_INCLUDE": {
+    "name": "CMAKE_FIND_ROOT_PATH_MODE_INCLUDE",
+    "description": "This variable controls whether the CMAKE_FIND_ROOT_PATH and CMAKE_SYSROOT are used by FIND_XXX."
+  },
+  "CMAKE_FIND_ROOT_PATH_MODE_LIBRARY": {
+    "name": "CMAKE_FIND_ROOT_PATH_MODE_LIBRARY",
+    "description": "This variable controls whether the CMAKE_FIND_ROOT_PATH and CMAKE_SYSROOT are used by FIND_XXX."
+  },
+  "CMAKE_FIND_ROOT_PATH_MODE_PACKAGE": {
+    "name": "CMAKE_FIND_ROOT_PATH_MODE_PACKAGE",
+    "description": "This variable controls whether the CMAKE_FIND_ROOT_PATH and CMAKE_SYSROOT are used by FIND_XXX."
+  },
+  "CMAKE_FIND_ROOT_PATH_MODE_PROGRAM": {
+    "name": "CMAKE_FIND_ROOT_PATH_MODE_PROGRAM",
+    "description": "This variable controls whether the CMAKE_FIND_ROOT_PATH and CMAKE_SYSROOT are used by FIND_XXX."
+  },
+  "CMAKE_FIND_USE_CMAKE_ENVIRONMENT_PATH": {
+    "name": "CMAKE_FIND_USE_CMAKE_ENVIRONMENT_PATH",
+    "description": "Controls the default behavior of the following commands for whether or not to search paths provided by cmake-specific environment variables:"
+  },
+  "CMAKE_FIND_USE_CMAKE_PATH": {
+    "name": "CMAKE_FIND_USE_CMAKE_PATH",
+    "description": "Controls the default behavior of the following commands for whether or not to search paths provided by cmake-specific cache variables:"
+  },
+  "CMAKE_FIND_USE_CMAKE_SYSTEM_PATH": {
+    "name": "CMAKE_FIND_USE_CMAKE_SYSTEM_PATH",
+    "description": "Controls the default behavior of the following commands for whether or not to search paths provided by platform-specific cmake variables:"
+  },
+  "CMAKE_FIND_USE_INSTALL_PREFIX": {
+    "name": "CMAKE_FIND_USE_INSTALL_PREFIX",
+    "description": "Controls the default behavior of the following commands for whether or not to search the locations in the CMAKE_INSTALL_PREFIX and CMAKE_STAGING_PREFIX variables."
+  },
+  "CMAKE_FIND_USE_PACKAGE_REGISTRY": {
+    "name": "CMAKE_FIND_USE_PACKAGE_REGISTRY",
+    "description": "Controls the default behavior of the find_package command for whether or not to search paths provided by the User Package Registry."
+  },
+  "CMAKE_FIND_USE_PACKAGE_ROOT_PATH": {
+    "name": "CMAKE_FIND_USE_PACKAGE_ROOT_PATH",
+    "description": "Controls the default behavior of the following commands for whether or not to search paths provided by <PackageName>_ROOT variables:"
+  },
+  "CMAKE_FIND_USE_SYSTEM_ENVIRONMENT_PATH": {
+    "name": "CMAKE_FIND_USE_SYSTEM_ENVIRONMENT_PATH",
+    "description": "Controls the default behavior of the following commands for whether or not to search paths provided by standard system environment variables:"
+  },
+  "CMAKE_FIND_USE_SYSTEM_PACKAGE_REGISTRY": {
+    "name": "CMAKE_FIND_USE_SYSTEM_PACKAGE_REGISTRY",
+    "description": "Controls searching the System Package Registry by the find_package command."
+  },
+  "CMAKE_FOLDER": {
+    "name": "CMAKE_FOLDER",
+    "description": "Set the folder name. Use to organize targets in an IDE."
+  },
+  "CMAKE_Fortran_FORMAT": {
+    "name": "CMAKE_Fortran_FORMAT",
+    "description": "Set to FIXED or FREE to indicate the Fortran source layout."
+  },
+  "CMAKE_Fortran_MODDIR_DEFAULT": {
+    "name": "CMAKE_Fortran_MODDIR_DEFAULT",
+    "description": "Fortran default module output directory."
+  },
+  "CMAKE_Fortran_MODDIR_FLAG": {
+    "name": "CMAKE_Fortran_MODDIR_FLAG",
+    "description": "Fortran flag for module output directory."
+  },
+  "CMAKE_Fortran_MODOUT_FLAG": {
+    "name": "CMAKE_Fortran_MODOUT_FLAG",
+    "description": "Fortran flag to enable module output."
+  },
+  "CMAKE_Fortran_MODULE_DIRECTORY": {
+    "name": "CMAKE_Fortran_MODULE_DIRECTORY",
+    "description": "Fortran module output directory."
+  },
+  "CMAKE_Fortran_PREPROCESS": {
+    "name": "CMAKE_Fortran_PREPROCESS",
+    "description": "Default value for Fortran_PREPROCESS of targets."
+  },
+  "CMAKE_FRAMEWORK": {
+    "name": "CMAKE_FRAMEWORK",
+    "description": "Default value for FRAMEWORK of targets."
+  },
+  "CMAKE_FRAMEWORK_MULTI_CONFIG_POSTFIX_<CONFIG>": {
+    "name": "CMAKE_FRAMEWORK_MULTI_CONFIG_POSTFIX_<CONFIG>",
+    "description": "Default framework filename postfix under configuration <CONFIG> when using a multi-config generator."
+  },
+  "CMAKE_FRAMEWORK_PATH": {
+    "name": "CMAKE_FRAMEWORK_PATH",
+    "description": "Semicolon-separated list  of directories specifying a search path for macOS frameworks used by the find_library, find_package, find_path, and find_file commands."
+  },
+  "CMAKE_GENERATOR": {
+    "name": "CMAKE_GENERATOR",
+    "description": "The generator used to build the project. See cmake-generators."
+  },
+  "CMAKE_GENERATOR_INSTANCE": {
+    "name": "CMAKE_GENERATOR_INSTANCE",
+    "description": "Generator-specific instance specification provided by user."
+  },
+  "CMAKE_GENERATOR_PLATFORM": {
+    "name": "CMAKE_GENERATOR_PLATFORM",
+    "description": "Generator-specific target platform specification provided by user."
+  },
+  "CMAKE_GENERATOR_TOOLSET": {
+    "name": "CMAKE_GENERATOR_TOOLSET",
+    "description": "Native build system toolset specification provided by user."
+  },
+  "CMAKE_GHS_NO_SOURCE_GROUP_FILE": {
+    "name": "CMAKE_GHS_NO_SOURCE_GROUP_FILE",
+    "description": "ON / OFF boolean to control if the project file for a target should be one single file or multiple files. Refer to GHS_NO_SOURCE_GROUP_FILE for further details."
+  },
+  "CMAKE_GLOBAL_AUTOGEN_TARGET": {
+    "name": "CMAKE_GLOBAL_AUTOGEN_TARGET",
+    "description": "Switch to enable generation of a global autogen target."
+  },
+  "CMAKE_GLOBAL_AUTOGEN_TARGET_NAME": {
+    "name": "CMAKE_GLOBAL_AUTOGEN_TARGET_NAME",
+    "description": "Change the name of the global autogen target."
+  },
+  "CMAKE_GLOBAL_AUTORCC_TARGET": {
+    "name": "CMAKE_GLOBAL_AUTORCC_TARGET",
+    "description": "Switch to enable generation of a global autorcc target."
+  },
+  "CMAKE_GLOBAL_AUTORCC_TARGET_NAME": {
+    "name": "CMAKE_GLOBAL_AUTORCC_TARGET_NAME",
+    "description": "Change the name of the global autorcc target."
+  },
+  "CMAKE_GNUtoMS": {
+    "name": "CMAKE_GNUtoMS",
+    "description": "Convert GNU import libraries (.dll.a) to MS format (.lib)."
+  },
+  "CMAKE_HIP_ARCHITECTURES": {
+    "name": "CMAKE_HIP_ARCHITECTURES",
+    "description": "List of GPU architectures to for which to generate device code. Architecture names are interpreted based on CMAKE_HIP_PLATFORM."
+  },
+  "CMAKE_HIP_COMPILE_FEATURES": {
+    "name": "CMAKE_HIP_COMPILE_FEATURES",
+    "description": "List of features known to the HIP compiler"
+  },
+  "CMAKE_HIP_EXTENSIONS": {
+    "name": "CMAKE_HIP_EXTENSIONS",
+    "description": "Default value for HIP_EXTENSIONS target property if set when a target is created."
+  },
+  "CMAKE_HIP_PLATFORM": {
+    "name": "CMAKE_HIP_PLATFORM",
+    "description": "GPU platform for which HIP language sources are to be compiled."
+  },
+  "CMAKE_HIP_STANDARD": {
+    "name": "CMAKE_HIP_STANDARD",
+    "description": "Default value for HIP_STANDARD target property if set when a target is created."
+  },
+  "CMAKE_HIP_STANDARD_REQUIRED": {
+    "name": "CMAKE_HIP_STANDARD_REQUIRED",
+    "description": "Default value for HIP_STANDARD_REQUIRED target property if set when a target is created."
+  },
+  "CMAKE_HOME_DIRECTORY": {
+    "name": "CMAKE_HOME_DIRECTORY",
+    "description": "Path to top of source tree. Same as CMAKE_SOURCE_DIR."
+  },
+  "CMAKE_HOST_APPLE": {
+    "name": "CMAKE_HOST_APPLE",
+    "description": "True for Apple macOS operating systems."
+  },
+  "CMAKE_HOST_BSD": {
+    "name": "CMAKE_HOST_BSD",
+    "description": "Set to a string value when the host system is BSD. This value can be one of the following: DragonFlyBSD, FreeBSD, OpenBSD, or NetBSD."
+  },
+  "CMAKE_HOST_LINUX": {
+    "name": "CMAKE_HOST_LINUX",
+    "description": "Set to true when the host system is Linux."
+  },
+  "CMAKE_HOST_SOLARIS": {
+    "name": "CMAKE_HOST_SOLARIS",
+    "description": "True for Oracle Solaris operating systems."
+  },
+  "CMAKE_HOST_SYSTEM": {
+    "name": "CMAKE_HOST_SYSTEM",
+    "description": "Composite Name of OS CMake is being run on."
+  },
+  "CMAKE_HOST_SYSTEM_NAME": {
+    "name": "CMAKE_HOST_SYSTEM_NAME",
+    "description": "Name of the OS CMake is running on."
+  },
+  "CMAKE_HOST_SYSTEM_PROCESSOR": {
+    "name": "CMAKE_HOST_SYSTEM_PROCESSOR",
+    "description": "The name of the CPU CMake is running on."
+  },
+  "CMAKE_HOST_SYSTEM_VERSION": {
+    "name": "CMAKE_HOST_SYSTEM_VERSION",
+    "description": "The OS version CMake is running on."
+  },
+  "CMAKE_HOST_UNIX": {
+    "name": "CMAKE_HOST_UNIX",
+    "description": "True for UNIX and UNIX like operating systems."
+  },
+  "CMAKE_HOST_WIN32": {
+    "name": "CMAKE_HOST_WIN32",
+    "description": "True if the host system is running Windows, including Windows 64-bit and MSYS."
+  },
+  "CMAKE_IGNORE_PATH": {
+    "name": "CMAKE_IGNORE_PATH",
+    "description": "Semicolon-separated list  of directories to be ignored by the various find...() commands."
+  },
+  "CMAKE_IGNORE_PREFIX_PATH": {
+    "name": "CMAKE_IGNORE_PREFIX_PATH",
+    "description": "Semicolon-separated list  of search prefixes to be ignored by the find_program, find_library, find_file, and find_path commands. The prefixes are also ignored by the Config mode of the find_package command (Module mode is unaffected). To ignore specific directories instead, see CMAKE_IGNORE_NONPREFIX_VAR."
+  },
+  "CMAKE_IMPORT_LIBRARY_PREFIX": {
+    "name": "CMAKE_IMPORT_LIBRARY_PREFIX",
+    "description": "The prefix for import libraries that you link to."
+  },
+  "CMAKE_IMPORT_LIBRARY_SUFFIX": {
+    "name": "CMAKE_IMPORT_LIBRARY_SUFFIX",
+    "description": "The suffix for import libraries that you link to."
+  },
+  "CMAKE_INCLUDE_CURRENT_DIR": {
+    "name": "CMAKE_INCLUDE_CURRENT_DIR",
+    "description": "Automatically add the current source and build directories to the include path."
+  },
+  "CMAKE_INCLUDE_CURRENT_DIR_IN_INTERFACE": {
+    "name": "CMAKE_INCLUDE_CURRENT_DIR_IN_INTERFACE",
+    "description": "Automatically add the current source and build directories to the INTERFACE_INCLUDE_DIRECTORIES target property."
+  },
+  "CMAKE_INCLUDE_DIRECTORIES_BEFORE": {
+    "name": "CMAKE_INCLUDE_DIRECTORIES_BEFORE",
+    "description": "Whether to append or prepend directories by default in include_directories."
+  },
+  "CMAKE_INCLUDE_DIRECTORIES_PROJECT_BEFORE": {
+    "name": "CMAKE_INCLUDE_DIRECTORIES_PROJECT_BEFORE",
+    "description": "Whether to force prepending of project include directories."
+  },
+  "CMAKE_INCLUDE_PATH": {
+    "name": "CMAKE_INCLUDE_PATH",
+    "description": "Semicolon-separated list  of directories specifying a search path for the find_file and find_path commands. By default it is empty, it is intended to be set by the project."
+  },
+  "CMAKE_INSTALL_DEFAULT_COMPONENT_NAME": {
+    "name": "CMAKE_INSTALL_DEFAULT_COMPONENT_NAME",
+    "description": "Default component used in install commands."
+  },
+  "CMAKE_INSTALL_DEFAULT_DIRECTORY_PERMISSIONS": {
+    "name": "CMAKE_INSTALL_DEFAULT_DIRECTORY_PERMISSIONS",
+    "description": "Default permissions for directories created implicitly during installation of files by install and file."
+  },
+  "CMAKE_INSTALL_MESSAGE": {
+    "name": "CMAKE_INSTALL_MESSAGE",
+    "description": "Specify verbosity of installation script code generated by the install command (using the file command). For paths that are newly installed or updated, installation may print lines like:"
+  },
+  "CMAKE_INSTALL_NAME_DIR": {
+    "name": "CMAKE_INSTALL_NAME_DIR",
+    "description": "Directory name for installed targets on Apple platforms."
+  },
+  "CMAKE_INSTALL_PREFIX": {
+    "name": "CMAKE_INSTALL_PREFIX",
+    "description": "Install directory used by install."
+  },
+  "CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT": {
+    "name": "CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT",
+    "description": "CMake sets this variable to a TRUE value when the CMAKE_INSTALL_PREFIX has just been initialized to its default value, typically on the first run of CMake within a new build tree and the CMAKE_INSTALL_PREFIX environment variable is not set on the first run of CMake. This can be used by project code to change the default without overriding a user-provided value:"
+  },
+  "CMAKE_INSTALL_REMOVE_ENVIRONMENT_RPATH": {
+    "name": "CMAKE_INSTALL_REMOVE_ENVIRONMENT_RPATH",
+    "description": "Sets the default for whether toolchain-defined rpaths should be removed during installation."
+  },
+  "CMAKE_INSTALL_RPATH": {
+    "name": "CMAKE_INSTALL_RPATH",
+    "description": "The rpath to use for installed targets."
+  },
+  "CMAKE_INSTALL_RPATH_USE_LINK_PATH": {
+    "name": "CMAKE_INSTALL_RPATH_USE_LINK_PATH",
+    "description": "Add paths to linker search and installed rpath."
+  },
+  "CMAKE_INTERNAL_PLATFORM_ABI": {
+    "name": "CMAKE_INTERNAL_PLATFORM_ABI",
+    "description": "An internal variable subject to change."
+  },
+  "CMAKE_INTERPROCEDURAL_OPTIMIZATION": {
+    "name": "CMAKE_INTERPROCEDURAL_OPTIMIZATION",
+    "description": "Default value for INTERPROCEDURAL_OPTIMIZATION of targets."
+  },
+  "CMAKE_INTERPROCEDURAL_OPTIMIZATION_<CONFIG>": {
+    "name": "CMAKE_INTERPROCEDURAL_OPTIMIZATION_<CONFIG>",
+    "description": "Default value for INTERPROCEDURAL_OPTIMIZATION_ of targets."
+  },
+  "CMAKE_IOS_INSTALL_COMBINED": {
+    "name": "CMAKE_IOS_INSTALL_COMBINED",
+    "description": "Default value for IOS_INSTALL_COMBINED of targets."
+  },
+  "CMAKE_ISPC_HEADER_DIRECTORY": {
+    "name": "CMAKE_ISPC_HEADER_DIRECTORY",
+    "description": "ISPC generated header output directory."
+  },
+  "CMAKE_ISPC_HEADER_SUFFIX": {
+    "name": "CMAKE_ISPC_HEADER_SUFFIX",
+    "description": "Output suffix to be used for ISPC generated headers."
+  },
+  "CMAKE_ISPC_INSTRUCTION_SETS": {
+    "name": "CMAKE_ISPC_INSTRUCTION_SETS",
+    "description": "Default value for ISPC_INSTRUCTION_SETS property of targets."
+  },
+  "CMAKE_JOB_POOLS": {
+    "name": "CMAKE_JOB_POOLS",
+    "description": "If the JOB_POOLS global property is not set, the value of this variable is used in its place. See JOB_POOLS for additional information."
+  },
+  "CMAKE_JOB_POOL_COMPILE": {
+    "name": "CMAKE_JOB_POOL_COMPILE",
+    "description": "This variable is used to initialize the JOB_POOL_COMPILE property on all the targets. See JOB_POOL_COMPILE for additional information."
+  },
+  "CMAKE_JOB_POOL_LINK": {
+    "name": "CMAKE_JOB_POOL_LINK",
+    "description": "This variable is used to initialize the JOB_POOL_LINK property on all the targets. See JOB_POOL_LINK for additional information."
+  },
+  "CMAKE_JOB_POOL_PRECOMPILE_HEADER": {
+    "name": "CMAKE_JOB_POOL_PRECOMPILE_HEADER",
+    "description": "This variable is used to initialize the JOB_POOL_PRECOMPILE_HEADER property on all the targets. See JOB_POOL_PRECOMPILE_HEADER for additional information."
+  },
+  "CMAKE_KATE_FILES_MODE": {
+    "name": "CMAKE_KATE_FILES_MODE",
+    "description": "This cache variable is used by the Kate project generator and controls to what mode the files entry in the project file will be set. See cmake-generators."
+  },
+  "CMAKE_KATE_MAKE_ARGUMENTS": {
+    "name": "CMAKE_KATE_MAKE_ARGUMENTS",
+    "description": "This cache variable is used by the Kate project generator. See cmake-generators."
+  },
+  "CMAKE_<LANG>_ANDROID_TOOLCHAIN_MACHINE": {
+    "name": "CMAKE_<LANG>_ANDROID_TOOLCHAIN_MACHINE",
+    "description": "When Cross Compiling for Android this variable contains the toolchain binutils machine name (e.g. gcc -dumpmachine). The binutils typically have a <machine>- prefix on their name."
+  },
+  "CMAKE_<LANG>_ANDROID_TOOLCHAIN_PREFIX": {
+    "name": "CMAKE_<LANG>_ANDROID_TOOLCHAIN_PREFIX",
+    "description": "When Cross Compiling for Android this variable contains the absolute path prefixing the toolchain GNU compiler and its binutils."
+  },
+  "CMAKE_<LANG>_ANDROID_TOOLCHAIN_SUFFIX": {
+    "name": "CMAKE_<LANG>_ANDROID_TOOLCHAIN_SUFFIX",
+    "description": "When Cross Compiling for Android this variable contains the host platform suffix of the toolchain GNU compiler and its binutils."
+  },
+  "CMAKE_<LANG>_ARCHIVE_APPEND": {
+    "name": "CMAKE_<LANG>_ARCHIVE_APPEND",
+    "description": "Rule variable to append to a static archive."
+  },
+  "CMAKE_<LANG>_ARCHIVE_CREATE": {
+    "name": "CMAKE_<LANG>_ARCHIVE_CREATE",
+    "description": "Rule variable to create a new static archive."
+  },
+  "CMAKE_<LANG>_ARCHIVE_FINISH": {
+    "name": "CMAKE_<LANG>_ARCHIVE_FINISH",
+    "description": "Rule variable to finish an existing static archive."
+  },
+  "CMAKE_<LANG>_BYTE_ORDER": {
+    "name": "CMAKE_<LANG>_BYTE_ORDER",
+    "description": "Byte order of <LANG> compiler target architecture, if known. If defined and not empty, the value is one of:"
+  },
+  "CMAKE_<LANG>_CLANG_TIDY": {
+    "name": "CMAKE_<LANG>_CLANG_TIDY",
+    "description": "Default value for <LANG>_CLANG_TIDY target property when <LANG> is C, CXX, OBJC or OBJCXX."
+  },
+  "CMAKE_<LANG>_CLANG_TIDY_EXPORT_FIXES_DIR": {
+    "name": "CMAKE_<LANG>_CLANG_TIDY_EXPORT_FIXES_DIR",
+    "description": "Default value for <LANG>_CLANG_TIDY_EXPORT_FIXES_DIR target property when <LANG> is C, CXX, OBJC or OBJCXX."
+  },
+  "CMAKE_<LANG>_COMPILER": {
+    "name": "CMAKE_<LANG>_COMPILER",
+    "description": "The full path to the compiler for LANG."
+  },
+  "CMAKE_<LANG>_COMPILER_ABI": {
+    "name": "CMAKE_<LANG>_COMPILER_ABI",
+    "description": "An internal variable subject to change."
+  },
+  "CMAKE_<LANG>_COMPILER_AR": {
+    "name": "CMAKE_<LANG>_COMPILER_AR",
+    "description": "A wrapper around ar adding the appropriate --plugin option for the compiler."
+  },
+  "CMAKE_<LANG>_COMPILER_ARCHITECTURE_ID": {
+    "name": "CMAKE_<LANG>_COMPILER_ARCHITECTURE_ID",
+    "description": "An internal variable subject to change."
+  },
+  "CMAKE_<LANG>_COMPILER_EXTERNAL_TOOLCHAIN": {
+    "name": "CMAKE_<LANG>_COMPILER_EXTERNAL_TOOLCHAIN",
+    "description": "The external toolchain for cross-compiling, if supported."
+  },
+  "CMAKE_<LANG>_COMPILER_FRONTEND_VARIANT": {
+    "name": "CMAKE_<LANG>_COMPILER_FRONTEND_VARIANT",
+    "description": "Identification string of the compiler frontend variant."
+  },
+  "CMAKE_<LANG>_COMPILER_ID": {
+    "name": "CMAKE_<LANG>_COMPILER_ID",
+    "description": "Compiler identification string."
+  },
+  "CMAKE_<LANG>_COMPILER_LAUNCHER": {
+    "name": "CMAKE_<LANG>_COMPILER_LAUNCHER",
+    "description": "Default value for <LANG>_COMPILER_LAUNCHER target property. This variable is used to initialize the property on each target as it is created. This is done only when <LANG> is C, CXX, Fortran, HIP, ISPC, OBJC, OBJCXX, or CUDA."
+  },
+  "CMAKE_<LANG>_COMPILER_LINKER": {
+    "name": "CMAKE_<LANG>_COMPILER_LINKER",
+    "description": "The full path to the linker for LANG."
+  },
+  "CMAKE_<LANG>_COMPILER_LINKER_FRONTEND_VARIANT": {
+    "name": "CMAKE_<LANG>_COMPILER_LINKER_FRONTEND_VARIANT",
+    "description": "Identification string of the linker frontend variant."
+  },
+  "CMAKE_<LANG>_COMPILER_LINKER_ID": {
+    "name": "CMAKE_<LANG>_COMPILER_LINKER_ID",
+    "description": "Linker identification string."
+  },
+  "CMAKE_<LANG>_COMPILER_LINKER_VERSION": {
+    "name": "CMAKE_<LANG>_COMPILER_LINKER_VERSION",
+    "description": "Linker version string."
+  },
+  "CMAKE_<LANG>_COMPILER_LOADED": {
+    "name": "CMAKE_<LANG>_COMPILER_LOADED",
+    "description": "Defined to true if the language is enabled."
+  },
+  "CMAKE_<LANG>_COMPILER_PREDEFINES_COMMAND": {
+    "name": "CMAKE_<LANG>_COMPILER_PREDEFINES_COMMAND",
+    "description": "Command that outputs the compiler pre definitions."
+  },
+  "CMAKE_<LANG>_COMPILER_RANLIB": {
+    "name": "CMAKE_<LANG>_COMPILER_RANLIB",
+    "description": "A wrapper around ranlib adding the appropriate --plugin option for the compiler."
+  },
+  "CMAKE_<LANG>_COMPILER_TARGET": {
+    "name": "CMAKE_<LANG>_COMPILER_TARGET",
+    "description": "The target for cross-compiling, if supported."
+  },
+  "CMAKE_<LANG>_COMPILER_VERSION": {
+    "name": "CMAKE_<LANG>_COMPILER_VERSION",
+    "description": "Compiler version string."
+  },
+  "CMAKE_<LANG>_COMPILER_VERSION_INTERNAL": {
+    "name": "CMAKE_<LANG>_COMPILER_VERSION_INTERNAL",
+    "description": "An internal variable subject to change."
+  },
+  "CMAKE_<LANG>_COMPILE_OBJECT": {
+    "name": "CMAKE_<LANG>_COMPILE_OBJECT",
+    "description": "Rule variable to compile a single object file."
+  },
+  "CMAKE_<LANG>_CPPCHECK": {
+    "name": "CMAKE_<LANG>_CPPCHECK",
+    "description": "Default value for <LANG>_CPPCHECK target property. This variable is used to initialize the property on each target as it is created. This is done only when <LANG> is C or CXX."
+  },
+  "CMAKE_<LANG>_CPPLINT": {
+    "name": "CMAKE_<LANG>_CPPLINT",
+    "description": "Default value for <LANG>_CPPLINT target property. This variable is used to initialize the property on each target as it is created. This is done only when <LANG> is C or CXX."
+  },
+  "CMAKE_<LANG>_CREATE_SHARED_LIBRARY": {
+    "name": "CMAKE_<LANG>_CREATE_SHARED_LIBRARY",
+    "description": "Rule variable to create a shared library."
+  },
+  "CMAKE_<LANG>_CREATE_SHARED_MODULE": {
+    "name": "CMAKE_<LANG>_CREATE_SHARED_MODULE",
+    "description": "Rule variable to create a shared module."
+  },
+  "CMAKE_<LANG>_CREATE_STATIC_LIBRARY": {
+    "name": "CMAKE_<LANG>_CREATE_STATIC_LIBRARY",
+    "description": "Rule variable to create a static library."
+  },
+  "CMAKE_<LANG>_EXTENSIONS": {
+    "name": "CMAKE_<LANG>_EXTENSIONS",
+    "description": "The variations are:"
+  },
+  "CMAKE_<LANG>_EXTENSIONS_DEFAULT": {
+    "name": "CMAKE_<LANG>_EXTENSIONS_DEFAULT",
+    "description": "Compiler's default extensions mode. Used as the default for the <LANG>_EXTENSIONS target property when CMAKE_<LANG>_EXTENSIONS is not set (see CMP0128)."
+  },
+  "CMAKE_<LANG>_FLAGS": {
+    "name": "CMAKE_<LANG>_FLAGS",
+    "description": "Language-wide flags for language <LANG> used when building for all configurations. These flags will be passed to all invocations of the compiler. This includes invocations that drive compiling and those that drive linking."
+  },
+  "CMAKE_<LANG>_FLAGS_<CONFIG>": {
+    "name": "CMAKE_<LANG>_FLAGS_<CONFIG>",
+    "description": "Language-wide flags for language <LANG> used when building for the <CONFIG> configuration. These flags will be passed to all invocations of the compiler in the corresponding configuration. This includes invocations that drive compiling and those that drive linking."
+  },
+  "CMAKE_<LANG>_FLAGS_<CONFIG>_INIT": {
+    "name": "CMAKE_<LANG>_FLAGS_<CONFIG>_INIT",
+    "description": "Value used to initialize the CMAKE_<LANG>_FLAGS_ cache entry the first time a build tree is configured for language <LANG>. This variable is meant to be set by a toolchain file . CMake may prepend or append content to the value based on the environment and target platform."
+  },
+  "CMAKE_<LANG>_FLAGS_DEBUG": {
+    "name": "CMAKE_<LANG>_FLAGS_DEBUG",
+    "description": "This variable is the Debug variant of the CMAKE_<LANG>_FLAGS_ variable."
+  },
+  "CMAKE_<LANG>_FLAGS_DEBUG_INIT": {
+    "name": "CMAKE_<LANG>_FLAGS_DEBUG_INIT",
+    "description": "This variable is the Debug variant of the CMAKE_<LANG>_FLAGS_<CONFIG>_INIT variable."
+  },
+  "CMAKE_<LANG>_FLAGS_INIT": {
+    "name": "CMAKE_<LANG>_FLAGS_INIT",
+    "description": "Value used to initialize the CMAKE_<LANG>_FLAGS cache entry the first time a build tree is configured for language <LANG>. This variable is meant to be set by a toolchain file . CMake may prepend or append content to the value based on the environment and target platform. For example, the contents of a xxxFLAGS environment variable will be prepended, where xxx will be language-specific but not necessarily the same as <LANG> (e.g. CXXFLAGS for CXX, FFLAGS for Fortran, and so on). This value is a command-line string fragment. Therefore, multiple options should be separated by spaces, and options with spaces should be quoted."
+  },
+  "CMAKE_<LANG>_FLAGS_MINSIZEREL": {
+    "name": "CMAKE_<LANG>_FLAGS_MINSIZEREL",
+    "description": "This variable is the MinSizeRel variant of the CMAKE_<LANG>_FLAGS_ variable."
+  },
+  "CMAKE_<LANG>_FLAGS_MINSIZEREL_INIT": {
+    "name": "CMAKE_<LANG>_FLAGS_MINSIZEREL_INIT",
+    "description": "This variable is the MinSizeRel variant of the CMAKE_<LANG>_FLAGS_<CONFIG>_INIT variable."
+  },
+  "CMAKE_<LANG>_FLAGS_RELEASE": {
+    "name": "CMAKE_<LANG>_FLAGS_RELEASE",
+    "description": "This variable is the Release variant of the CMAKE_<LANG>_FLAGS_ variable."
+  },
+  "CMAKE_<LANG>_FLAGS_RELEASE_INIT": {
+    "name": "CMAKE_<LANG>_FLAGS_RELEASE_INIT",
+    "description": "This variable is the Release variant of the CMAKE_<LANG>_FLAGS_<CONFIG>_INIT variable."
+  },
+  "CMAKE_<LANG>_FLAGS_RELWITHDEBINFO": {
+    "name": "CMAKE_<LANG>_FLAGS_RELWITHDEBINFO",
+    "description": "This variable is the RelWithDebInfo variant of the CMAKE_<LANG>_FLAGS_ variable."
+  },
+  "CMAKE_<LANG>_FLAGS_RELWITHDEBINFO_INIT": {
+    "name": "CMAKE_<LANG>_FLAGS_RELWITHDEBINFO_INIT",
+    "description": "This variable is the RelWithDebInfo variant of the CMAKE_<LANG>_FLAGS_<CONFIG>_INIT variable."
+  },
+  "CMAKE_<LANG>_HOST_COMPILER": {
+    "name": "CMAKE_<LANG>_HOST_COMPILER",
+    "description": "This variable is available when <LANG> is CUDA or HIP."
+  },
+  "CMAKE_<LANG>_IGNORE_EXTENSIONS": {
+    "name": "CMAKE_<LANG>_IGNORE_EXTENSIONS",
+    "description": "File extensions that should be ignored by the build."
+  },
+  "CMAKE_<LANG>_IMPLICIT_INCLUDE_DIRECTORIES": {
+    "name": "CMAKE_<LANG>_IMPLICIT_INCLUDE_DIRECTORIES",
+    "description": "Directories implicitly searched by the compiler for header files."
+  },
+  "CMAKE_<LANG>_IMPLICIT_LINK_DIRECTORIES": {
+    "name": "CMAKE_<LANG>_IMPLICIT_LINK_DIRECTORIES",
+    "description": "Implicit linker search path detected for language <LANG>."
+  },
+  "CMAKE_<LANG>_IMPLICIT_LINK_FRAMEWORK_DIRECTORIES": {
+    "name": "CMAKE_<LANG>_IMPLICIT_LINK_FRAMEWORK_DIRECTORIES",
+    "description": "Implicit linker framework search path detected for language <LANG>."
+  },
+  "CMAKE_<LANG>_IMPLICIT_LINK_LIBRARIES": {
+    "name": "CMAKE_<LANG>_IMPLICIT_LINK_LIBRARIES",
+    "description": "Implicit link libraries and flags detected for language <LANG>."
+  },
+  "CMAKE_<LANG>_INCLUDE_WHAT_YOU_USE": {
+    "name": "CMAKE_<LANG>_INCLUDE_WHAT_YOU_USE",
+    "description": "Default value for <LANG>_INCLUDE_WHAT_YOU_USE target property. This variable is used to initialize the property on each target as it is created. This is done only when <LANG> is C or CXX."
+  },
+  "CMAKE_<LANG>_LIBRARY_ARCHITECTURE": {
+    "name": "CMAKE_<LANG>_LIBRARY_ARCHITECTURE",
+    "description": "Target architecture library directory name detected for <LANG>."
+  },
+  "CMAKE_<LANG>_LINKER_LAUNCHER": {
+    "name": "CMAKE_<LANG>_LINKER_LAUNCHER",
+    "description": "Default value for <LANG>_LINKER_LAUNCHER target property. This variable is used to initialize the property on each target as it is created. This is done only when <LANG> is C, CXX, OBJC, or OBJCXX."
+  },
+  "CMAKE_<LANG>_LINKER_PREFERENCE": {
+    "name": "CMAKE_<LANG>_LINKER_PREFERENCE",
+    "description": "An internal variable subject to change."
+  },
+  "CMAKE_<LANG>_LINKER_PREFERENCE_PROPAGATES": {
+    "name": "CMAKE_<LANG>_LINKER_PREFERENCE_PROPAGATES",
+    "description": "An internal variable subject to change."
+  },
+  "CMAKE_<LANG>_LINKER_WRAPPER_FLAG": {
+    "name": "CMAKE_<LANG>_LINKER_WRAPPER_FLAG",
+    "description": "Defines the syntax of compiler driver option to pass options to the linker tool. It will be used to translate the LINKER: prefix in the link options (see add_link_options and target_link_options)."
+  },
+  "CMAKE_<LANG>_LINKER_WRAPPER_FLAG_SEP": {
+    "name": "CMAKE_<LANG>_LINKER_WRAPPER_FLAG_SEP",
+    "description": "This variable is used with CMAKE_<LANG>_LINKER_WRAPPER_FLAG variable to format LINKER: prefix in the link options (see add_link_options and target_link_options)."
+  },
+  "CMAKE_<LANG>_LINK_EXECUTABLE": {
+    "name": "CMAKE_<LANG>_LINK_EXECUTABLE",
+    "description": "Rule variable to link an executable."
+  },
+  "CMAKE_<LANG>_LINK_GROUP_USING_<FEATURE>": {
+    "name": "CMAKE_<LANG>_LINK_GROUP_USING_<FEATURE>",
+    "description": "This variable defines how to link a group of libraries for the specified <FEATURE> when a LINK_GROUP generator expression is used and the link language for the target is <LANG>. For this variable to have any effect, the associated CMAKE_<LANG>_LINK_GROUP_USING_<FEATURE>_SUPPORTED variable must be set to true."
+  },
+  "CMAKE_<LANG>_LINK_GROUP_USING_<FEATURE>_SUPPORTED": {
+    "name": "CMAKE_<LANG>_LINK_GROUP_USING_<FEATURE>_SUPPORTED",
+    "description": "This variable specifies whether the <FEATURE> is supported for the link language <LANG>. If this variable is true, then the <FEATURE> must be defined by CMAKE_<LANG>_LINK_GROUP_USING_, and the more generic CMAKE_LINK_GROUP_USING_<FEATURE>_SUPPORTED and CMAKE_LINK_GROUP_USING_ variables are not used."
+  },
+  "CMAKE_<LANG>_LINK_LIBRARY_<FEATURE>_ATTRIBUTES": {
+    "name": "CMAKE_<LANG>_LINK_LIBRARY_<FEATURE>_ATTRIBUTES",
+    "description": "This variable defines the semantics of the specified link library <FEATURE> when linking with the link language <LANG>. It takes precedence over CMAKE_LINK_LIBRARY_<FEATURE>_ATTRIBUTES if that variable is also defined for the same <FEATURE>, but otherwise has similar effects. See CMAKE_LINK_LIBRARY_<FEATURE>_ATTRIBUTES for further details."
+  },
+  "CMAKE_<LANG>_LINK_LIBRARY_FILE_FLAG": {
+    "name": "CMAKE_<LANG>_LINK_LIBRARY_FILE_FLAG",
+    "description": "Language-specific flag to be used to link a library specified by a path to its file."
+  },
+  "CMAKE_<LANG>_LINK_LIBRARY_FLAG": {
+    "name": "CMAKE_<LANG>_LINK_LIBRARY_FLAG",
+    "description": "Flag to be used to link a library into a shared library or executable."
+  },
+  "CMAKE_<LANG>_LINK_LIBRARY_SUFFIX": {
+    "name": "CMAKE_<LANG>_LINK_LIBRARY_SUFFIX",
+    "description": "Language-specific suffix for libraries that you link to."
+  },
+  "CMAKE_<LANG>_LINK_LIBRARY_USING_<FEATURE>": {
+    "name": "CMAKE_<LANG>_LINK_LIBRARY_USING_<FEATURE>",
+    "description": "This variable defines how to link a library or framework for the specified <FEATURE> when a LINK_LIBRARY generator expression is used and the link language for the target is <LANG>. For this variable to have any effect, the associated CMAKE_<LANG>_LINK_LIBRARY_USING_<FEATURE>_SUPPORTED variable must be set to true."
+  },
+  "CMAKE_<LANG>_LINK_LIBRARY_USING_<FEATURE>_SUPPORTED": {
+    "name": "CMAKE_<LANG>_LINK_LIBRARY_USING_<FEATURE>_SUPPORTED",
+    "description": "Set to TRUE if the <FEATURE>, as defined by variable CMAKE_<LANG>_LINK_LIBRARY_USING_, is supported for the linker language <LANG>."
+  },
+  "CMAKE_<LANG>_LINK_WHAT_YOU_USE_FLAG": {
+    "name": "CMAKE_<LANG>_LINK_WHAT_YOU_USE_FLAG",
+    "description": "Linker flag to be used to configure linker so that all specified libraries on the command line will be linked into the target."
+  },
+  "CMAKE_<LANG>_OUTPUT_EXTENSION": {
+    "name": "CMAKE_<LANG>_OUTPUT_EXTENSION",
+    "description": "Extension for the output of a compile for a single file."
+  },
+  "CMAKE_<LANG>_PLATFORM_ID": {
+    "name": "CMAKE_<LANG>_PLATFORM_ID",
+    "description": "An internal variable subject to change."
+  },
+  "CMAKE_<LANG>_SIMULATE_ID": {
+    "name": "CMAKE_<LANG>_SIMULATE_ID",
+    "description": "Identification string of the \"simulated\" compiler."
+  },
+  "CMAKE_<LANG>_SIMULATE_VERSION": {
+    "name": "CMAKE_<LANG>_SIMULATE_VERSION",
+    "description": "Version string of \"simulated\" compiler."
+  },
+  "CMAKE_<LANG>_SIZEOF_DATA_PTR": {
+    "name": "CMAKE_<LANG>_SIZEOF_DATA_PTR",
+    "description": "Size of pointer-to-data types for language <LANG>."
+  },
+  "CMAKE_<LANG>_SOURCE_FILE_EXTENSIONS": {
+    "name": "CMAKE_<LANG>_SOURCE_FILE_EXTENSIONS",
+    "description": "Extensions of source files for the given language."
+  },
+  "CMAKE_<LANG>_STANDARD": {
+    "name": "CMAKE_<LANG>_STANDARD",
+    "description": "The variations are:"
+  },
+  "CMAKE_<LANG>_STANDARD_DEFAULT": {
+    "name": "CMAKE_<LANG>_STANDARD_DEFAULT",
+    "description": "The compiler's default standard for the language <LANG>. Empty if the compiler has no conception of standard levels."
+  },
+  "CMAKE_<LANG>_STANDARD_INCLUDE_DIRECTORIES": {
+    "name": "CMAKE_<LANG>_STANDARD_INCLUDE_DIRECTORIES",
+    "description": "Include directories to be used for every source file compiled with the <LANG> compiler. This is meant for specification of system include directories needed by the language for the current platform. The directories always appear at the end of the include path passed to the compiler."
+  },
+  "CMAKE_<LANG>_STANDARD_LATEST": {
+    "name": "CMAKE_<LANG>_STANDARD_LATEST",
+    "description": "This variable represents the minimum between the latest version of the standard for language <LANG> which is supported by the current compiler and the latest version which is supported by CMake. Its value will be set to one of the supported values of the corresponding <LANG>_STANDARD target property; see the documentation of that property for a list of supported languages."
+  },
+  "CMAKE_<LANG>_STANDARD_LIBRARIES": {
+    "name": "CMAKE_<LANG>_STANDARD_LIBRARIES",
+    "description": "Libraries linked into every executable and shared library linked for language <LANG>. This is meant for specification of system libraries needed by the language for the current platform."
+  },
+  "CMAKE_<LANG>_STANDARD_REQUIRED": {
+    "name": "CMAKE_<LANG>_STANDARD_REQUIRED",
+    "description": "The variations are:"
+  },
+  "CMAKE_<LANG>_USING_LINKER_MODE": {
+    "name": "CMAKE_<LANG>_USING_LINKER_MODE",
+    "description": "This controls how the value of the CMAKE_<LANG>_USING_LINKER_ variable should be interpreted. The supported linker mode values are:"
+  },
+  "CMAKE_<LANG>_USING_LINKER_<TYPE>": {
+    "name": "CMAKE_<LANG>_USING_LINKER_<TYPE>",
+    "description": "This variable defines how to specify the <TYPE> linker for the link step, as controlled by the CMAKE_LINKER_TYPE variable or the LINKER_TYPE target property. Depending on the value of the CMAKE_<LANG>_USING_LINKER_MODE variable, CMAKE_<LANG>_USING_LINKER_<TYPE> can hold compiler flags for the link step, or flags to be given directly to the linker tool."
+  },
+  "CMAKE_<LANG>_VISIBILITY_PRESET": {
+    "name": "CMAKE_<LANG>_VISIBILITY_PRESET",
+    "description": "Default value for the <LANG>_VISIBILITY_PRESET target property when a target is created."
+  },
+  "CMAKE_LIBRARY_ARCHITECTURE": {
+    "name": "CMAKE_LIBRARY_ARCHITECTURE",
+    "description": "Target architecture library directory name, if detected."
+  },
+  "CMAKE_LIBRARY_ARCHITECTURE_REGEX": {
+    "name": "CMAKE_LIBRARY_ARCHITECTURE_REGEX",
+    "description": "Regex matching possible target architecture library directory names."
+  },
+  "CMAKE_LIBRARY_OUTPUT_DIRECTORY": {
+    "name": "CMAKE_LIBRARY_OUTPUT_DIRECTORY",
+    "description": "Where to put all the LIBRARY  target files when built."
+  },
+  "CMAKE_LIBRARY_OUTPUT_DIRECTORY_<CONFIG>": {
+    "name": "CMAKE_LIBRARY_OUTPUT_DIRECTORY_<CONFIG>",
+    "description": "Where to put all the LIBRARY  target files when built for a specific configuration."
+  },
+  "CMAKE_LIBRARY_PATH": {
+    "name": "CMAKE_LIBRARY_PATH",
+    "description": "Semicolon-separated list  of directories specifying a search path for the find_library command. By default it is empty, it is intended to be set by the project."
+  },
+  "CMAKE_LIBRARY_PATH_FLAG": {
+    "name": "CMAKE_LIBRARY_PATH_FLAG",
+    "description": "The flag to be used to add a library search path to a compiler."
+  },
+  "CMAKE_LINKER_TYPE": {
+    "name": "CMAKE_LINKER_TYPE",
+    "description": "Specify which linker will be used for the link step."
+  },
+  "CMAKE_LINK_DEF_FILE_FLAG": {
+    "name": "CMAKE_LINK_DEF_FILE_FLAG",
+    "description": "Linker flag to be used to specify a .def file for dll creation."
+  },
+  "CMAKE_LINK_DEPENDS_NO_SHARED": {
+    "name": "CMAKE_LINK_DEPENDS_NO_SHARED",
+    "description": "Whether to skip link dependencies on shared library files."
+  },
+  "CMAKE_LINK_DEPENDS_USE_LINKER": {
+    "name": "CMAKE_LINK_DEPENDS_USE_LINKER",
+    "description": "For the Makefile  and Ninja  generators, link dependencies are now, for a selection of linkers, generated by the linker itself. By defining this variable with value FALSE, you can deactivate this feature."
+  },
+  "CMAKE_LINK_DIRECTORIES_BEFORE": {
+    "name": "CMAKE_LINK_DIRECTORIES_BEFORE",
+    "description": "Whether to append or prepend directories by default in link_directories."
+  },
+  "CMAKE_LINK_GROUP_USING_<FEATURE>": {
+    "name": "CMAKE_LINK_GROUP_USING_<FEATURE>",
+    "description": "This variable defines how to link a group of libraries for the specified <FEATURE> when a LINK_GROUP generator expression is used. Both of the following conditions must be met for this variable to have any effect:"
+  },
+  "CMAKE_LINK_GROUP_USING_<FEATURE>_SUPPORTED": {
+    "name": "CMAKE_LINK_GROUP_USING_<FEATURE>_SUPPORTED",
+    "description": "This variable specifies whether the <FEATURE> is supported regardless of the link language. If this variable is true, then the <FEATURE> must be defined by CMAKE_LINK_GROUP_USING_."
+  },
+  "CMAKE_LINK_INTERFACE_LIBRARIES": {
+    "name": "CMAKE_LINK_INTERFACE_LIBRARIES",
+    "description": "Default value for LINK_INTERFACE_LIBRARIES of targets."
+  },
+  "CMAKE_LINK_LIBRARIES_ONLY_TARGETS": {
+    "name": "CMAKE_LINK_LIBRARIES_ONLY_TARGETS",
+    "description": "Set this variable to initialize the LINK_LIBRARIES_ONLY_TARGETS property of non-imported targets when they are created. Setting it to true enables an additional check that all items named by target_link_libraries that can be target names are actually names of existing targets. See the target property documentation for details."
+  },
+  "CMAKE_LINK_LIBRARY_<FEATURE>_ATTRIBUTES": {
+    "name": "CMAKE_LINK_LIBRARY_<FEATURE>_ATTRIBUTES",
+    "description": "This variable defines the behavior of the specified link library <FEATURE>. It specifies how the <FEATURE> interacts with other features, when the <FEATURE> should be applied, and aspects of how the <FEATURE> should be handled when CMake assembles the final linker command line (e.g. de-duplication)."
+  },
+  "CMAKE_LINK_LIBRARY_FILE_FLAG": {
+    "name": "CMAKE_LINK_LIBRARY_FILE_FLAG",
+    "description": "Flag to be used to link a library specified by a path to its file."
+  },
+  "CMAKE_LINK_LIBRARY_FLAG": {
+    "name": "CMAKE_LINK_LIBRARY_FLAG",
+    "description": "Flag to be used to link a library into an executable."
+  },
+  "CMAKE_LINK_LIBRARY_SUFFIX": {
+    "name": "CMAKE_LINK_LIBRARY_SUFFIX",
+    "description": "The suffix for libraries that you link to."
+  },
+  "CMAKE_LINK_LIBRARY_USING_<FEATURE>": {
+    "name": "CMAKE_LINK_LIBRARY_USING_<FEATURE>",
+    "description": "This variable defines how to link a library or framework for the specified <FEATURE> when a LINK_LIBRARY generator expression is used. Both of the following conditions must be met for this variable to have any effect:"
+  },
+  "CMAKE_LINK_LIBRARY_USING_<FEATURE>_SUPPORTED": {
+    "name": "CMAKE_LINK_LIBRARY_USING_<FEATURE>_SUPPORTED",
+    "description": "Set to TRUE if the <FEATURE>, as defined by variable CMAKE_LINK_LIBRARY_USING_, is supported regardless the linker language."
+  },
+  "CMAKE_LINK_SEARCH_END_STATIC": {
+    "name": "CMAKE_LINK_SEARCH_END_STATIC",
+    "description": "End a link line such that static system libraries are used."
+  },
+  "CMAKE_LINK_SEARCH_START_STATIC": {
+    "name": "CMAKE_LINK_SEARCH_START_STATIC",
+    "description": "Assume the linker looks for static libraries by default."
+  },
+  "CMAKE_LINK_WHAT_YOU_USE": {
+    "name": "CMAKE_LINK_WHAT_YOU_USE",
+    "description": "Default value for LINK_WHAT_YOU_USE target property. This variable is used to initialize the property on each target as it is created."
+  },
+  "CMAKE_LINK_WHAT_YOU_USE_CHECK": {
+    "name": "CMAKE_LINK_WHAT_YOU_USE_CHECK",
+    "description": "Defines the command executed after the link step to check libraries usage. This check is currently only defined on ELF platforms with value ldd -u -r."
+  },
+  "CMAKE_MACOSX_BUNDLE": {
+    "name": "CMAKE_MACOSX_BUNDLE",
+    "description": "Default value for MACOSX_BUNDLE of targets."
+  },
+  "CMAKE_MACOSX_RPATH": {
+    "name": "CMAKE_MACOSX_RPATH",
+    "description": "Whether to use rpaths on macOS and iOS."
+  },
+  "CMAKE_MAJOR_VERSION": {
+    "name": "CMAKE_MAJOR_VERSION",
+    "description": "First version number component of the CMAKE_VERSION variable."
+  },
+  "CMAKE_MAKE_PROGRAM": {
+    "name": "CMAKE_MAKE_PROGRAM",
+    "description": "Tool that can launch the native build system. The value may be the full path to an executable or just the tool name if it is expected to be in the PATH."
+  },
+  "CMAKE_MAP_IMPORTED_CONFIG_<CONFIG>": {
+    "name": "CMAKE_MAP_IMPORTED_CONFIG_<CONFIG>",
+    "description": "Default value for MAP_IMPORTED_CONFIG_ of targets."
+  },
+  "CMAKE_MATCH_COUNT": {
+    "name": "CMAKE_MATCH_COUNT",
+    "description": "The number of matches with the last regular expression."
+  },
+  "CMAKE_MATCH_<n>": {
+    "name": "CMAKE_MATCH_<n>",
+    "description": "Capture group <n> matched by the last regular expression, for groups 0 through 9. Group 0 is the entire match. Groups 1 through 9 are the subexpressions captured by () syntax."
+  },
+  "CMAKE_MAXIMUM_RECURSION_DEPTH": {
+    "name": "CMAKE_MAXIMUM_RECURSION_DEPTH",
+    "description": "Maximum recursion depth for CMake scripts. It is intended to be set on the command line with -DCMAKE_MAXIMUM_RECURSION_DEPTH=<x>, or within CMakeLists.txt by projects that require a large recursion depth. Projects that set this variable should provide the user with a way to override it. For example:"
+  },
+  "CMAKE_MESSAGE_CONTEXT": {
+    "name": "CMAKE_MESSAGE_CONTEXT",
+    "description": "When enabled by the cmake --log-context command line option or the CMAKE_MESSAGE_CONTEXT_SHOW variable, the message command converts the CMAKE_MESSAGE_CONTEXT list into a dot-separated string surrounded by square brackets and prepends it to each line for messages of log levels NOTICE and below."
+  },
+  "CMAKE_MESSAGE_CONTEXT_SHOW": {
+    "name": "CMAKE_MESSAGE_CONTEXT_SHOW",
+    "description": "Setting this variable to true enables showing a context with each line logged by the message command (see CMAKE_MESSAGE_CONTEXT for how the context itself is specified)."
+  },
+  "CMAKE_MESSAGE_INDENT": {
+    "name": "CMAKE_MESSAGE_INDENT",
+    "description": "The message command joins the strings from this list and for log levels of NOTICE and below, it prepends the resultant string to each line of the message."
+  },
+  "CMAKE_MESSAGE_LOG_LEVEL": {
+    "name": "CMAKE_MESSAGE_LOG_LEVEL",
+    "description": "When set, this variable specifies the logging level used by the message command. Valid values are the same as those for the --log-level <cmake --log-level> command line option of the cmake program. If this variable is set and the --log-level <cmake --log-level> command line option is given, the command line option takes precedence."
+  },
+  "CMAKE_MFC_FLAG": {
+    "name": "CMAKE_MFC_FLAG",
+    "description": "Use the MFC library for an executable or dll."
+  },
+  "CMAKE_MINIMUM_REQUIRED_VERSION": {
+    "name": "CMAKE_MINIMUM_REQUIRED_VERSION",
+    "description": "The <min> version of CMake given to the most recent call to the cmake_minimum_required command in the current variable scope or any parent variable scope."
+  },
+  "CMAKE_MINOR_VERSION": {
+    "name": "CMAKE_MINOR_VERSION",
+    "description": "Second version number component of the CMAKE_VERSION variable."
+  },
+  "CMAKE_MODULE_LINKER_FLAGS": {
+    "name": "CMAKE_MODULE_LINKER_FLAGS",
+    "description": "Linker flags to be used to create modules."
+  },
+  "CMAKE_MODULE_LINKER_FLAGS_<CONFIG>": {
+    "name": "CMAKE_MODULE_LINKER_FLAGS_<CONFIG>",
+    "description": "Flags to be used when linking a module."
+  },
+  "CMAKE_MODULE_LINKER_FLAGS_<CONFIG>_INIT": {
+    "name": "CMAKE_MODULE_LINKER_FLAGS_<CONFIG>_INIT",
+    "description": "Value used to initialize the CMAKE_MODULE_LINKER_FLAGS_ cache entry the first time a build tree is configured. This variable is meant to be set by a toolchain file . CMake may prepend or append content to the value based on the environment and target platform."
+  },
+  "CMAKE_MODULE_LINKER_FLAGS_INIT": {
+    "name": "CMAKE_MODULE_LINKER_FLAGS_INIT",
+    "description": "Value used to initialize the CMAKE_MODULE_LINKER_FLAGS cache entry the first time a build tree is configured. This variable is meant to be set by a toolchain file . CMake may prepend or append content to the value based on the environment and target platform."
+  },
+  "CMAKE_MODULE_PATH": {
+    "name": "CMAKE_MODULE_PATH",
+    "description": "Semicolon-separated list  of directories, represented using forward slashes, specifying a search path for CMake modules to be loaded by the include or find_package commands before checking the default modules that come with CMake. By default it is empty. It is intended to be set by the project."
+  },
+  "CMAKE_MSVCIDE_RUN_PATH": {
+    "name": "CMAKE_MSVCIDE_RUN_PATH",
+    "description": "Extra PATH locations that should be used when executing add_custom_command or add_custom_target when using the Visual Studio 12 2013 (or above) generator. This allows for running commands and using dll's that the IDE environment is not aware of."
+  },
+  "CMAKE_MSVC_DEBUG_INFORMATION_FORMAT": {
+    "name": "CMAKE_MSVC_DEBUG_INFORMATION_FORMAT",
+    "description": "Select the MSVC debug information format targeting the MSVC ABI. This variable is used to initialize the MSVC_DEBUG_INFORMATION_FORMAT property on all targets as they are created. It is also propagated by calls to the try_compile command into the test project."
+  },
+  "CMAKE_MSVC_RUNTIME_LIBRARY": {
+    "name": "CMAKE_MSVC_RUNTIME_LIBRARY",
+    "description": "Select the MSVC runtime library for use by compilers targeting the MSVC ABI. This variable is used to initialize the MSVC_RUNTIME_LIBRARY property on all targets as they are created. It is also propagated by calls to the try_compile command into the test project."
+  },
+  "CMAKE_NETRC": {
+    "name": "CMAKE_NETRC",
+    "description": "This variable is used to initialize the NETRC option for the file and file commands. See those commands for additional information."
+  },
+  "CMAKE_NETRC_FILE": {
+    "name": "CMAKE_NETRC_FILE",
+    "description": "This variable is used to initialize the NETRC_FILE option for the file and file commands. See those commands for additional information."
+  },
+  "CMAKE_NINJA_OUTPUT_PATH_PREFIX": {
+    "name": "CMAKE_NINJA_OUTPUT_PATH_PREFIX",
+    "description": "Tell the Ninja Generators to add a prefix to every output path in build.ninja. A trailing slash is appended to the prefix, if missing."
+  },
+  "CMAKE_NOT_USING_CONFIG_FLAGS": {
+    "name": "CMAKE_NOT_USING_CONFIG_FLAGS",
+    "description": "Skip _BUILD_TYPE flags if true."
+  },
+  "CMAKE_NO_BUILTIN_CHRPATH": {
+    "name": "CMAKE_NO_BUILTIN_CHRPATH",
+    "description": "Do not use the builtin binary editor to fix runtime library search paths on installation."
+  },
+  "CMAKE_NO_SYSTEM_FROM_IMPORTED": {
+    "name": "CMAKE_NO_SYSTEM_FROM_IMPORTED",
+    "description": "Default value for NO_SYSTEM_FROM_IMPORTED of targets."
+  },
+  "CMAKE_OBJCXX_EXTENSIONS": {
+    "name": "CMAKE_OBJCXX_EXTENSIONS",
+    "description": "Default value for OBJCXX_EXTENSIONS target property if set when a target is created."
+  },
+  "CMAKE_OBJCXX_STANDARD": {
+    "name": "CMAKE_OBJCXX_STANDARD",
+    "description": "Default value for OBJCXX_STANDARD target property if set when a target is created."
+  },
+  "CMAKE_OBJCXX_STANDARD_REQUIRED": {
+    "name": "CMAKE_OBJCXX_STANDARD_REQUIRED",
+    "description": "Default value for OBJCXX_STANDARD_REQUIRED target property if set when a target is created."
+  },
+  "CMAKE_OBJC_EXTENSIONS": {
+    "name": "CMAKE_OBJC_EXTENSIONS",
+    "description": "Default value for OBJC_EXTENSIONS target property if set when a target is created."
+  },
+  "CMAKE_OBJC_STANDARD": {
+    "name": "CMAKE_OBJC_STANDARD",
+    "description": "Default value for OBJC_STANDARD target property if set when a target is created."
+  },
+  "CMAKE_OBJC_STANDARD_REQUIRED": {
+    "name": "CMAKE_OBJC_STANDARD_REQUIRED",
+    "description": "Default value for OBJC_STANDARD_REQUIRED target property if set when a target is created."
+  },
+  "CMAKE_OBJECT_PATH_MAX": {
+    "name": "CMAKE_OBJECT_PATH_MAX",
+    "description": "Maximum object file full-path length allowed by native build tools."
+  },
+  "CMAKE_OPTIMIZE_DEPENDENCIES": {
+    "name": "CMAKE_OPTIMIZE_DEPENDENCIES",
+    "description": "Initializes the OPTIMIZE_DEPENDENCIES target property."
+  },
+  "CMAKE_OSX_ARCHITECTURES": {
+    "name": "CMAKE_OSX_ARCHITECTURES",
+    "description": "Target specific architectures for macOS and iOS."
+  },
+  "CMAKE_OSX_DEPLOYMENT_TARGET": {
+    "name": "CMAKE_OSX_DEPLOYMENT_TARGET",
+    "description": "Specify the minimum version of the target platform (e.g. macOS or iOS) on which the target binaries are to be deployed. CMake uses this variable value for the -mmacosx-version-min flag or their respective target platform equivalents. For older Xcode versions that shipped multiple macOS SDKs this variable also helps to choose the SDK in case CMAKE_OSX_SYSROOT is unset."
+  },
+  "CMAKE_OSX_SYSROOT": {
+    "name": "CMAKE_OSX_SYSROOT",
+    "description": "Specify the location or name of the macOS platform SDK to be used. CMake uses this value to compute the value of the -isysroot flag or equivalent and to help the find_* commands locate files in the SDK."
+  },
+  "CMAKE_PARENT_LIST_FILE": {
+    "name": "CMAKE_PARENT_LIST_FILE",
+    "description": "Full path to the CMake file that included the current one."
+  },
+  "CMAKE_PATCH_VERSION": {
+    "name": "CMAKE_PATCH_VERSION",
+    "description": "Third version number component of the CMAKE_VERSION variable."
+  },
+  "CMAKE_PCH_INSTANTIATE_TEMPLATES": {
+    "name": "CMAKE_PCH_INSTANTIATE_TEMPLATES",
+    "description": "This variable is used to initialize the PCH_INSTANTIATE_TEMPLATES property of targets when they are created."
+  },
+  "CMAKE_PCH_WARN_INVALID": {
+    "name": "CMAKE_PCH_WARN_INVALID",
+    "description": "This variable is used to initialize the PCH_WARN_INVALID property of targets when they are created."
+  },
+  "CMAKE_PDB_OUTPUT_DIRECTORY": {
+    "name": "CMAKE_PDB_OUTPUT_DIRECTORY",
+    "description": "Output directory for MS debug symbol .pdb files generated by the linker for executable and shared library targets."
+  },
+  "CMAKE_PDB_OUTPUT_DIRECTORY_<CONFIG>": {
+    "name": "CMAKE_PDB_OUTPUT_DIRECTORY_<CONFIG>",
+    "description": "Per-configuration output directory for MS debug symbol .pdb files generated by the linker for executable and shared library targets."
+  },
+  "CMAKE_PLATFORM_NO_VERSIONED_SONAME": {
+    "name": "CMAKE_PLATFORM_NO_VERSIONED_SONAME",
+    "description": "This variable is used to globally control whether the VERSION and SOVERSION target properties should be used for shared libraries. When set to true, adding version information to each shared library target is disabled."
+  },
+  "CMAKE_POLICY_DEFAULT_CMP<NNNN>": {
+    "name": "CMAKE_POLICY_DEFAULT_CMP<NNNN>",
+    "description": "Default for CMake Policy CMP<NNNN> when it is otherwise left unset."
+  },
+  "CMAKE_POLICY_WARNING_CMP<NNNN>": {
+    "name": "CMAKE_POLICY_WARNING_CMP<NNNN>",
+    "description": "Explicitly enable or disable the warning when CMake Policy CMP<NNNN> has not been set explicitly by cmake_policy or implicitly by cmake_minimum_required. This is meaningful only for the policies that do not warn by default:"
+  },
+  "CMAKE_POSITION_INDEPENDENT_CODE": {
+    "name": "CMAKE_POSITION_INDEPENDENT_CODE",
+    "description": "Default value for POSITION_INDEPENDENT_CODE of targets."
+  },
+  "CMAKE_PREFIX_PATH": {
+    "name": "CMAKE_PREFIX_PATH",
+    "description": "Semicolon-separated list  of directories specifying installation prefixes to be searched by the find_package, find_program, find_library, find_file, and find_path commands. Each command will add appropriate subdirectories (like bin, lib, or include) as specified in its own documentation."
+  },
+  "CMAKE_PROGRAM_PATH": {
+    "name": "CMAKE_PROGRAM_PATH",
+    "description": "Semicolon-separated list  of directories specifying a search path for the find_program command. By default it is empty, it is intended to be set by the project."
+  },
+  "CMAKE_PROJECT_DESCRIPTION": {
+    "name": "CMAKE_PROJECT_DESCRIPTION",
+    "description": "The description of the top level project."
+  },
+  "CMAKE_PROJECT_HOMEPAGE_URL": {
+    "name": "CMAKE_PROJECT_HOMEPAGE_URL",
+    "description": "The homepage URL of the top level project."
+  },
+  "CMAKE_PROJECT_INCLUDE": {
+    "name": "CMAKE_PROJECT_INCLUDE",
+    "description": "A CMake language file to be included as the last step of all project command calls. This is intended for injecting custom code into project builds without modifying their source. See Code Injection for a more detailed discussion of files potentially included during a project call."
+  },
+  "CMAKE_PROJECT_INCLUDE_BEFORE": {
+    "name": "CMAKE_PROJECT_INCLUDE_BEFORE",
+    "description": "A CMake language file to be included as the first step of all project command calls. This is intended for injecting custom code into project builds without modifying their source. See Code Injection for a more detailed discussion of files potentially included during a project call."
+  },
+  "CMAKE_PROJECT_NAME": {
+    "name": "CMAKE_PROJECT_NAME",
+    "description": "The name of the top level project."
+  },
+  "CMAKE_PROJECT_<PROJECT-NAME>_INCLUDE": {
+    "name": "CMAKE_PROJECT_<PROJECT-NAME>_INCLUDE",
+    "description": "A CMake language file to be included as the last step of any project command calls that specify <PROJECT-NAME> as the project name. This is intended for injecting custom code into project builds without modifying their source. See Code Injection for a more detailed discussion of files potentially included during a project call."
+  },
+  "CMAKE_PROJECT_<PROJECT-NAME>_INCLUDE_BEFORE": {
+    "name": "CMAKE_PROJECT_<PROJECT-NAME>_INCLUDE_BEFORE",
+    "description": "A CMake language file to be included as the first step of any project command calls that specify <PROJECT-NAME> as the project name. This is intended for injecting custom code into project builds without modifying their source. See Code Injection for a more detailed discussion of files potentially included during a project call."
+  },
+  "CMAKE_PROJECT_TOP_LEVEL_INCLUDES": {
+    "name": "CMAKE_PROJECT_TOP_LEVEL_INCLUDES",
+    "description": "Semicolon-separated list  of CMake language files to include as part of the very first project call. The files will be included immediately after the toolchain file has been read (if one is specified) and platform variables have been set, but before any languages have been enabled. Therefore, language-specific variables, including things like CMAKE_<LANG>_COMPILER, might not be set. See Code Injection for a more detailed discussion of files potentially included during a project call."
+  },
+  "CMAKE_PROJECT_VERSION": {
+    "name": "CMAKE_PROJECT_VERSION",
+    "description": "The version of the top level project."
+  },
+  "CMAKE_PROJECT_VERSION_MAJOR": {
+    "name": "CMAKE_PROJECT_VERSION_MAJOR",
+    "description": "The major version of the top level project."
+  },
+  "CMAKE_PROJECT_VERSION_MINOR": {
+    "name": "CMAKE_PROJECT_VERSION_MINOR",
+    "description": "The minor version of the top level project."
+  },
+  "CMAKE_PROJECT_VERSION_PATCH": {
+    "name": "CMAKE_PROJECT_VERSION_PATCH",
+    "description": "The patch version of the top level project."
+  },
+  "CMAKE_PROJECT_VERSION_TWEAK": {
+    "name": "CMAKE_PROJECT_VERSION_TWEAK",
+    "description": "The tweak version of the top level project."
+  },
+  "CMAKE_RANLIB": {
+    "name": "CMAKE_RANLIB",
+    "description": "Name of randomizing tool for static libraries."
+  },
+  "CMAKE_REQUIRE_FIND_PACKAGE_<PackageName>": {
+    "name": "CMAKE_REQUIRE_FIND_PACKAGE_<PackageName>",
+    "description": "Variable for making find_package call REQUIRED."
+  },
+  "CMAKE_ROOT": {
+    "name": "CMAKE_ROOT",
+    "description": "Install directory for running cmake."
+  },
+  "CMAKE_RULE_MESSAGES": {
+    "name": "CMAKE_RULE_MESSAGES",
+    "description": "Specify whether to report a message for each make rule."
+  },
+  "CMAKE_RUNTIME_OUTPUT_DIRECTORY": {
+    "name": "CMAKE_RUNTIME_OUTPUT_DIRECTORY",
+    "description": "Where to put all the RUNTIME  target files when built."
+  },
+  "CMAKE_RUNTIME_OUTPUT_DIRECTORY_<CONFIG>": {
+    "name": "CMAKE_RUNTIME_OUTPUT_DIRECTORY_<CONFIG>",
+    "description": "Where to put all the RUNTIME  target files when built for a specific configuration."
+  },
+  "CMAKE_SCRIPT_MODE_FILE": {
+    "name": "CMAKE_SCRIPT_MODE_FILE",
+    "description": "Full path to the cmake -P script file currently being processed."
+  },
+  "CMAKE_SHARED_LIBRARY_ENABLE_EXPORTS": {
+    "name": "CMAKE_SHARED_LIBRARY_ENABLE_EXPORTS",
+    "description": "Specify whether shared library generates an import file."
+  },
+  "CMAKE_SHARED_LIBRARY_PREFIX": {
+    "name": "CMAKE_SHARED_LIBRARY_PREFIX",
+    "description": "The prefix for shared libraries that you link to."
+  },
+  "CMAKE_SHARED_LIBRARY_SUFFIX": {
+    "name": "CMAKE_SHARED_LIBRARY_SUFFIX",
+    "description": "The suffix for shared libraries that you link to."
+  },
+  "CMAKE_SHARED_LINKER_FLAGS": {
+    "name": "CMAKE_SHARED_LINKER_FLAGS",
+    "description": "Linker flags to be used to create shared libraries."
+  },
+  "CMAKE_SHARED_LINKER_FLAGS_<CONFIG>": {
+    "name": "CMAKE_SHARED_LINKER_FLAGS_<CONFIG>",
+    "description": "Flags to be used when linking a shared library."
+  },
+  "CMAKE_SHARED_LINKER_FLAGS_<CONFIG>_INIT": {
+    "name": "CMAKE_SHARED_LINKER_FLAGS_<CONFIG>_INIT",
+    "description": "Value used to initialize the CMAKE_SHARED_LINKER_FLAGS_ cache entry the first time a build tree is configured. This variable is meant to be set by a toolchain file . CMake may prepend or append content to the value based on the environment and target platform."
+  },
+  "CMAKE_SHARED_LINKER_FLAGS_INIT": {
+    "name": "CMAKE_SHARED_LINKER_FLAGS_INIT",
+    "description": "Value used to initialize the CMAKE_SHARED_LINKER_FLAGS cache entry the first time a build tree is configured. This variable is meant to be set by a toolchain file . CMake may prepend or append content to the value based on the environment and target platform."
+  },
+  "CMAKE_SHARED_MODULE_PREFIX": {
+    "name": "CMAKE_SHARED_MODULE_PREFIX",
+    "description": "The prefix for loadable modules that you link to."
+  },
+  "CMAKE_SHARED_MODULE_SUFFIX": {
+    "name": "CMAKE_SHARED_MODULE_SUFFIX",
+    "description": "The suffix for shared libraries that you link to."
+  },
+  "CMAKE_SIZEOF_VOID_P": {
+    "name": "CMAKE_SIZEOF_VOID_P",
+    "description": "Size of a void pointer."
+  },
+  "CMAKE_SKIP_BUILD_RPATH": {
+    "name": "CMAKE_SKIP_BUILD_RPATH",
+    "description": "Do not include RPATHs in the build tree."
+  },
+  "CMAKE_SKIP_INSTALL_ALL_DEPENDENCY": {
+    "name": "CMAKE_SKIP_INSTALL_ALL_DEPENDENCY",
+    "description": "Don't make the install target depend on the all target."
+  },
+  "CMAKE_SKIP_INSTALL_RPATH": {
+    "name": "CMAKE_SKIP_INSTALL_RPATH",
+    "description": "Do not include RPATHs in the install tree."
+  },
+  "CMAKE_SKIP_INSTALL_RULES": {
+    "name": "CMAKE_SKIP_INSTALL_RULES",
+    "description": "Whether to disable generation of installation rules."
+  },
+  "CMAKE_SKIP_RPATH": {
+    "name": "CMAKE_SKIP_RPATH",
+    "description": "If true, do not add run time path information."
+  },
+  "CMAKE_SKIP_TEST_ALL_DEPENDENCY": {
+    "name": "CMAKE_SKIP_TEST_ALL_DEPENDENCY",
+    "description": "Control whether the test target depends on the all target."
+  },
+  "CMAKE_SOURCE_DIR": {
+    "name": "CMAKE_SOURCE_DIR",
+    "description": "The path to the top level of the source tree."
+  },
+  "CMAKE_STAGING_PREFIX": {
+    "name": "CMAKE_STAGING_PREFIX",
+    "description": "This variable may be set to a path to install to when cross-compiling. This can be useful if the path in CMAKE_SYSROOT is read-only, or otherwise should remain pristine."
+  },
+  "CMAKE_STATIC_LIBRARY_PREFIX": {
+    "name": "CMAKE_STATIC_LIBRARY_PREFIX",
+    "description": "The prefix for static libraries that you link to."
+  },
+  "CMAKE_STATIC_LIBRARY_SUFFIX": {
+    "name": "CMAKE_STATIC_LIBRARY_SUFFIX",
+    "description": "The suffix for static libraries that you link to."
+  },
+  "CMAKE_STATIC_LINKER_FLAGS": {
+    "name": "CMAKE_STATIC_LINKER_FLAGS",
+    "description": "Flags to be used to create static libraries. These flags will be passed to the archiver when creating a static library."
+  },
+  "CMAKE_STATIC_LINKER_FLAGS_<CONFIG>": {
+    "name": "CMAKE_STATIC_LINKER_FLAGS_<CONFIG>",
+    "description": "Flags to be used to create static libraries. These flags will be passed to the archiver when creating a static library in the <CONFIG> configuration."
+  },
+  "CMAKE_STATIC_LINKER_FLAGS_<CONFIG>_INIT": {
+    "name": "CMAKE_STATIC_LINKER_FLAGS_<CONFIG>_INIT",
+    "description": "Value used to initialize the CMAKE_STATIC_LINKER_FLAGS_ cache entry the first time a build tree is configured. This variable is meant to be set by a toolchain file . CMake may prepend or append content to the value based on the environment and target platform."
+  },
+  "CMAKE_STATIC_LINKER_FLAGS_INIT": {
+    "name": "CMAKE_STATIC_LINKER_FLAGS_INIT",
+    "description": "Value used to initialize the CMAKE_STATIC_LINKER_FLAGS cache entry the first time a build tree is configured. This variable is meant to be set by a toolchain file . CMake may prepend or append content to the value based on the environment and target platform."
+  },
+  "CMAKE_SUBLIME_TEXT_2_ENV_SETTINGS": {
+    "name": "CMAKE_SUBLIME_TEXT_2_ENV_SETTINGS",
+    "description": "This variable contains a list of env vars as a list of tokens with the syntax var=value."
+  },
+  "CMAKE_SUBLIME_TEXT_2_EXCLUDE_BUILD_TREE": {
+    "name": "CMAKE_SUBLIME_TEXT_2_EXCLUDE_BUILD_TREE",
+    "description": "If this variable evaluates to ON at the end of the top-level CMakeLists.txt file, the Sublime Text 2 extra generator excludes the build tree from the .sublime-project if it is inside the source tree."
+  },
+  "CMAKE_SUPPRESS_REGENERATION": {
+    "name": "CMAKE_SUPPRESS_REGENERATION",
+    "description": "If CMAKE_SUPPRESS_REGENERATION is OFF, which is default, then CMake adds a special target on which all other targets depend that checks the build system and optionally re-runs CMake to regenerate the build system when the target specification source changes."
+  },
+  "CMAKE_Swift_COMPILATION_MODE": {
+    "name": "CMAKE_Swift_COMPILATION_MODE",
+    "description": "Specify how Swift compiles a target. This variable is used to initialize the Swift_COMPILATION_MODE property on targets as they are created."
+  },
+  "CMAKE_Swift_LANGUAGE_VERSION": {
+    "name": "CMAKE_Swift_LANGUAGE_VERSION",
+    "description": "Set to the Swift language version number. If not set, the oldest legacy version known to be available in the host Xcode version is assumed:"
+  },
+  "CMAKE_Swift_MODULE_DIRECTORY": {
+    "name": "CMAKE_Swift_MODULE_DIRECTORY",
+    "description": "Swift module output directory."
+  },
+  "CMAKE_Swift_NUM_THREADS": {
+    "name": "CMAKE_Swift_NUM_THREADS",
+    "description": "Number of threads for parallel compilation for Swift targets."
+  },
+  "CMAKE_SYSROOT": {
+    "name": "CMAKE_SYSROOT",
+    "description": "Path to pass to the compiler in the --sysroot flag."
+  },
+  "CMAKE_SYSROOT_COMPILE": {
+    "name": "CMAKE_SYSROOT_COMPILE",
+    "description": "Path to pass to the compiler in the --sysroot flag when compiling source files. This is the same as CMAKE_SYSROOT but is used only for compiling sources and not linking."
+  },
+  "CMAKE_SYSROOT_LINK": {
+    "name": "CMAKE_SYSROOT_LINK",
+    "description": "Path to pass to the compiler in the --sysroot flag when linking. This is the same as CMAKE_SYSROOT but is used only for linking and not compiling sources."
+  },
+  "CMAKE_SYSTEM": {
+    "name": "CMAKE_SYSTEM",
+    "description": "Composite name of operating system CMake is compiling for."
+  },
+  "CMAKE_SYSTEM_APPBUNDLE_PATH": {
+    "name": "CMAKE_SYSTEM_APPBUNDLE_PATH",
+    "description": "Search path for macOS application bundles used by the find_program, and find_package commands. By default it contains the standard directories for the current system. It is not intended to be modified by the project, use CMAKE_APPBUNDLE_PATH for this."
+  },
+  "CMAKE_SYSTEM_FRAMEWORK_PATH": {
+    "name": "CMAKE_SYSTEM_FRAMEWORK_PATH",
+    "description": "Search path for macOS frameworks used by the find_library, find_package, find_path, and find_file commands. By default it contains the standard directories for the current system. It is not intended to be modified by the project, use CMAKE_FRAMEWORK_PATH for this."
+  },
+  "CMAKE_SYSTEM_IGNORE_PATH": {
+    "name": "CMAKE_SYSTEM_IGNORE_PATH",
+    "description": "Semicolon-separated list  of directories to be ignored by the various find...() commands."
+  },
+  "CMAKE_SYSTEM_IGNORE_PREFIX_PATH": {
+    "name": "CMAKE_SYSTEM_IGNORE_PREFIX_PATH",
+    "description": "Semicolon-separated list  of search prefixes to be ignored by the find_program, find_library, find_file, and find_path commands. The prefixes are also ignored by the Config mode of the find_package command (Module mode is unaffected). To ignore specific directories instead, see CMAKE_IGNORE_NONPREFIX_VAR."
+  },
+  "CMAKE_SYSTEM_INCLUDE_PATH": {
+    "name": "CMAKE_SYSTEM_INCLUDE_PATH",
+    "description": "Semicolon-separated list  of directories specifying a search path for the find_file and find_path commands. By default this contains the standard directories for the current system. It is not intended to be modified by the project; use CMAKE_INCLUDE_PATH for this. See also CMAKE_SYSTEM_PREFIX_PATH."
+  },
+  "CMAKE_SYSTEM_LIBRARY_PATH": {
+    "name": "CMAKE_SYSTEM_LIBRARY_PATH",
+    "description": "Semicolon-separated list  of directories specifying a search path for the find_library command. By default this contains the standard directories for the current system. It is not intended to be modified by the project; use CMAKE_LIBRARY_PATH for this. See also CMAKE_SYSTEM_PREFIX_PATH."
+  },
+  "CMAKE_SYSTEM_NAME": {
+    "name": "CMAKE_SYSTEM_NAME",
+    "description": "The name of the operating system for which CMake is to build. See the CMAKE_SYSTEM_VERSION variable for the OS version."
+  },
+  "CMAKE_SYSTEM_PREFIX_PATH": {
+    "name": "CMAKE_SYSTEM_PREFIX_PATH",
+    "description": "Semicolon-separated list  of directories specifying installation prefixes to be searched by the find_package, find_program, find_library, find_file, and find_path commands. Each command will add appropriate subdirectories (like bin, lib, or include) as specified in its own documentation."
+  },
+  "CMAKE_SYSTEM_PROCESSOR": {
+    "name": "CMAKE_SYSTEM_PROCESSOR",
+    "description": "When not cross-compiling, this variable has the same value as the CMAKE_HOST_SYSTEM_PROCESSOR variable. In many cases, this will correspond to the target architecture for the build, but this is not guaranteed. (E.g. on Windows, the host may be AMD64 even when using a MSVC cl compiler with a 32-bit target.)"
+  },
+  "CMAKE_SYSTEM_PROGRAM_PATH": {
+    "name": "CMAKE_SYSTEM_PROGRAM_PATH",
+    "description": "Semicolon-separated list  of directories specifying a search path for the find_program command. By default this contains the standard directories for the current system. It is not intended to be modified by the project; use CMAKE_PROGRAM_PATH for this. See also CMAKE_SYSTEM_PREFIX_PATH."
+  },
+  "CMAKE_SYSTEM_VERSION": {
+    "name": "CMAKE_SYSTEM_VERSION",
+    "description": "The version of the operating system for which CMake is to build. See the CMAKE_SYSTEM_NAME variable for the OS name."
+  },
+  "CMAKE_TASKING_TOOLSET": {
+    "name": "CMAKE_TASKING_TOOLSET",
+    "description": "Select the Tasking toolset which provides the compiler"
+  },
+  "CMAKE_TEST_LAUNCHER": {
+    "name": "CMAKE_TEST_LAUNCHER",
+    "description": "This variable is used to initialize the TEST_LAUNCHER target property of executable targets as they are created. It is used to specify a launcher for running tests, added by the add_test command, that run an executable target."
+  },
+  "CMAKE_TLS_CAINFO": {
+    "name": "CMAKE_TLS_CAINFO",
+    "description": "Specify the default value for the file and file commands' TLS_CAINFO options. It is unset by default."
+  },
+  "CMAKE_TLS_VERIFY": {
+    "name": "CMAKE_TLS_VERIFY",
+    "description": "Specify the default value for the file and file commands' TLS_VERIFY options. If this variable is not set, the commands check the CMAKE_TLS_VERIFY environment variable. If neither is set, the default is off."
+  },
+  "CMAKE_TLS_VERSION": {
+    "name": "CMAKE_TLS_VERSION",
+    "description": "Specify the default value for the file and file commands' TLS_VERSION option. If this variable is not set, the commands check the CMAKE_TLS_VERSION environment variable."
+  },
+  "CMAKE_TOOLCHAIN_FILE": {
+    "name": "CMAKE_TOOLCHAIN_FILE",
+    "description": "Path to toolchain file supplied to cmake."
+  },
+  "CMAKE_TRY_COMPILE_CONFIGURATION": {
+    "name": "CMAKE_TRY_COMPILE_CONFIGURATION",
+    "description": "Build configuration used for try_compile and try_run projects."
+  },
+  "CMAKE_TRY_COMPILE_NO_PLATFORM_VARIABLES": {
+    "name": "CMAKE_TRY_COMPILE_NO_PLATFORM_VARIABLES",
+    "description": "Set to a true value to tell the try_compile command not to propagate any platform variables into the test project."
+  },
+  "CMAKE_TRY_COMPILE_PLATFORM_VARIABLES": {
+    "name": "CMAKE_TRY_COMPILE_PLATFORM_VARIABLES",
+    "description": "List of variables that the try_compile command source file signature must propagate into the test project in order to target the same platform as the host project."
+  },
+  "CMAKE_TRY_COMPILE_TARGET_TYPE": {
+    "name": "CMAKE_TRY_COMPILE_TARGET_TYPE",
+    "description": "Type of target generated for try_compile calls using the source file signature. Valid values are:"
+  },
+  "CMAKE_TWEAK_VERSION": {
+    "name": "CMAKE_TWEAK_VERSION",
+    "description": "Defined to 0 for compatibility with code written for older CMake versions that may have defined higher values."
+  },
+  "CMAKE_UNITY_BUILD": {
+    "name": "CMAKE_UNITY_BUILD",
+    "description": "This variable is used to initialize the UNITY_BUILD property of targets when they are created. Setting it to true enables batch compilation of multiple sources within each target. This feature is known as a Unity or Jumbo build."
+  },
+  "CMAKE_UNITY_BUILD_BATCH_SIZE": {
+    "name": "CMAKE_UNITY_BUILD_BATCH_SIZE",
+    "description": "This variable is used to initialize the UNITY_BUILD_BATCH_SIZE property of targets when they are created. It specifies the default upper limit on the number of source files that may be combined in any one unity source file when unity builds are enabled for a target."
+  },
+  "CMAKE_UNITY_BUILD_UNIQUE_ID": {
+    "name": "CMAKE_UNITY_BUILD_UNIQUE_ID",
+    "description": "This variable is used to initialize the UNITY_BUILD_UNIQUE_ID property of targets when they are created. It specifies the name of the unique identifier generated per file in a unity build."
+  },
+  "CMAKE_USER_MAKE_RULES_OVERRIDE": {
+    "name": "CMAKE_USER_MAKE_RULES_OVERRIDE",
+    "description": "Specify a CMake file that overrides platform information."
+  },
+  "CMAKE_USER_MAKE_RULES_OVERRIDE_<LANG>": {
+    "name": "CMAKE_USER_MAKE_RULES_OVERRIDE_<LANG>",
+    "description": "Specify a CMake file that overrides platform information for <LANG>."
+  },
+  "CMAKE_USE_RELATIVE_PATHS": {
+    "name": "CMAKE_USE_RELATIVE_PATHS",
+    "description": "This variable has no effect. The partially implemented effect it had in previous releases was removed in CMake 3.4."
+  },
+  "CMAKE_VERBOSE_MAKEFILE": {
+    "name": "CMAKE_VERBOSE_MAKEFILE",
+    "description": "Enable verbose output from Makefile builds."
+  },
+  "CMAKE_VERIFY_INTERFACE_HEADER_SETS": {
+    "name": "CMAKE_VERIFY_INTERFACE_HEADER_SETS",
+    "description": "This variable is used to initialize the VERIFY_INTERFACE_HEADER_SETS property of targets when they are created. Setting it to true enables header set verification."
+  },
+  "CMAKE_VERSION": {
+    "name": "CMAKE_VERSION",
+    "description": "The CMake version string as three non-negative integer components separated by . and possibly followed by - and other information. The first two components represent the feature level and the third component represents either a bug-fix level or development date."
+  },
+  "CMAKE_VISIBILITY_INLINES_HIDDEN": {
+    "name": "CMAKE_VISIBILITY_INLINES_HIDDEN",
+    "description": "Default value for the VISIBILITY_INLINES_HIDDEN target property when a target is created."
+  },
+  "CMAKE_VS_DEBUGGER_COMMAND": {
+    "name": "CMAKE_VS_DEBUGGER_COMMAND",
+    "description": "This variable is used to initialize the VS_DEBUGGER_COMMAND property on each target as it is created. See that target property for additional information."
+  },
+  "CMAKE_VS_DEBUGGER_COMMAND_ARGUMENTS": {
+    "name": "CMAKE_VS_DEBUGGER_COMMAND_ARGUMENTS",
+    "description": "This variable is used to initialize the VS_DEBUGGER_COMMAND_ARGUMENTS property on each target as it is created. See that target property for additional information."
+  },
+  "CMAKE_VS_DEBUGGER_ENVIRONMENT": {
+    "name": "CMAKE_VS_DEBUGGER_ENVIRONMENT",
+    "description": "This variable is used to initialize the VS_DEBUGGER_ENVIRONMENT property on each target as it is created. See that target property for additional information."
+  },
+  "CMAKE_VS_DEBUGGER_WORKING_DIRECTORY": {
+    "name": "CMAKE_VS_DEBUGGER_WORKING_DIRECTORY",
+    "description": "This variable is used to initialize the VS_DEBUGGER_WORKING_DIRECTORY property on each target as it is created. See that target property for additional information."
+  },
+  "CMAKE_VS_DEVENV_COMMAND": {
+    "name": "CMAKE_VS_DEVENV_COMMAND",
+    "description": "The generators for Visual Studio 12 2013 and above set this variable to the devenv.com command installed with the corresponding Visual Studio version. Note that this variable may be empty on Visual Studio Express editions because they do not provide this tool."
+  },
+  "CMAKE_VS_GLOBALS": {
+    "name": "CMAKE_VS_GLOBALS",
+    "description": "List of Key=Value records to be set per target as target properties VS_GLOBAL_ with variable=Key and value Value."
+  },
+  "CMAKE_VS_INCLUDE_INSTALL_TO_DEFAULT_BUILD": {
+    "name": "CMAKE_VS_INCLUDE_INSTALL_TO_DEFAULT_BUILD",
+    "description": "Include INSTALL target to default build."
+  },
+  "CMAKE_VS_INCLUDE_PACKAGE_TO_DEFAULT_BUILD": {
+    "name": "CMAKE_VS_INCLUDE_PACKAGE_TO_DEFAULT_BUILD",
+    "description": "Include PACKAGE target to default build."
+  },
+  "CMAKE_VS_INTEL_Fortran_PROJECT_VERSION": {
+    "name": "CMAKE_VS_INTEL_Fortran_PROJECT_VERSION",
+    "description": "When generating for Visual Studio 12 2013 or greater with the Intel Fortran plugin installed, this specifies the .vfproj project file format version. This is intended for internal use by CMake and should not be used by project code."
+  },
+  "CMAKE_VS_JUST_MY_CODE_DEBUGGING": {
+    "name": "CMAKE_VS_JUST_MY_CODE_DEBUGGING",
+    "description": "Enable Just My Code with Visual Studio debugger."
+  },
+  "CMAKE_VS_MSBUILD_COMMAND": {
+    "name": "CMAKE_VS_MSBUILD_COMMAND",
+    "description": "The generators for Visual Studio 12 2013 and above set this variable to the MSBuild.exe command installed with the corresponding Visual Studio version."
+  },
+  "CMAKE_VS_NO_COMPILE_BATCHING": {
+    "name": "CMAKE_VS_NO_COMPILE_BATCHING",
+    "description": "Turn off compile batching when using Visual Studio Generators."
+  },
+  "CMAKE_VS_NsightTegra_VERSION": {
+    "name": "CMAKE_VS_NsightTegra_VERSION",
+    "description": "When using a Visual Studio generator with the CMAKE_SYSTEM_NAME variable set to Android, this variable contains the version number of the installed NVIDIA Nsight Tegra Visual Studio Edition."
+  },
+  "CMAKE_VS_NUGET_PACKAGE_RESTORE": {
+    "name": "CMAKE_VS_NUGET_PACKAGE_RESTORE",
+    "description": "When using a Visual Studio generator, this cache variable controls if msbuild should automatically attempt to restore NuGet packages prior to a build. NuGet packages can be defined using the VS_PACKAGE_REFERENCES property on a target. If no package references are defined, this setting will do nothing."
+  },
+  "CMAKE_VS_PLATFORM_NAME": {
+    "name": "CMAKE_VS_PLATFORM_NAME",
+    "description": "Visual Studio target platform name used by the current generator."
+  },
+  "CMAKE_VS_PLATFORM_NAME_DEFAULT": {
+    "name": "CMAKE_VS_PLATFORM_NAME_DEFAULT",
+    "description": "Default for the Visual Studio target platform name for the current generator without considering the value of the CMAKE_GENERATOR_PLATFORM variable. For Visual Studio Generators for VS 2017 and below this is always Win32. For VS 2019 and above this is based on the host platform."
+  },
+  "CMAKE_VS_PLATFORM_TOOLSET": {
+    "name": "CMAKE_VS_PLATFORM_TOOLSET",
+    "description": "Visual Studio Platform Toolset name."
+  },
+  "CMAKE_VS_PLATFORM_TOOLSET_CUDA": {
+    "name": "CMAKE_VS_PLATFORM_TOOLSET_CUDA",
+    "description": "NVIDIA CUDA Toolkit version whose Visual Studio toolset to use."
+  },
+  "CMAKE_VS_PLATFORM_TOOLSET_CUDA_CUSTOM_DIR": {
+    "name": "CMAKE_VS_PLATFORM_TOOLSET_CUDA_CUSTOM_DIR",
+    "description": "Path to standalone NVIDIA CUDA Toolkit (eg. extracted from installer)."
+  },
+  "CMAKE_VS_PLATFORM_TOOLSET_FORTRAN": {
+    "name": "CMAKE_VS_PLATFORM_TOOLSET_FORTRAN",
+    "description": "Fortran compiler to be used by Visual Studio projects."
+  },
+  "CMAKE_VS_PLATFORM_TOOLSET_HOST_ARCHITECTURE": {
+    "name": "CMAKE_VS_PLATFORM_TOOLSET_HOST_ARCHITECTURE",
+    "description": "Visual Studio preferred tool architecture."
+  },
+  "CMAKE_VS_PLATFORM_TOOLSET_VERSION": {
+    "name": "CMAKE_VS_PLATFORM_TOOLSET_VERSION",
+    "description": "Visual Studio Platform Toolset version."
+  },
+  "CMAKE_VS_SDK_EXCLUDE_DIRECTORIES": {
+    "name": "CMAKE_VS_SDK_EXCLUDE_DIRECTORIES",
+    "description": "This variable allows to override Visual Studio default Exclude Directories."
+  },
+  "CMAKE_VS_SDK_EXECUTABLE_DIRECTORIES": {
+    "name": "CMAKE_VS_SDK_EXECUTABLE_DIRECTORIES",
+    "description": "This variable allows to override Visual Studio default Executable Directories."
+  },
+  "CMAKE_VS_SDK_INCLUDE_DIRECTORIES": {
+    "name": "CMAKE_VS_SDK_INCLUDE_DIRECTORIES",
+    "description": "This variable allows to override Visual Studio default Include Directories."
+  },
+  "CMAKE_VS_SDK_LIBRARY_DIRECTORIES": {
+    "name": "CMAKE_VS_SDK_LIBRARY_DIRECTORIES",
+    "description": "This variable allows to override Visual Studio default Library Directories."
+  },
+  "CMAKE_VS_SDK_LIBRARY_WINRT_DIRECTORIES": {
+    "name": "CMAKE_VS_SDK_LIBRARY_WINRT_DIRECTORIES",
+    "description": "This variable allows to override Visual Studio default Library WinRT Directories."
+  },
+  "CMAKE_VS_SDK_REFERENCE_DIRECTORIES": {
+    "name": "CMAKE_VS_SDK_REFERENCE_DIRECTORIES",
+    "description": "This variable allows to override Visual Studio default Reference Directories."
+  },
+  "CMAKE_VS_SDK_SOURCE_DIRECTORIES": {
+    "name": "CMAKE_VS_SDK_SOURCE_DIRECTORIES",
+    "description": "This variable allows to override Visual Studio default Source Directories."
+  },
+  "CMAKE_VS_TARGET_FRAMEWORK_IDENTIFIER": {
+    "name": "CMAKE_VS_TARGET_FRAMEWORK_IDENTIFIER",
+    "description": "Visual Studio target framework identifier."
+  },
+  "CMAKE_VS_TARGET_FRAMEWORK_TARGETS_VERSION": {
+    "name": "CMAKE_VS_TARGET_FRAMEWORK_TARGETS_VERSION",
+    "description": "Visual Studio target framework targets version."
+  },
+  "CMAKE_VS_TARGET_FRAMEWORK_VERSION": {
+    "name": "CMAKE_VS_TARGET_FRAMEWORK_VERSION",
+    "description": "Visual Studio target framework version."
+  },
+  "CMAKE_VS_USE_DEBUG_LIBRARIES": {
+    "name": "CMAKE_VS_USE_DEBUG_LIBRARIES",
+    "description": "Indicate to Visual Studio Generators what configurations are considered debug configurations. This controls the UseDebugLibraries setting in each configuration of a .vcxproj file."
+  },
+  "CMAKE_VS_VERSION_BUILD_NUMBER": {
+    "name": "CMAKE_VS_VERSION_BUILD_NUMBER",
+    "description": "Visual Studio version."
+  },
+  "CMAKE_VS_WINDOWS_TARGET_PLATFORM_MIN_VERSION": {
+    "name": "CMAKE_VS_WINDOWS_TARGET_PLATFORM_MIN_VERSION",
+    "description": "Tell Visual Studio Generators to use the given Windows Target Platform Minimum Version."
+  },
+  "CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION": {
+    "name": "CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION",
+    "description": "Visual Studio Windows Target Platform Version."
+  },
+  "CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION_MAXIMUM": {
+    "name": "CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION_MAXIMUM",
+    "description": "Override the Windows 10 SDK Maximum Version for VS 2015 and beyond."
+  },
+  "CMAKE_VS_WINRT_BY_DEFAULT": {
+    "name": "CMAKE_VS_WINRT_BY_DEFAULT",
+    "description": "Inform Visual Studio Generators for VS 2010 and above that the target platform enables WinRT compilation by default and it needs to be explicitly disabled if /ZW or VS_WINRT_COMPONENT is omitted (as opposed to enabling it when either of those options is present)"
+  },
+  "CMAKE_WARN_DEPRECATED": {
+    "name": "CMAKE_WARN_DEPRECATED",
+    "description": "Whether to issue warnings for deprecated functionality."
+  },
+  "CMAKE_WARN_ON_ABSOLUTE_INSTALL_DESTINATION": {
+    "name": "CMAKE_WARN_ON_ABSOLUTE_INSTALL_DESTINATION",
+    "description": "Ask cmake_install.cmake script to warn each time a file with absolute INSTALL DESTINATION is encountered."
+  },
+  "CMAKE_WATCOM_RUNTIME_LIBRARY": {
+    "name": "CMAKE_WATCOM_RUNTIME_LIBRARY",
+    "description": "Select the Watcom runtime library for use by compilers targeting the Watcom ABI. This variable is used to initialize the WATCOM_RUNTIME_LIBRARY property on all targets as they are created. It is also propagated by calls to the try_compile command into the test project."
+  },
+  "CMAKE_WIN32_EXECUTABLE": {
+    "name": "CMAKE_WIN32_EXECUTABLE",
+    "description": "Default value for WIN32_EXECUTABLE of targets."
+  },
+  "CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS": {
+    "name": "CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS",
+    "description": "Default value for WINDOWS_EXPORT_ALL_SYMBOLS target property. This variable is used to initialize the property on each target as it is created."
+  },
+  "CMAKE_XCODE_ATTRIBUTE_<an-attribute>": {
+    "name": "CMAKE_XCODE_ATTRIBUTE_<an-attribute>",
+    "description": "Set Xcode target attributes directly."
+  },
+  "CMAKE_XCODE_BUILD_SYSTEM": {
+    "name": "CMAKE_XCODE_BUILD_SYSTEM",
+    "description": "Xcode build system selection."
+  },
+  "CMAKE_XCODE_GENERATE_SCHEME": {
+    "name": "CMAKE_XCODE_GENERATE_SCHEME",
+    "description": "If enabled, the Xcode generator will generate schema files. These are useful to invoke analyze, archive, build-for-testing and test actions from the command line."
+  },
+  "CMAKE_XCODE_GENERATE_TOP_LEVEL_PROJECT_ONLY": {
+    "name": "CMAKE_XCODE_GENERATE_TOP_LEVEL_PROJECT_ONLY",
+    "description": "If enabled, the Xcode generator will generate only a single Xcode project file for the topmost project() command instead of generating one for every project() command."
+  },
+  "CMAKE_XCODE_LINK_BUILD_PHASE_MODE": {
+    "name": "CMAKE_XCODE_LINK_BUILD_PHASE_MODE",
+    "description": "This variable is used to initialize the XCODE_LINK_BUILD_PHASE_MODE property on targets. It affects the methods that the Xcode generator uses to link different kinds of libraries. Its default value is NONE."
+  },
+  "CMAKE_XCODE_PLATFORM_TOOLSET": {
+    "name": "CMAKE_XCODE_PLATFORM_TOOLSET",
+    "description": "Xcode compiler selection."
+  },
+  "CMAKE_XCODE_SCHEME_ADDRESS_SANITIZER": {
+    "name": "CMAKE_XCODE_SCHEME_ADDRESS_SANITIZER",
+    "description": "Whether to enable Address Sanitizer in the Diagnostics section of the generated Xcode scheme."
+  },
+  "CMAKE_XCODE_SCHEME_ADDRESS_SANITIZER_USE_AFTER_RETURN": {
+    "name": "CMAKE_XCODE_SCHEME_ADDRESS_SANITIZER_USE_AFTER_RETURN",
+    "description": "Whether to enable Detect use of stack after return in the Diagnostics section of the generated Xcode scheme."
+  },
+  "CMAKE_XCODE_SCHEME_DEBUG_DOCUMENT_VERSIONING": {
+    "name": "CMAKE_XCODE_SCHEME_DEBUG_DOCUMENT_VERSIONING",
+    "description": "Whether to enable Allow debugging when using document Versions Browser in the Options section of the generated Xcode scheme."
+  },
+  "CMAKE_XCODE_SCHEME_DISABLE_MAIN_THREAD_CHECKER": {
+    "name": "CMAKE_XCODE_SCHEME_DISABLE_MAIN_THREAD_CHECKER",
+    "description": "Whether to disable the Main Thread Checker in the Diagnostics section of the generated Xcode scheme."
+  },
+  "CMAKE_XCODE_SCHEME_DYNAMIC_LIBRARY_LOADS": {
+    "name": "CMAKE_XCODE_SCHEME_DYNAMIC_LIBRARY_LOADS",
+    "description": "Whether to enable Dynamic Library Loads in the Diagnostics section of the generated Xcode scheme."
+  },
+  "CMAKE_XCODE_SCHEME_DYNAMIC_LINKER_API_USAGE": {
+    "name": "CMAKE_XCODE_SCHEME_DYNAMIC_LINKER_API_USAGE",
+    "description": "Whether to enable Dynamic Linker API usage in the Diagnostics section of the generated Xcode scheme."
+  },
+  "CMAKE_XCODE_SCHEME_ENABLE_GPU_API_VALIDATION": {
+    "name": "CMAKE_XCODE_SCHEME_ENABLE_GPU_API_VALIDATION",
+    "description": "Property value for Metal: API Validation in the Options section of the generated Xcode scheme."
+  },
+  "CMAKE_XCODE_SCHEME_ENABLE_GPU_FRAME_CAPTURE_MODE": {
+    "name": "CMAKE_XCODE_SCHEME_ENABLE_GPU_FRAME_CAPTURE_MODE",
+    "description": "Property value for GPU Frame Capture in the Options section of the generated Xcode scheme. Example values are Metal and Disabled."
+  },
+  "CMAKE_XCODE_SCHEME_ENABLE_GPU_SHADER_VALIDATION": {
+    "name": "CMAKE_XCODE_SCHEME_ENABLE_GPU_SHADER_VALIDATION",
+    "description": "Property value for Metal: Shader Validation in the Options section of the generated Xcode scheme."
+  },
+  "CMAKE_XCODE_SCHEME_ENVIRONMENT": {
+    "name": "CMAKE_XCODE_SCHEME_ENVIRONMENT",
+    "description": "Specify environment variables that should be added to the Arguments section of the generated Xcode scheme."
+  },
+  "CMAKE_XCODE_SCHEME_GUARD_MALLOC": {
+    "name": "CMAKE_XCODE_SCHEME_GUARD_MALLOC",
+    "description": "Whether to enable Guard Malloc in the Diagnostics section of the generated Xcode scheme."
+  },
+  "CMAKE_XCODE_SCHEME_LAUNCH_CONFIGURATION": {
+    "name": "CMAKE_XCODE_SCHEME_LAUNCH_CONFIGURATION",
+    "description": "Set the build configuration to run the target."
+  },
+  "CMAKE_XCODE_SCHEME_LAUNCH_MODE": {
+    "name": "CMAKE_XCODE_SCHEME_LAUNCH_MODE",
+    "description": "Property value for Launch in the Info section of the generated Xcode scheme."
+  },
+  "CMAKE_XCODE_SCHEME_MAIN_THREAD_CHECKER_STOP": {
+    "name": "CMAKE_XCODE_SCHEME_MAIN_THREAD_CHECKER_STOP",
+    "description": "Whether to enable the Main Thread Checker option Pause on issues in the Diagnostics section of the generated Xcode scheme."
+  },
+  "CMAKE_XCODE_SCHEME_MALLOC_GUARD_EDGES": {
+    "name": "CMAKE_XCODE_SCHEME_MALLOC_GUARD_EDGES",
+    "description": "Whether to enable Malloc Guard Edges in the Diagnostics section of the generated Xcode scheme."
+  },
+  "CMAKE_XCODE_SCHEME_MALLOC_SCRIBBLE": {
+    "name": "CMAKE_XCODE_SCHEME_MALLOC_SCRIBBLE",
+    "description": "Whether to enable Malloc Scribble in the Diagnostics section of the generated Xcode scheme."
+  },
+  "CMAKE_XCODE_SCHEME_MALLOC_STACK": {
+    "name": "CMAKE_XCODE_SCHEME_MALLOC_STACK",
+    "description": "Whether to enable Malloc Stack in the Diagnostics section of the generated Xcode scheme."
+  },
+  "CMAKE_XCODE_SCHEME_THREAD_SANITIZER": {
+    "name": "CMAKE_XCODE_SCHEME_THREAD_SANITIZER",
+    "description": "Whether to enable Thread Sanitizer in the Diagnostics section of the generated Xcode scheme."
+  },
+  "CMAKE_XCODE_SCHEME_THREAD_SANITIZER_STOP": {
+    "name": "CMAKE_XCODE_SCHEME_THREAD_SANITIZER_STOP",
+    "description": "Whether to enable Thread Sanitizer - Pause on issues in the Diagnostics section of the generated Xcode scheme."
+  },
+  "CMAKE_XCODE_SCHEME_UNDEFINED_BEHAVIOUR_SANITIZER": {
+    "name": "CMAKE_XCODE_SCHEME_UNDEFINED_BEHAVIOUR_SANITIZER",
+    "description": "Whether to enable Undefined Behavior Sanitizer in the Diagnostics section of the generated Xcode scheme."
+  },
+  "CMAKE_XCODE_SCHEME_UNDEFINED_BEHAVIOUR_SANITIZER_STOP": {
+    "name": "CMAKE_XCODE_SCHEME_UNDEFINED_BEHAVIOUR_SANITIZER_STOP",
+    "description": "Whether to enable Undefined Behavior Sanitizer option Pause on issues in the Diagnostics section of the generated Xcode scheme."
+  },
+  "CMAKE_XCODE_SCHEME_WORKING_DIRECTORY": {
+    "name": "CMAKE_XCODE_SCHEME_WORKING_DIRECTORY",
+    "description": "Specify the Working Directory of the Run and Profile actions in the generated Xcode scheme."
+  },
+  "CMAKE_XCODE_SCHEME_ZOMBIE_OBJECTS": {
+    "name": "CMAKE_XCODE_SCHEME_ZOMBIE_OBJECTS",
+    "description": "Whether to enable Zombie Objects in the Diagnostics section of the generated Xcode scheme."
+  },
+  "CMAKE_XCODE_XCCONFIG": {
+    "name": "CMAKE_XCODE_XCCONFIG",
+    "description": "If set, the Xcode generator will register the specified file as a global XCConfig file. For target-level XCConfig files see the XCODE_XCCONFIG target property."
+  },
+  "CPACK_ABSOLUTE_DESTINATION_FILES": {
+    "name": "CPACK_ABSOLUTE_DESTINATION_FILES",
+    "description": "List of files which have been installed using an ABSOLUTE DESTINATION path."
+  },
+  "CPACK_COMPONENT_INCLUDE_TOPLEVEL_DIRECTORY": {
+    "name": "CPACK_COMPONENT_INCLUDE_TOPLEVEL_DIRECTORY",
+    "description": "Boolean toggle to include/exclude top level directory (component case)."
+  },
+  "CPACK_CUSTOM_INSTALL_VARIABLES": {
+    "name": "CPACK_CUSTOM_INSTALL_VARIABLES",
+    "description": "CPack variables (set via e.g. cpack -D, CPackConfig.cmake or CPACK_PROJECT_CONFIG_FILE scripts) are not directly visible in installation scripts. Instead, one can pass a list of varName=value pairs in the CPACK_CUSTOM_INSTALL_VARIABLES variable. At install time, each list item will result in a variable of the specified name (varName) being set to the given value. The = can be omitted for an empty value."
+  },
+  "CPACK_ERROR_ON_ABSOLUTE_INSTALL_DESTINATION": {
+    "name": "CPACK_ERROR_ON_ABSOLUTE_INSTALL_DESTINATION",
+    "description": "Ask CPack to error out as soon as a file with absolute INSTALL DESTINATION is encountered."
+  },
+  "CPACK_INCLUDE_TOPLEVEL_DIRECTORY": {
+    "name": "CPACK_INCLUDE_TOPLEVEL_DIRECTORY",
+    "description": "Boolean toggle to include/exclude top level directory."
+  },
+  "CPACK_INSTALL_DEFAULT_DIRECTORY_PERMISSIONS": {
+    "name": "CPACK_INSTALL_DEFAULT_DIRECTORY_PERMISSIONS",
+    "description": "Default permissions for implicitly created directories during packaging."
+  },
+  "CPACK_PACKAGING_INSTALL_PREFIX": {
+    "name": "CPACK_PACKAGING_INSTALL_PREFIX",
+    "description": "The prefix used in the built package."
+  },
+  "CPACK_SET_DESTDIR": {
+    "name": "CPACK_SET_DESTDIR",
+    "description": "Boolean toggle to make CPack use DESTDIR mechanism when packaging."
+  },
+  "CPACK_WARN_ON_ABSOLUTE_INSTALL_DESTINATION": {
+    "name": "CPACK_WARN_ON_ABSOLUTE_INSTALL_DESTINATION",
+    "description": "Ask CPack to warn each time a file with absolute INSTALL DESTINATION is encountered."
+  },
+  "CTEST_BINARY_DIRECTORY": {
+    "name": "CTEST_BINARY_DIRECTORY",
+    "description": "Specify the CTest BuildDirectory setting in a ctest dashboard client script."
+  },
+  "CTEST_BUILD_COMMAND": {
+    "name": "CTEST_BUILD_COMMAND",
+    "description": "Specify the CTest MakeCommand setting in a ctest dashboard client script."
+  },
+  "CTEST_BUILD_NAME": {
+    "name": "CTEST_BUILD_NAME",
+    "description": "Specify the CTest BuildName setting in a ctest dashboard client script."
+  },
+  "CTEST_BZR_COMMAND": {
+    "name": "CTEST_BZR_COMMAND",
+    "description": "Specify the CTest BZRCommand setting in a ctest dashboard client script."
+  },
+  "CTEST_BZR_UPDATE_OPTIONS": {
+    "name": "CTEST_BZR_UPDATE_OPTIONS",
+    "description": "Specify the CTest BZRUpdateOptions setting in a ctest dashboard client script."
+  },
+  "CTEST_CHANGE_ID": {
+    "name": "CTEST_CHANGE_ID",
+    "description": "Specify the CTest ChangeId setting in a ctest dashboard client script."
+  },
+  "CTEST_CHECKOUT_COMMAND": {
+    "name": "CTEST_CHECKOUT_COMMAND",
+    "description": "Tell the ctest_start command how to checkout or initialize the source directory in a ctest dashboard client script."
+  },
+  "CTEST_CONFIGURATION_TYPE": {
+    "name": "CTEST_CONFIGURATION_TYPE",
+    "description": "Specify the CTest DefaultCTestConfigurationType setting in a ctest dashboard client script."
+  },
+  "CTEST_CONFIGURE_COMMAND": {
+    "name": "CTEST_CONFIGURE_COMMAND",
+    "description": "Specify the CTest ConfigureCommand setting in a ctest dashboard client script."
+  },
+  "CTEST_COVERAGE_COMMAND": {
+    "name": "CTEST_COVERAGE_COMMAND",
+    "description": "Specify the CTest CoverageCommand setting in a ctest dashboard client script."
+  },
+  "CTEST_COVERAGE_EXTRA_FLAGS": {
+    "name": "CTEST_COVERAGE_EXTRA_FLAGS",
+    "description": "Specify the CTest CoverageExtraFlags setting in a ctest dashboard client script."
+  },
+  "CTEST_CURL_OPTIONS": {
+    "name": "CTEST_CURL_OPTIONS",
+    "description": "Specify the CTest CurlOptions setting in a ctest dashboard client script."
+  },
+  "CTEST_CUSTOM_COVERAGE_EXCLUDE": {
+    "name": "CTEST_CUSTOM_COVERAGE_EXCLUDE",
+    "description": "A list of regular expressions which will be used to exclude files by their path from coverage output by the ctest_coverage command."
+  },
+  "CTEST_CUSTOM_ERROR_EXCEPTION": {
+    "name": "CTEST_CUSTOM_ERROR_EXCEPTION",
+    "description": "A list of regular expressions which will be used to exclude when detecting error messages in build outputs by the ctest_build command."
+  },
+  "CTEST_CUSTOM_ERROR_MATCH": {
+    "name": "CTEST_CUSTOM_ERROR_MATCH",
+    "description": "A list of regular expressions which will be used to detect error messages in build outputs by the ctest_build command."
+  },
+  "CTEST_CUSTOM_ERROR_POST_CONTEXT": {
+    "name": "CTEST_CUSTOM_ERROR_POST_CONTEXT",
+    "description": "The number of lines to include as context which follow an error message by the ctest_build command. The default is 10."
+  },
+  "CTEST_CUSTOM_ERROR_PRE_CONTEXT": {
+    "name": "CTEST_CUSTOM_ERROR_PRE_CONTEXT",
+    "description": "The number of lines to include as context which precede an error message by the ctest_build command. The default is 10."
+  },
+  "CTEST_CUSTOM_MAXIMUM_FAILED_TEST_OUTPUT_SIZE": {
+    "name": "CTEST_CUSTOM_MAXIMUM_FAILED_TEST_OUTPUT_SIZE",
+    "description": "When saving a failing test's output, this is the maximum size, in bytes, that will be collected by the ctest_test command. Defaults to 307200 (300 KiB). See CTEST_CUSTOM_TEST_OUTPUT_TRUNCATION for possible truncation modes."
+  },
+  "CTEST_CUSTOM_MAXIMUM_NUMBER_OF_ERRORS": {
+    "name": "CTEST_CUSTOM_MAXIMUM_NUMBER_OF_ERRORS",
+    "description": "The maximum number of errors in a single build step which will be detected. After this, the ctest_test command will truncate the output. Defaults to 50."
+  },
+  "CTEST_CUSTOM_MAXIMUM_NUMBER_OF_WARNINGS": {
+    "name": "CTEST_CUSTOM_MAXIMUM_NUMBER_OF_WARNINGS",
+    "description": "The maximum number of warnings in a single build step which will be detected. After this, the ctest_test command will truncate the output. Defaults to 50."
+  },
+  "CTEST_CUSTOM_MAXIMUM_PASSED_TEST_OUTPUT_SIZE": {
+    "name": "CTEST_CUSTOM_MAXIMUM_PASSED_TEST_OUTPUT_SIZE",
+    "description": "When saving a passing test's output, this is the maximum size, in bytes, that will be collected by the ctest_test command. Defaults to 1024 (1 KiB). See CTEST_CUSTOM_TEST_OUTPUT_TRUNCATION for possible truncation modes."
+  },
+  "CTEST_CUSTOM_MEMCHECK_IGNORE": {
+    "name": "CTEST_CUSTOM_MEMCHECK_IGNORE",
+    "description": "A list of regular expressions to use to exclude tests during the ctest_memcheck command."
+  },
+  "CTEST_CUSTOM_POST_MEMCHECK": {
+    "name": "CTEST_CUSTOM_POST_MEMCHECK",
+    "description": "A list of commands to run at the end of the ctest_memcheck command."
+  },
+  "CTEST_CUSTOM_POST_TEST": {
+    "name": "CTEST_CUSTOM_POST_TEST",
+    "description": "A list of commands to run at the end of the ctest_test command."
+  },
+  "CTEST_CUSTOM_PRE_MEMCHECK": {
+    "name": "CTEST_CUSTOM_PRE_MEMCHECK",
+    "description": "A list of commands to run at the start of the ctest_memcheck command."
+  },
+  "CTEST_CUSTOM_PRE_TEST": {
+    "name": "CTEST_CUSTOM_PRE_TEST",
+    "description": "A list of commands to run at the start of the ctest_test command."
+  },
+  "CTEST_CUSTOM_TESTS_IGNORE": {
+    "name": "CTEST_CUSTOM_TESTS_IGNORE",
+    "description": "A list of test names to be excluded from the set of tests run by the ctest_test command."
+  },
+  "CTEST_CUSTOM_TEST_OUTPUT_TRUNCATION": {
+    "name": "CTEST_CUSTOM_TEST_OUTPUT_TRUNCATION",
+    "description": "Set the test output truncation mode in case a maximum size is configured via the CTEST_CUSTOM_MAXIMUM_PASSED_TEST_OUTPUT_SIZE or CTEST_CUSTOM_MAXIMUM_FAILED_TEST_OUTPUT_SIZE variables. By default the tail of the output will be truncated. Other possible values are middle and head."
+  },
+  "CTEST_CUSTOM_WARNING_EXCEPTION": {
+    "name": "CTEST_CUSTOM_WARNING_EXCEPTION",
+    "description": "A list of regular expressions which will be used to exclude when detecting warning messages in build outputs by the ctest_build command."
+  },
+  "CTEST_CUSTOM_WARNING_MATCH": {
+    "name": "CTEST_CUSTOM_WARNING_MATCH",
+    "description": "A list of regular expressions which will be used to detect warning messages in build outputs by the ctest_build command."
+  },
+  "CTEST_CVS_CHECKOUT": {
+    "name": "CTEST_CVS_CHECKOUT",
+    "description": "Deprecated. Use CTEST_CHECKOUT_COMMAND instead."
+  },
+  "CTEST_CVS_COMMAND": {
+    "name": "CTEST_CVS_COMMAND",
+    "description": "Specify the CTest CVSCommand setting in a ctest dashboard client script."
+  },
+  "CTEST_CVS_UPDATE_OPTIONS": {
+    "name": "CTEST_CVS_UPDATE_OPTIONS",
+    "description": "Specify the CTest CVSUpdateOptions setting in a ctest dashboard client script."
+  },
+  "CTEST_DROP_LOCATION": {
+    "name": "CTEST_DROP_LOCATION",
+    "description": "Specify the CTest DropLocation setting in a ctest dashboard client script."
+  },
+  "CTEST_DROP_METHOD": {
+    "name": "CTEST_DROP_METHOD",
+    "description": "Specify the CTest DropMethod setting in a ctest dashboard client script."
+  },
+  "CTEST_DROP_SITE": {
+    "name": "CTEST_DROP_SITE",
+    "description": "Specify the CTest DropSite setting in a ctest dashboard client script."
+  },
+  "CTEST_DROP_SITE_CDASH": {
+    "name": "CTEST_DROP_SITE_CDASH",
+    "description": "Specify the CTest IsCDash setting in a ctest dashboard client script."
+  },
+  "CTEST_DROP_SITE_PASSWORD": {
+    "name": "CTEST_DROP_SITE_PASSWORD",
+    "description": "Specify the CTest DropSitePassword setting in a ctest dashboard client script."
+  },
+  "CTEST_DROP_SITE_USER": {
+    "name": "CTEST_DROP_SITE_USER",
+    "description": "Specify the CTest DropSiteUser setting in a ctest dashboard client script."
+  },
+  "CTEST_EXTRA_COVERAGE_GLOB": {
+    "name": "CTEST_EXTRA_COVERAGE_GLOB",
+    "description": "A list of regular expressions which will be used to find files which should be covered by the ctest_coverage command."
+  },
+  "CTEST_GIT_COMMAND": {
+    "name": "CTEST_GIT_COMMAND",
+    "description": "Specify the CTest GITCommand setting in a ctest dashboard client script."
+  },
+  "CTEST_GIT_INIT_SUBMODULES": {
+    "name": "CTEST_GIT_INIT_SUBMODULES",
+    "description": "Specify the CTest GITInitSubmodules setting in a ctest dashboard client script."
+  },
+  "CTEST_GIT_UPDATE_CUSTOM": {
+    "name": "CTEST_GIT_UPDATE_CUSTOM",
+    "description": "Specify the CTest GITUpdateCustom setting in a ctest dashboard client script."
+  },
+  "CTEST_GIT_UPDATE_OPTIONS": {
+    "name": "CTEST_GIT_UPDATE_OPTIONS",
+    "description": "Specify the CTest GITUpdateOptions setting in a ctest dashboard client script."
+  },
+  "CTEST_HG_COMMAND": {
+    "name": "CTEST_HG_COMMAND",
+    "description": "Specify the CTest HGCommand setting in a ctest dashboard client script."
+  },
+  "CTEST_HG_UPDATE_OPTIONS": {
+    "name": "CTEST_HG_UPDATE_OPTIONS",
+    "description": "Specify the CTest HGUpdateOptions setting in a ctest dashboard client script."
+  },
+  "CTEST_LABELS_FOR_SUBPROJECTS": {
+    "name": "CTEST_LABELS_FOR_SUBPROJECTS",
+    "description": "Specify the CTest LabelsForSubprojects setting in a ctest dashboard client script."
+  },
+  "CTEST_MEMORYCHECK_COMMAND": {
+    "name": "CTEST_MEMORYCHECK_COMMAND",
+    "description": "Specify the CTest MemoryCheckCommand setting in a ctest dashboard client script."
+  },
+  "CTEST_MEMORYCHECK_COMMAND_OPTIONS": {
+    "name": "CTEST_MEMORYCHECK_COMMAND_OPTIONS",
+    "description": "Specify the CTest MemoryCheckCommandOptions setting in a ctest dashboard client script."
+  },
+  "CTEST_MEMORYCHECK_SANITIZER_OPTIONS": {
+    "name": "CTEST_MEMORYCHECK_SANITIZER_OPTIONS",
+    "description": "Specify the CTest MemoryCheckSanitizerOptions setting in a ctest dashboard client script."
+  },
+  "CTEST_MEMORYCHECK_SUPPRESSIONS_FILE": {
+    "name": "CTEST_MEMORYCHECK_SUPPRESSIONS_FILE",
+    "description": "Specify the CTest MemoryCheckSuppressionFile setting in a ctest dashboard client script."
+  },
+  "CTEST_MEMORYCHECK_TYPE": {
+    "name": "CTEST_MEMORYCHECK_TYPE",
+    "description": "Specify the CTest MemoryCheckType setting in a ctest dashboard client script. Valid values are Valgrind, Purify, BoundsChecker, DrMemory, CudaSanitizer, ThreadSanitizer, AddressSanitizer, LeakSanitizer, MemorySanitizer and UndefinedBehaviorSanitizer."
+  },
+  "CTEST_NIGHTLY_START_TIME": {
+    "name": "CTEST_NIGHTLY_START_TIME",
+    "description": "Specify the CTest NightlyStartTime setting in a ctest dashboard client script."
+  },
+  "CTEST_P4_CLIENT": {
+    "name": "CTEST_P4_CLIENT",
+    "description": "Specify the CTest P4Client setting in a ctest dashboard client script."
+  },
+  "CTEST_P4_COMMAND": {
+    "name": "CTEST_P4_COMMAND",
+    "description": "Specify the CTest P4Command setting in a ctest dashboard client script."
+  },
+  "CTEST_P4_OPTIONS": {
+    "name": "CTEST_P4_OPTIONS",
+    "description": "Specify the CTest P4Options setting in a ctest dashboard client script."
+  },
+  "CTEST_P4_UPDATE_OPTIONS": {
+    "name": "CTEST_P4_UPDATE_OPTIONS",
+    "description": "Specify the CTest P4UpdateOptions setting in a ctest dashboard client script."
+  },
+  "CTEST_RESOURCE_SPEC_FILE": {
+    "name": "CTEST_RESOURCE_SPEC_FILE",
+    "description": "Specify the CTest ResourceSpecFile setting in a ctest dashboard client script."
+  },
+  "CTEST_RUN_CURRENT_SCRIPT": {
+    "name": "CTEST_RUN_CURRENT_SCRIPT",
+    "description": "Setting this to 0 prevents ctest from being run again when it reaches the end of a script run by calling ctest -S."
+  },
+  "CTEST_SCP_COMMAND": {
+    "name": "CTEST_SCP_COMMAND",
+    "description": "Legacy option. Not used."
+  },
+  "CTEST_SCRIPT_DIRECTORY": {
+    "name": "CTEST_SCRIPT_DIRECTORY",
+    "description": "The directory containing the top-level CTest script. The concept is similar to CMAKE_SOURCE_DIR."
+  },
+  "CTEST_SITE": {
+    "name": "CTEST_SITE",
+    "description": "Specify the CTest Site setting in a ctest dashboard client script."
+  },
+  "CTEST_SOURCE_DIRECTORY": {
+    "name": "CTEST_SOURCE_DIRECTORY",
+    "description": "Specify the CTest SourceDirectory setting in a ctest dashboard client script."
+  },
+  "CTEST_SUBMIT_INACTIVITY_TIMEOUT": {
+    "name": "CTEST_SUBMIT_INACTIVITY_TIMEOUT",
+    "description": "Specify the CTest SubmitInactivityTimeout setting in a ctest dashboard client script."
+  },
+  "CTEST_SUBMIT_URL": {
+    "name": "CTEST_SUBMIT_URL",
+    "description": "Specify the CTest SubmitURL setting in a ctest dashboard client script."
+  },
+  "CTEST_SVN_COMMAND": {
+    "name": "CTEST_SVN_COMMAND",
+    "description": "Specify the CTest SVNCommand setting in a ctest dashboard client script."
+  },
+  "CTEST_SVN_OPTIONS": {
+    "name": "CTEST_SVN_OPTIONS",
+    "description": "Specify the CTest SVNOptions setting in a ctest dashboard client script."
+  },
+  "CTEST_SVN_UPDATE_OPTIONS": {
+    "name": "CTEST_SVN_UPDATE_OPTIONS",
+    "description": "Specify the CTest SVNUpdateOptions setting in a ctest dashboard client script."
+  },
+  "CTEST_TEST_LOAD": {
+    "name": "CTEST_TEST_LOAD",
+    "description": "Specify the TestLoad setting in the CTest Test Step of a ctest dashboard client script. This sets the default value for the TEST_LOAD option of the ctest_test command."
+  },
+  "CTEST_TEST_TIMEOUT": {
+    "name": "CTEST_TEST_TIMEOUT",
+    "description": "Specify the CTest TimeOut setting in a ctest dashboard client script."
+  },
+  "CTEST_TLS_VERIFY": {
+    "name": "CTEST_TLS_VERIFY",
+    "description": "Specify the CTest TLSVerify setting in a ctest Dashboard Client script or in project CMakeLists.txt code before including the CTest module. The value is a boolean indicating whether to verify the server certificate when submitting to a dashboard via https:// URLs."
+  },
+  "CTEST_TLS_VERSION": {
+    "name": "CTEST_TLS_VERSION",
+    "description": "Specify the CTest TLSVersion setting in a ctest Dashboard Client script or in project CMakeLists.txt code before including the CTest module. The value is a minimum TLS version allowed when submitting to a dashboard via https:// URLs."
+  },
+  "CTEST_TRIGGER_SITE": {
+    "name": "CTEST_TRIGGER_SITE",
+    "description": "Legacy option. Not used."
+  },
+  "CTEST_UPDATE_COMMAND": {
+    "name": "CTEST_UPDATE_COMMAND",
+    "description": "Specify the CTest UpdateCommand setting in a ctest dashboard client script."
+  },
+  "CTEST_UPDATE_OPTIONS": {
+    "name": "CTEST_UPDATE_OPTIONS",
+    "description": "Specify the CTest UpdateOptions setting in a ctest dashboard client script."
+  },
+  "CTEST_UPDATE_VERSION_ONLY": {
+    "name": "CTEST_UPDATE_VERSION_ONLY",
+    "description": "Specify the CTest UpdateVersionOnly  setting in a ctest dashboard client script."
+  },
+  "CTEST_UPDATE_VERSION_OVERRIDE": {
+    "name": "CTEST_UPDATE_VERSION_OVERRIDE",
+    "description": "Specify the CTest UpdateVersionOverride  setting in a ctest dashboard client script."
+  },
+  "CTEST_USE_LAUNCHERS": {
+    "name": "CTEST_USE_LAUNCHERS",
+    "description": "Specify the CTest UseLaunchers setting in a ctest dashboard client script."
+  },
+  "CYGWIN": { "name": "CYGWIN", "description": "True for Cygwin." },
+  "ENV": {
+    "name": "ENV",
+    "description": "Operator to read environment variables."
+  },
+  "EXECUTABLE_OUTPUT_PATH": {
+    "name": "EXECUTABLE_OUTPUT_PATH",
+    "description": "Old executable location variable."
+  },
+  "GHSMULTI": {
+    "name": "GHSMULTI",
+    "description": "1 when using Green Hills MULTI generator."
+  },
+  "IOS": {
+    "name": "IOS",
+    "description": "Set to 1 when the target system (CMAKE_SYSTEM_NAME) is iOS."
+  },
+  "LIBRARY_OUTPUT_PATH": {
+    "name": "LIBRARY_OUTPUT_PATH",
+    "description": "Old library location variable."
+  },
+  "LINUX": {
+    "name": "LINUX",
+    "description": "Set to true when the target system is Linux."
+  },
+  "MINGW": {
+    "name": "MINGW",
+    "description": "Set to a true value when at least one language is enabled with a compiler targeting the GNU ABI on Windows (MinGW)."
+  },
+  "MSVC": {
+    "name": "MSVC",
+    "description": "Set to true when the compiler is some version of Microsoft Visual C++ or another compiler simulating the Visual C++ cl command-line syntax."
+  },
+  "MSVC10": {
+    "name": "MSVC10",
+    "description": "Discouraged. Use the MSVC_VERSION variable instead."
+  },
+  "MSVC11": {
+    "name": "MSVC11",
+    "description": "Discouraged. Use the MSVC_VERSION variable instead."
+  },
+  "MSVC12": {
+    "name": "MSVC12",
+    "description": "Discouraged. Use the MSVC_VERSION variable instead."
+  },
+  "MSVC14": {
+    "name": "MSVC14",
+    "description": "Discouraged. Use the MSVC_VERSION variable instead."
+  },
+  "MSVC60": {
+    "name": "MSVC60",
+    "description": "Discouraged. Use the MSVC_VERSION variable instead."
+  },
+  "MSVC70": {
+    "name": "MSVC70",
+    "description": "Discouraged. Use the MSVC_VERSION variable instead."
+  },
+  "MSVC71": {
+    "name": "MSVC71",
+    "description": "Discouraged. Use the MSVC_VERSION variable instead."
+  },
+  "MSVC80": {
+    "name": "MSVC80",
+    "description": "Discouraged. Use the MSVC_VERSION variable instead."
+  },
+  "MSVC90": {
+    "name": "MSVC90",
+    "description": "Discouraged. Use the MSVC_VERSION variable instead."
+  },
+  "MSVC_IDE": {
+    "name": "MSVC_IDE",
+    "description": "True when using the Microsoft Visual C++ IDE."
+  },
+  "MSVC_TOOLSET_VERSION": {
+    "name": "MSVC_TOOLSET_VERSION",
+    "description": "The toolset version of Microsoft Visual C/C++ being used if any. If MSVC-like is being used, this variable is set based on the version of the compiler as given by the MSVC_VERSION variable."
+  },
+  "MSVC_VERSION": {
+    "name": "MSVC_VERSION",
+    "description": "The version of Microsoft Visual C/C++ being used if any. If a compiler simulating Visual C++ is being used, this variable is set to the toolset version simulated as given by the _MSC_VER preprocessor definition."
+  },
+  "MSYS": {
+    "name": "MSYS",
+    "description": "True when using the MSYS Makefiles generator."
+  },
+  "<PackageName>_ROOT": {
+    "name": "<PackageName>_ROOT",
+    "description": "Calls to find_package(<PackageName>) will search in prefixes specified by the <PackageName>_ROOT CMake variable, where <PackageName> is the (case-preserved) name given to the find_package call and _ROOT is literal. For example, find_package(Foo) will search prefixes specified in the Foo_ROOT CMake variable (if set). See policy CMP0074."
+  },
+  "<PROJECT-NAME>_BINARY_DIR": {
+    "name": "<PROJECT-NAME>_BINARY_DIR",
+    "description": "Top level binary directory for the named project."
+  },
+  "<PROJECT-NAME>_DESCRIPTION": {
+    "name": "<PROJECT-NAME>_DESCRIPTION",
+    "description": "Value given to the DESCRIPTION option of the most recent call to the project command with project name <PROJECT-NAME>, if any."
+  },
+  "<PROJECT-NAME>_HOMEPAGE_URL": {
+    "name": "<PROJECT-NAME>_HOMEPAGE_URL",
+    "description": "Value given to the HOMEPAGE_URL option of the most recent call to the project command with project name <PROJECT-NAME>, if any."
+  },
+  "<PROJECT-NAME>_IS_TOP_LEVEL": {
+    "name": "<PROJECT-NAME>_IS_TOP_LEVEL",
+    "description": "A boolean variable indicating whether the named project was called in a top level CMakeLists.txt file."
+  },
+  "<PROJECT-NAME>_SOURCE_DIR": {
+    "name": "<PROJECT-NAME>_SOURCE_DIR",
+    "description": "Top level source directory for the named project."
+  },
+  "<PROJECT-NAME>_VERSION": {
+    "name": "<PROJECT-NAME>_VERSION",
+    "description": "Value given to the VERSION option of the most recent call to the project command with project name <PROJECT-NAME>, if any."
+  },
+  "<PROJECT-NAME>_VERSION_MAJOR": {
+    "name": "<PROJECT-NAME>_VERSION_MAJOR",
+    "description": "First version number component of the <PROJECT-NAME>_VERSION variable as set by the project command."
+  },
+  "<PROJECT-NAME>_VERSION_MINOR": {
+    "name": "<PROJECT-NAME>_VERSION_MINOR",
+    "description": "Second version number component of the <PROJECT-NAME>_VERSION variable as set by the project command."
+  },
+  "<PROJECT-NAME>_VERSION_PATCH": {
+    "name": "<PROJECT-NAME>_VERSION_PATCH",
+    "description": "Third version number component of the <PROJECT-NAME>_VERSION variable as set by the project command."
+  },
+  "<PROJECT-NAME>_VERSION_TWEAK": {
+    "name": "<PROJECT-NAME>_VERSION_TWEAK",
+    "description": "Fourth version number component of the <PROJECT-NAME>_VERSION variable as set by the project command."
+  },
+  "PROJECT_BINARY_DIR": {
+    "name": "PROJECT_BINARY_DIR",
+    "description": "Full path to build directory for project."
+  },
+  "PROJECT_DESCRIPTION": {
+    "name": "PROJECT_DESCRIPTION",
+    "description": "Short project description given to the project command."
+  },
+  "PROJECT_HOMEPAGE_URL": {
+    "name": "PROJECT_HOMEPAGE_URL",
+    "description": "The homepage URL of the project."
+  },
+  "PROJECT_IS_TOP_LEVEL": {
+    "name": "PROJECT_IS_TOP_LEVEL",
+    "description": "A boolean variable indicating whether the most recently called project command in the current scope or above was in the top level CMakeLists.txt file."
+  },
+  "PROJECT_NAME": {
+    "name": "PROJECT_NAME",
+    "description": "Name of the project given to the project command."
+  },
+  "PROJECT_SOURCE_DIR": {
+    "name": "PROJECT_SOURCE_DIR",
+    "description": "This is the source directory of the last call to the project command made in the current directory scope or one of its parents. Note, it is not affected by calls to project made within a child directory scope (i.e. from within a call to add_subdirectory from the current scope)."
+  },
+  "PROJECT_VERSION": {
+    "name": "PROJECT_VERSION",
+    "description": "Value given to the VERSION option of the most recent call to the project command, if any."
+  },
+  "PROJECT_VERSION_MAJOR": {
+    "name": "PROJECT_VERSION_MAJOR",
+    "description": "First version number component of the PROJECT_VERSION variable as set by the project command."
+  },
+  "PROJECT_VERSION_MINOR": {
+    "name": "PROJECT_VERSION_MINOR",
+    "description": "Second version number component of the PROJECT_VERSION variable as set by the project command."
+  },
+  "PROJECT_VERSION_PATCH": {
+    "name": "PROJECT_VERSION_PATCH",
+    "description": "Third version number component of the PROJECT_VERSION variable as set by the project command."
+  },
+  "PROJECT_VERSION_TWEAK": {
+    "name": "PROJECT_VERSION_TWEAK",
+    "description": "Fourth version number component of the PROJECT_VERSION variable as set by the project command."
+  },
+  "UNIX": {
+    "name": "UNIX",
+    "description": "Set to True when the target system is UNIX or UNIX-like (e.g. APPLE and CYGWIN). The CMAKE_SYSTEM_NAME variable should be queried if a more specific understanding of the target system is required."
+  },
+  "WIN32": {
+    "name": "WIN32",
+    "description": "Set to True when the target system is Windows, including Win64."
+  },
+  "WINCE": {
+    "name": "WINCE",
+    "description": "True when the CMAKE_SYSTEM_NAME variable is set to WindowsCE."
+  },
+  "WINDOWS_PHONE": {
+    "name": "WINDOWS_PHONE",
+    "description": "True when the CMAKE_SYSTEM_NAME variable is set to WindowsPhone."
+  },
+  "WINDOWS_STORE": {
+    "name": "WINDOWS_STORE",
+    "description": "True when the CMAKE_SYSTEM_NAME variable is set to WindowsStore."
+  },
+  "XCODE": {
+    "name": "XCODE",
+    "description": "True when using Xcode generator."
+  },
+  "XCODE_VERSION": {
+    "name": "XCODE_VERSION",
+    "description": "Version of Xcode (Xcode generator only)."
+  },
+  "ADVANCED": {
+    "name": "ADVANCED",
+    "description": "True if entry should be hidden by default in GUIs."
+  },
+  "HELPSTRING": {
+    "name": "HELPSTRING",
+    "description": "Help associated with entry in GUIs."
+  },
+  "MODIFIED": {
+    "name": "MODIFIED",
+    "description": "Internal management property. Do not set or get."
+  },
+  "STRINGS": {
+    "name": "STRINGS",
+    "description": "Enumerate possible STRING entry values for GUI selection."
+  },
+  "TYPE": { "name": "TYPE", "description": "Widget type for entry in GUIs." },
+  "VALUE": { "name": "VALUE", "description": "Value of a cache entry." },
+  "ADDITIONAL_CLEAN_FILES": {
+    "name": "ADDITIONAL_CLEAN_FILES",
+    "description": "A Semicolon-separated list  of files or directories that will be removed as a part of the global clean target. It is useful for specifying generated files or directories that are used by multiple targets or by CMake itself, or that are generated in ways which cannot be captured as outputs or byproducts of custom commands."
+  },
+  "ADDITIONAL_MAKE_CLEAN_FILES": {
+    "name": "ADDITIONAL_MAKE_CLEAN_FILES",
+    "description": "Additional files to remove during the clean stage."
+  },
+  "BINARY_DIR": {
+    "name": "BINARY_DIR",
+    "description": "This read-only directory property reports absolute path to the binary directory corresponding to the source on which it is read."
+  },
+  "BUILDSYSTEM_TARGETS": {
+    "name": "BUILDSYSTEM_TARGETS",
+    "description": "This read-only directory property contains a semicolon-separated list  of buildsystem targets added in the directory by calls to the add_library, add_executable, and add_custom_target commands. The list does not include any Imported Targets or Alias Targets, but does include Interface Libraries. Each entry in the list is the logical name of a target, suitable to pass to the get_property command TARGET option."
+  },
+  "CACHE_VARIABLES": {
+    "name": "CACHE_VARIABLES",
+    "description": "List of cache variables available in the current directory."
+  },
+  "CLEAN_NO_CUSTOM": {
+    "name": "CLEAN_NO_CUSTOM",
+    "description": "Set to true to tell Makefile Generators not to remove the outputs of custom commands for this directory during the make clean operation. This is ignored on other generators because it is not possible to implement."
+  },
+  "CMAKE_CONFIGURE_DEPENDS": {
+    "name": "CMAKE_CONFIGURE_DEPENDS",
+    "description": "Tell CMake about additional input files to the configuration process. If any named file is modified the build system will re-run CMake to re-configure the file and generate the build system again."
+  },
+  "COMPILE_DEFINITIONS": {
+    "name": "COMPILE_DEFINITIONS",
+    "description": "Preprocessor definitions for compiling a directory's sources."
+  },
+  "COMPILE_DEFINITIONS_<CONFIG>": {
+    "name": "COMPILE_DEFINITIONS_<CONFIG>",
+    "description": "Ignored. See CMake Policy CMP0043."
+  },
+  "COMPILE_OPTIONS": {
+    "name": "COMPILE_OPTIONS",
+    "description": "List of options to pass to the compiler."
+  },
+  "DEFINITIONS": {
+    "name": "DEFINITIONS",
+    "description": "For CMake 2.4 compatibility only. Use COMPILE_DEFINITIONS instead."
+  },
+  "EXCLUDE_FROM_ALL": {
+    "name": "EXCLUDE_FROM_ALL",
+    "description": "Set this directory property to a true value on a subdirectory to exclude its targets from the \"all\" target of its ancestors. If excluded, running e.g. make in the parent directory will not build targets the subdirectory by default. This does not affect the \"all\" target of the subdirectory itself. Running e.g. make inside the subdirectory will still build its targets."
+  },
+  "IMPLICIT_DEPENDS_INCLUDE_TRANSFORM": {
+    "name": "IMPLICIT_DEPENDS_INCLUDE_TRANSFORM",
+    "description": "Specify #include line transforms for dependencies in a directory."
+  },
+  "IMPORTED_TARGETS": {
+    "name": "IMPORTED_TARGETS",
+    "description": "This read-only directory property contains a semicolon-separated list  of Imported Targets added in the directory by calls to the add_library and add_executable commands. Each entry in the list is the logical name of a target, suitable to pass to the get_property command TARGET option when called in the same directory."
+  },
+  "INCLUDE_DIRECTORIES": {
+    "name": "INCLUDE_DIRECTORIES",
+    "description": "List of preprocessor include file search directories."
+  },
+  "INCLUDE_REGULAR_EXPRESSION": {
+    "name": "INCLUDE_REGULAR_EXPRESSION",
+    "description": "Include file scanning regular expression."
+  },
+  "INTERPROCEDURAL_OPTIMIZATION": {
+    "name": "INTERPROCEDURAL_OPTIMIZATION",
+    "description": "This directory property does not exist anymore."
+  },
+  "INTERPROCEDURAL_OPTIMIZATION_<CONFIG>": {
+    "name": "INTERPROCEDURAL_OPTIMIZATION_<CONFIG>",
+    "description": "This directory property does not exist anymore."
+  },
+  "LABELS": {
+    "name": "LABELS",
+    "description": "Specify a list of text labels associated with a directory and all of its subdirectories. This is equivalent to setting the LABELS target property and the LABELS test property on all targets and tests in the current directory and subdirectories. Note: Launchers must enabled to propagate labels to targets."
+  },
+  "LINK_DIRECTORIES": {
+    "name": "LINK_DIRECTORIES",
+    "description": "List of linker search directories."
+  },
+  "LINK_OPTIONS": {
+    "name": "LINK_OPTIONS",
+    "description": "List of options to use for the link step of shared library, module and executable targets as well as the device link step."
+  },
+  "LISTFILE_STACK": {
+    "name": "LISTFILE_STACK",
+    "description": "The current stack of listfiles being processed."
+  },
+  "MACROS": {
+    "name": "MACROS",
+    "description": "List of macro commands available in the current directory."
+  },
+  "PARENT_DIRECTORY": {
+    "name": "PARENT_DIRECTORY",
+    "description": "Source directory that added current subdirectory."
+  },
+  "RULE_LAUNCH_COMPILE": {
+    "name": "RULE_LAUNCH_COMPILE",
+    "description": "Specify a launcher for compile rules."
+  },
+  "RULE_LAUNCH_CUSTOM": {
+    "name": "RULE_LAUNCH_CUSTOM",
+    "description": "Specify a launcher for custom rules."
+  },
+  "RULE_LAUNCH_LINK": {
+    "name": "RULE_LAUNCH_LINK",
+    "description": "Specify a launcher for link rules."
+  },
+  "SOURCE_DIR": {
+    "name": "SOURCE_DIR",
+    "description": "This read-only directory property reports absolute path to the source directory on which it is read."
+  },
+  "SUBDIRECTORIES": {
+    "name": "SUBDIRECTORIES",
+    "description": "This read-only directory property contains a semicolon-separated list  of subdirectories processed so far by the add_subdirectory or subdirs commands. Each entry is the absolute path to the source directory (containing the CMakeLists.txt file). This is suitable to pass to the get_property command DIRECTORY option."
+  },
+  "SYSTEM": {
+    "name": "SYSTEM",
+    "description": "This directory property is used to initialize the SYSTEM target property for non-imported targets created in that directory. It is set to true by add_subdirectory and FetchContent_Declare when the SYSTEM option is given as an argument to those commands."
+  },
+  "TESTS": { "name": "TESTS", "description": "List of tests." },
+  "TEST_INCLUDE_FILE": {
+    "name": "TEST_INCLUDE_FILE",
+    "description": "Deprecated. Use TEST_INCLUDE_FILES instead."
+  },
+  "TEST_INCLUDE_FILES": {
+    "name": "TEST_INCLUDE_FILES",
+    "description": "A list of cmake files that will be included when ctest is run."
+  },
+  "VARIABLES": {
+    "name": "VARIABLES",
+    "description": "List of variables defined in the current directory."
+  },
+  "VS_GLOBAL_SECTION_POST_<section>": {
+    "name": "VS_GLOBAL_SECTION_POST_<section>",
+    "description": "Specify a postSolution global section in Visual Studio."
+  },
+  "VS_GLOBAL_SECTION_PRE_<section>": {
+    "name": "VS_GLOBAL_SECTION_PRE_<section>",
+    "description": "Specify a preSolution global section in Visual Studio."
+  },
+  "VS_STARTUP_PROJECT": {
+    "name": "VS_STARTUP_PROJECT",
+    "description": "Specify the default startup project in a Visual Studio solution."
+  },
+  "ALLOW_DUPLICATE_CUSTOM_TARGETS": {
+    "name": "ALLOW_DUPLICATE_CUSTOM_TARGETS",
+    "description": "Allow duplicate custom targets to be created."
+  },
+  "AUTOGEN_SOURCE_GROUP": {
+    "name": "AUTOGEN_SOURCE_GROUP",
+    "description": "Name of the source_group for AUTOMOC, AUTORCC and AUTOUIC generated files."
+  },
+  "AUTOGEN_TARGETS_FOLDER": {
+    "name": "AUTOGEN_TARGETS_FOLDER",
+    "description": "Name of FOLDER for *_autogen targets that are added automatically by CMake for targets for which AUTOMOC is enabled."
+  },
+  "AUTOMOC_SOURCE_GROUP": {
+    "name": "AUTOMOC_SOURCE_GROUP",
+    "description": "Name of the source_group for AUTOMOC generated files."
+  },
+  "AUTOMOC_TARGETS_FOLDER": {
+    "name": "AUTOMOC_TARGETS_FOLDER",
+    "description": "Name of FOLDER for *_autogen targets that are added automatically by CMake for targets for which AUTOMOC is enabled."
+  },
+  "AUTORCC_SOURCE_GROUP": {
+    "name": "AUTORCC_SOURCE_GROUP",
+    "description": "Name of the source_group for AUTORCC generated files."
+  },
+  "AUTOUIC_SOURCE_GROUP": {
+    "name": "AUTOUIC_SOURCE_GROUP",
+    "description": "Name of the source_group for AUTOUIC generated files."
+  },
+  "CMAKE_CUDA_KNOWN_FEATURES": {
+    "name": "CMAKE_CUDA_KNOWN_FEATURES",
+    "description": "List of CUDA features known to this version of CMake."
+  },
+  "CMAKE_CXX_KNOWN_FEATURES": {
+    "name": "CMAKE_CXX_KNOWN_FEATURES",
+    "description": "List of C++ features known to this version of CMake."
+  },
+  "CMAKE_C_KNOWN_FEATURES": {
+    "name": "CMAKE_C_KNOWN_FEATURES",
+    "description": "List of C features known to this version of CMake."
+  },
+  "CMAKE_HIP_KNOWN_FEATURES": {
+    "name": "CMAKE_HIP_KNOWN_FEATURES",
+    "description": "List of HIP features known to this version of CMake."
+  },
+  "CMAKE_ROLE": {
+    "name": "CMAKE_ROLE",
+    "description": "Tells what mode the current running script is in. Could be one of several values:"
+  },
+  "DEBUG_CONFIGURATIONS": {
+    "name": "DEBUG_CONFIGURATIONS",
+    "description": "Specify which configurations are for debugging."
+  },
+  "DISABLED_FEATURES": {
+    "name": "DISABLED_FEATURES",
+    "description": "List of features which are disabled during the CMake run."
+  },
+  "ECLIPSE_EXTRA_CPROJECT_CONTENTS": {
+    "name": "ECLIPSE_EXTRA_CPROJECT_CONTENTS",
+    "description": "Additional contents to be inserted into the generated Eclipse cproject file."
+  },
+  "ECLIPSE_EXTRA_NATURES": {
+    "name": "ECLIPSE_EXTRA_NATURES",
+    "description": "List of natures to add to the generated Eclipse project file."
+  },
+  "ENABLED_FEATURES": {
+    "name": "ENABLED_FEATURES",
+    "description": "List of features which are enabled during the CMake run."
+  },
+  "ENABLED_LANGUAGES": {
+    "name": "ENABLED_LANGUAGES",
+    "description": "Read-only property that contains the list of currently enabled languages"
+  },
+  "FIND_LIBRARY_USE_LIB32_PATHS": {
+    "name": "FIND_LIBRARY_USE_LIB32_PATHS",
+    "description": "Whether the find_library command should automatically search lib32 directories."
+  },
+  "FIND_LIBRARY_USE_LIB64_PATHS": {
+    "name": "FIND_LIBRARY_USE_LIB64_PATHS",
+    "description": "Whether find_library should automatically search lib64 directories."
+  },
+  "FIND_LIBRARY_USE_LIBX32_PATHS": {
+    "name": "FIND_LIBRARY_USE_LIBX32_PATHS",
+    "description": "Whether the find_library command should automatically search libx32 directories."
+  },
+  "FIND_LIBRARY_USE_OPENBSD_VERSIONING": {
+    "name": "FIND_LIBRARY_USE_OPENBSD_VERSIONING",
+    "description": "Whether find_library should find OpenBSD-style shared libraries."
+  },
+  "GENERATOR_IS_MULTI_CONFIG": {
+    "name": "GENERATOR_IS_MULTI_CONFIG",
+    "description": "Read-only property that is true on multi-configuration generators."
+  },
+  "GLOBAL_DEPENDS_DEBUG_MODE": {
+    "name": "GLOBAL_DEPENDS_DEBUG_MODE",
+    "description": "Enable global target dependency graph debug mode."
+  },
+  "GLOBAL_DEPENDS_NO_CYCLES": {
+    "name": "GLOBAL_DEPENDS_NO_CYCLES",
+    "description": "Disallow global target dependency graph cycles."
+  },
+  "INSTALL_PARALLEL": {
+    "name": "INSTALL_PARALLEL",
+    "description": "Enables parallel installation option for the Ninja generator."
+  },
+  "IN_TRY_COMPILE": {
+    "name": "IN_TRY_COMPILE",
+    "description": "Read-only property that is true during a try-compile configuration."
+  },
+  "JOB_POOLS": {
+    "name": "JOB_POOLS",
+    "description": "Ninja only: List of available pools."
+  },
+  "PACKAGES_FOUND": {
+    "name": "PACKAGES_FOUND",
+    "description": "List of packages which were found during the CMake run."
+  },
+  "PACKAGES_NOT_FOUND": {
+    "name": "PACKAGES_NOT_FOUND",
+    "description": "List of packages which were not found during the CMake run."
+  },
+  "PREDEFINED_TARGETS_FOLDER": {
+    "name": "PREDEFINED_TARGETS_FOLDER",
+    "description": "Name of FOLDER for targets that are added automatically by CMake."
+  },
+  "PROPAGATE_TOP_LEVEL_INCLUDES_TO_TRY_COMPILE": {
+    "name": "PROPAGATE_TOP_LEVEL_INCLUDES_TO_TRY_COMPILE",
+    "description": "When this global property is set to true, the CMAKE_PROJECT_TOP_LEVEL_INCLUDES variable is propagated into try_compile calls that use the whole-project signature . Calls to the source file signature  are not affected by this property. PROPAGATE_TOP_LEVEL_INCLUDES_TO_TRY_COMPILE is unset by default."
+  },
+  "REPORT_UNDEFINED_PROPERTIES": {
+    "name": "REPORT_UNDEFINED_PROPERTIES",
+    "description": "If set, report any undefined properties to this file."
+  },
+  "RULE_MESSAGES": {
+    "name": "RULE_MESSAGES",
+    "description": "Specify whether to report a message for each make rule."
+  },
+  "TARGET_ARCHIVES_MAY_BE_SHARED_LIBS": {
+    "name": "TARGET_ARCHIVES_MAY_BE_SHARED_LIBS",
+    "description": "Set if shared libraries may be named like archives."
+  },
+  "TARGET_MESSAGES": {
+    "name": "TARGET_MESSAGES",
+    "description": "Specify whether to report the completion of each target."
+  },
+  "TARGET_SUPPORTS_SHARED_LIBS": {
+    "name": "TARGET_SUPPORTS_SHARED_LIBS",
+    "description": "Does the target platform support shared libraries."
+  },
+  "USE_FOLDERS": {
+    "name": "USE_FOLDERS",
+    "description": "Controls whether to use the FOLDER target property to organize targets into folders. The value of USE_FOLDERS at the end of the top level CMakeLists.txt file is what determines the behavior."
+  },
+  "XCODE_EMIT_EFFECTIVE_PLATFORM_NAME": {
+    "name": "XCODE_EMIT_EFFECTIVE_PLATFORM_NAME",
+    "description": "Control emission of EFFECTIVE_PLATFORM_NAME by the Xcode generator."
+  },
+  "CPACK_DESKTOP_SHORTCUTS": {
+    "name": "CPACK_DESKTOP_SHORTCUTS",
+    "description": "Species a list of shortcut names that should be created on the Desktop for this file."
+  },
+  "CPACK_NEVER_OVERWRITE": {
+    "name": "CPACK_NEVER_OVERWRITE",
+    "description": "Request that this file not be overwritten on install or reinstall."
+  },
+  "CPACK_PERMANENT": {
+    "name": "CPACK_PERMANENT",
+    "description": "Request that this file not be removed on uninstall."
+  },
+  "CPACK_STARTUP_SHORTCUTS": {
+    "name": "CPACK_STARTUP_SHORTCUTS",
+    "description": "Species a list of shortcut names that should be created in the Startup folder for this file."
+  },
+  "CPACK_START_MENU_SHORTCUTS": {
+    "name": "CPACK_START_MENU_SHORTCUTS",
+    "description": "Species a list of shortcut names that should be created in the Start Menu for this file."
+  },
+  "CPACK_WIX_ACL": {
+    "name": "CPACK_WIX_ACL",
+    "description": "Specifies access permissions for files or directories installed by a WiX installer."
+  },
+  "ABSTRACT": {
+    "name": "ABSTRACT",
+    "description": "Is this source file an abstract class."
+  },
+  "AUTORCC_OPTIONS": {
+    "name": "AUTORCC_OPTIONS",
+    "description": "Additional options for rcc when using AUTORCC"
+  },
+  "AUTOUIC_OPTIONS": {
+    "name": "AUTOUIC_OPTIONS",
+    "description": "Additional options for uic when using AUTOUIC"
+  },
+  "COMPILE_FLAGS": {
+    "name": "COMPILE_FLAGS",
+    "description": "Additional flags to be added when compiling this source file."
+  },
+  "CXX_SCAN_FOR_MODULES": {
+    "name": "CXX_SCAN_FOR_MODULES",
+    "description": "CXX_SCAN_FOR_MODULES is a boolean specifying whether CMake will scan the source for C++ module dependencies. See also the CXX_SCAN_FOR_MODULES for target-wide settings."
+  },
+  "EXTERNAL_OBJECT": {
+    "name": "EXTERNAL_OBJECT",
+    "description": "If set to true then this is an object file."
+  },
+  "Fortran_FORMAT": {
+    "name": "Fortran_FORMAT",
+    "description": "Set to FIXED or FREE to indicate the Fortran source layout."
+  },
+  "Fortran_PREPROCESS": {
+    "name": "Fortran_PREPROCESS",
+    "description": "Control whether the Fortran source file should be unconditionally preprocessed."
+  },
+  "GENERATED": {
+    "name": "GENERATED",
+    "description": "Is this source file generated as part of the build or CMake process."
+  },
+  "HEADER_FILE_ONLY": {
+    "name": "HEADER_FILE_ONLY",
+    "description": "Is this source file only a header file."
+  },
+  "KEEP_EXTENSION": {
+    "name": "KEEP_EXTENSION",
+    "description": "Make the output file have the same extension as the source file."
+  },
+  "LANGUAGE": {
+    "name": "LANGUAGE",
+    "description": "Specify the programming language in which a source file is written."
+  },
+  "LOCATION": {
+    "name": "LOCATION",
+    "description": "The full path to a source file."
+  },
+  "MACOSX_PACKAGE_LOCATION": {
+    "name": "MACOSX_PACKAGE_LOCATION",
+    "description": "Place a source file inside a Application Bundle (MACOSX_BUNDLE), Core Foundation Bundle (BUNDLE), or Framework Bundle (FRAMEWORK). It is applicable for macOS and iOS."
+  },
+  "OBJECT_DEPENDS": {
+    "name": "OBJECT_DEPENDS",
+    "description": "Additional files on which a compiled object file depends."
+  },
+  "OBJECT_OUTPUTS": {
+    "name": "OBJECT_OUTPUTS",
+    "description": "Additional outputs for a Ninja or Makefile Generators rule."
+  },
+  "SKIP_AUTOGEN": {
+    "name": "SKIP_AUTOGEN",
+    "description": "Exclude the source file from AUTOMOC, AUTOUIC and AUTORCC processing (for Qt projects)."
+  },
+  "SKIP_AUTOMOC": {
+    "name": "SKIP_AUTOMOC",
+    "description": "Exclude the source file from AUTOMOC processing (for Qt projects)."
+  },
+  "SKIP_AUTORCC": {
+    "name": "SKIP_AUTORCC",
+    "description": "Exclude the source file from AUTORCC processing (for Qt projects)."
+  },
+  "SKIP_AUTOUIC": {
+    "name": "SKIP_AUTOUIC",
+    "description": "Exclude the source file from AUTOUIC processing (for Qt projects)."
+  },
+  "SKIP_LINTING": {
+    "name": "SKIP_LINTING",
+    "description": "This property allows you to exclude a specific source file from the linting process. The linting process involves running tools such as <LANG>_CPPLINT, <LANG>_CLANG_TIDY, <LANG>_CPPCHECK, and <LANG>_INCLUDE_WHAT_YOU_USE on the source files, as well as compiling header files as part of VERIFY_INTERFACE_HEADER_SETS. By setting SKIP_LINTING on a source file, the mentioned linting tools will not be executed for that particular file."
+  },
+  "SKIP_PRECOMPILE_HEADERS": {
+    "name": "SKIP_PRECOMPILE_HEADERS",
+    "description": "Is this source file skipped by PRECOMPILE_HEADERS feature."
+  },
+  "SKIP_UNITY_BUILD_INCLUSION": {
+    "name": "SKIP_UNITY_BUILD_INCLUSION",
+    "description": "Setting this property to true ensures the source file will be skipped by unity builds when its associated target has its UNITY_BUILD property set to true. The source file will instead be compiled on its own in the same way as it would with unity builds disabled."
+  },
+  "Swift_DEPENDENCIES_FILE": {
+    "name": "Swift_DEPENDENCIES_FILE",
+    "description": "This property sets the path for the Swift dependency file (swiftdeps) for the source. If one is not specified, it will default to <OBJECT>.swiftdeps."
+  },
+  "Swift_DIAGNOSTICS_FILE": {
+    "name": "Swift_DIAGNOSTICS_FILE",
+    "description": "This property controls where the Swift diagnostics are serialized."
+  },
+  "SYMBOLIC": {
+    "name": "SYMBOLIC",
+    "description": "Is this just a name for a rule."
+  },
+  "UNITY_GROUP": {
+    "name": "UNITY_GROUP",
+    "description": "This property controls which bucket the source will be part of when the UNITY_BUILD_MODE is set to GROUP."
+  },
+  "VS_COPY_TO_OUT_DIR": {
+    "name": "VS_COPY_TO_OUT_DIR",
+    "description": "Sets the <CopyToOutputDirectory> tag for a source file in a Visual Studio project file. Valid values are Never, Always and PreserveNewest."
+  },
+  "VS_CSHARP_<tagname>": {
+    "name": "VS_CSHARP_<tagname>",
+    "description": "Visual Studio and CSharp source-file-specific configuration."
+  },
+  "VS_DEPLOYMENT_CONTENT": {
+    "name": "VS_DEPLOYMENT_CONTENT",
+    "description": "Mark a source file as content for deployment with a Windows Phone or Windows Store application when built with a Visual Studio generators <cmake-generators(7)>. The value must evaluate to either 1 or 0 and may use generator expressions <cmake-generator-expressions(7)> to make the choice based on the build configuration. The .vcxproj file entry for the source file will be marked either DeploymentContent or ExcludedFromBuild for values 1 and 0, respectively."
+  },
+  "VS_DEPLOYMENT_LOCATION": {
+    "name": "VS_DEPLOYMENT_LOCATION",
+    "description": "Specifies the deployment location for a content source file with a Windows Phone or Windows Store application when built with a Visual Studio generators <cmake-generators(7)>. This property is only applicable when using VS_DEPLOYMENT_CONTENT. The value represent the path relative to the app package and applies to all configurations."
+  },
+  "VS_INCLUDE_IN_VSIX": {
+    "name": "VS_INCLUDE_IN_VSIX",
+    "description": "Boolean property to specify if the file should be included within a VSIX (Visual Studio Integration Extension) extension package. This is needed for development of Visual Studio extensions."
+  },
+  "VS_RESOURCE_GENERATOR": {
+    "name": "VS_RESOURCE_GENERATOR",
+    "description": "This property allows to specify the resource generator to be used on this file. It defaults to PublicResXFileCodeGenerator if not set."
+  },
+  "VS_SETTINGS": {
+    "name": "VS_SETTINGS",
+    "description": "Set any item metadata on a file."
+  },
+  "VS_SHADER_DISABLE_OPTIMIZATIONS": {
+    "name": "VS_SHADER_DISABLE_OPTIMIZATIONS",
+    "description": "Disable compiler optimizations for an .hlsl source file. This adds the -Od flag to the command line for the FxCompiler tool. Specify the value true for this property to disable compiler optimizations."
+  },
+  "VS_SHADER_ENABLE_DEBUG": {
+    "name": "VS_SHADER_ENABLE_DEBUG",
+    "description": "Enable debugging information for an .hlsl source file. This adds the -Zi flag to the command line for the FxCompiler tool. Specify the value true to generate debugging information for the compiled shader."
+  },
+  "VS_SHADER_ENTRYPOINT": {
+    "name": "VS_SHADER_ENTRYPOINT",
+    "description": "Specifies the name of the entry point for the shader of a .hlsl source file."
+  },
+  "VS_SHADER_FLAGS": {
+    "name": "VS_SHADER_FLAGS",
+    "description": "Set additional Visual Studio shader flags of a .hlsl source file."
+  },
+  "VS_SHADER_MODEL": {
+    "name": "VS_SHADER_MODEL",
+    "description": "Specifies the shader model of a .hlsl source file. Some shader types can only be used with recent shader models"
+  },
+  "VS_SHADER_OBJECT_FILE_NAME": {
+    "name": "VS_SHADER_OBJECT_FILE_NAME",
+    "description": "Specifies a file name for the compiled shader object file for an .hlsl source file. This adds the -Fo flag to the command line for the FxCompiler tool."
+  },
+  "VS_SHADER_OUTPUT_HEADER_FILE": {
+    "name": "VS_SHADER_OUTPUT_HEADER_FILE",
+    "description": "Set filename for output header file containing object code of a .hlsl source file."
+  },
+  "VS_SHADER_TYPE": {
+    "name": "VS_SHADER_TYPE",
+    "description": "Set the Visual Studio shader type of a .hlsl source file."
+  },
+  "VS_SHADER_VARIABLE_NAME": {
+    "name": "VS_SHADER_VARIABLE_NAME",
+    "description": "Set name of variable in header file containing object code of a .hlsl source file."
+  },
+  "VS_TOOL_OVERRIDE": {
+    "name": "VS_TOOL_OVERRIDE",
+    "description": "Override the default Visual Studio tool that will be applied to the source file with a new tool not based on the extension of the file."
+  },
+  "VS_XAML_TYPE": {
+    "name": "VS_XAML_TYPE",
+    "description": "Mark a Extensible Application Markup Language (XAML) source file as a different type than the default Page. The most common usage would be to set the default App.xaml file as ApplicationDefinition."
+  },
+  "WRAP_EXCLUDE": {
+    "name": "WRAP_EXCLUDE",
+    "description": "Exclude this source file from any code wrapping techniques."
+  },
+  "XCODE_EXPLICIT_FILE_TYPE": {
+    "name": "XCODE_EXPLICIT_FILE_TYPE",
+    "description": "Set the Xcode explicitFileType attribute on its reference to a source file. CMake computes a default based on file extension but can be told explicitly with this property."
+  },
+  "XCODE_FILE_ATTRIBUTES": {
+    "name": "XCODE_FILE_ATTRIBUTES",
+    "description": "Add values to the Xcode ATTRIBUTES setting on its reference to a source file. Among other things, this can be used to set the role on a .mig file:"
+  },
+  "XCODE_LAST_KNOWN_FILE_TYPE": {
+    "name": "XCODE_LAST_KNOWN_FILE_TYPE",
+    "description": "Set the Xcode lastKnownFileType attribute on its reference to a source file. CMake computes a default based on file extension but can be told explicitly with this property."
+  },
+  "ATTACHED_FILES": {
+    "name": "ATTACHED_FILES",
+    "description": "Attach a list of files to a dashboard submission."
+  },
+  "ATTACHED_FILES_ON_FAIL": {
+    "name": "ATTACHED_FILES_ON_FAIL",
+    "description": "Attach a list of files to a dashboard submission if the test fails."
+  },
+  "COST": {
+    "name": "COST",
+    "description": "This property describes the cost of a test. When parallel testing is enabled, tests in the test set will be run in descending order of cost. Projects can explicitly define the cost of a test by setting this property to a floating point value."
+  },
+  "DEPENDS": {
+    "name": "DEPENDS",
+    "description": "Specifies that this test should only be run after the specified list of tests."
+  },
+  "DISABLED": {
+    "name": "DISABLED",
+    "description": "If set to True, the test will be skipped and its status will be 'Not Run'. A DISABLED test will not be counted in the total number of tests and its completion status will be reported to CDash as Disabled."
+  },
+  "ENVIRONMENT": {
+    "name": "ENVIRONMENT",
+    "description": "Specify environment variables that should be defined for running a test."
+  },
+  "ENVIRONMENT_MODIFICATION": {
+    "name": "ENVIRONMENT_MODIFICATION",
+    "description": "Specify environment variables that should be modified for running a test. Note that the operations performed by this property are performed after the ENVIRONMENT property is already applied."
+  },
+  "FAIL_REGULAR_EXPRESSION": {
+    "name": "FAIL_REGULAR_EXPRESSION",
+    "description": "If the test output (stdout or stderr) matches this regular expression the test will fail, regardless of the process exit code. Tests that exceed the timeout specified by TIMEOUT fail regardless of FAIL_REGULAR_EXPRESSION. Any non-zero return code or system-level test failures including segmentation faults, signal abort, or heap errors fail the test even if the regular expression does not match."
+  },
+  "FIXTURES_CLEANUP": {
+    "name": "FIXTURES_CLEANUP",
+    "description": "Specifies a list of fixtures for which the test is to be treated as a cleanup test. These fixture names are distinct from test case names and are not required to have any similarity to the names of tests associated with them."
+  },
+  "FIXTURES_REQUIRED": {
+    "name": "FIXTURES_REQUIRED",
+    "description": "Specifies a list of fixtures the test requires. Fixture names are case sensitive and they are not required to have any similarity to test names."
+  },
+  "FIXTURES_SETUP": {
+    "name": "FIXTURES_SETUP",
+    "description": "Specifies a list of fixtures for which the test is to be treated as a setup test. These fixture names are distinct from test case names and are not required to have any similarity to the names of tests associated with them."
+  },
+  "GENERATED_RESOURCE_SPEC_FILE": {
+    "name": "GENERATED_RESOURCE_SPEC_FILE",
+    "description": "Path to the dynamically-generated resource spec file <ctest-resource-dynamically-generated-spec-file> generated by this test."
+  },
+  "MEASUREMENT": {
+    "name": "MEASUREMENT",
+    "description": "Specify a CDASH measurement and value to be reported for a test."
+  },
+  "PASS_REGULAR_EXPRESSION": {
+    "name": "PASS_REGULAR_EXPRESSION",
+    "description": "The test output (stdout or stderr) must match this regular expression for the test to pass. The process exit code is ignored. Tests that exceed the timeout specified by TIMEOUT still fail regardless of PASS_REGULAR_EXPRESSION. System-level test failures including segmentation faults, signal abort, or heap errors may fail the test even if PASS_REGULAR_EXPRESSION is matched."
+  },
+  "PROCESSORS": {
+    "name": "PROCESSORS",
+    "description": "Set to specify how many process slots this test requires. If not set, the default is 1 processor."
+  },
+  "PROCESSOR_AFFINITY": {
+    "name": "PROCESSOR_AFFINITY",
+    "description": "Set to a true value to ask CTest to launch the test process with CPU affinity for a fixed set of processors. If enabled and supported for the current platform, CTest will choose a set of processors to place in the CPU affinity mask when launching the test process. The number of processors in the set is determined by the PROCESSORS test property or the number of processors available to CTest, whichever is smaller. The set of processors chosen will be disjoint from the processors assigned to other concurrently running tests that also have the PROCESSOR_AFFINITY property enabled."
+  },
+  "REQUIRED_FILES": {
+    "name": "REQUIRED_FILES",
+    "description": "List of files required to run the test. The filenames are relative to the test WORKING_DIRECTORY unless an absolute path is specified."
+  },
+  "RESOURCE_GROUPS": {
+    "name": "RESOURCE_GROUPS",
+    "description": "Specify resources required by a test, grouped in a way that is meaningful to the test. See resource allocation <ctest-resource-allocation> for more information on how this property integrates into the CTest resource allocation feature."
+  },
+  "RESOURCE_LOCK": {
+    "name": "RESOURCE_LOCK",
+    "description": "Specify a list of resources that are locked by this test."
+  },
+  "RUN_SERIAL": {
+    "name": "RUN_SERIAL",
+    "description": "Do not run this test in parallel with any other test."
+  },
+  "SKIP_REGULAR_EXPRESSION": {
+    "name": "SKIP_REGULAR_EXPRESSION",
+    "description": "If the test output (stderr or stdout) matches this regular expression the test will be marked as skipped, regardless of the process exit code. Tests that exceed the timeout specified by TIMEOUT still fail regardless of SKIP_REGULAR_EXPRESSION. System-level test failures including segmentation faults, signal abort, or heap errors may fail the test even if the regular expression matches."
+  },
+  "SKIP_RETURN_CODE": {
+    "name": "SKIP_RETURN_CODE",
+    "description": "Return code to mark a test as skipped."
+  },
+  "TIMEOUT": {
+    "name": "TIMEOUT",
+    "description": "How many seconds to allow for this test."
+  },
+  "TIMEOUT_AFTER_MATCH": {
+    "name": "TIMEOUT_AFTER_MATCH",
+    "description": "Change a test's timeout duration after a matching line is encountered in its output."
+  },
+  "TIMEOUT_SIGNAL_GRACE_PERIOD": {
+    "name": "TIMEOUT_SIGNAL_GRACE_PERIOD",
+    "description": "If the TIMEOUT_SIGNAL_NAME test property is set, this property specifies the number of seconds to wait for a test process to terminate after sending the custom signal. Otherwise, this property has no meaning."
+  },
+  "TIMEOUT_SIGNAL_NAME": {
+    "name": "TIMEOUT_SIGNAL_NAME",
+    "description": "Specify a custom signal to send to a test process when its timeout is reached. This is available only on platforms supporting POSIX signals. It is not available on Windows."
+  },
+  "WILL_FAIL": {
+    "name": "WILL_FAIL",
+    "description": "If true, inverts the pass / fail test criteria. Tests for which WILL_FAIL is true fail with return code 0 and pass with non-zero return code. Tests that exceed the timeout specified by TIMEOUT still fail regardless of WILL_FAIL. System-level test failures including segmentation faults, signal abort, or heap errors may fail the test even if WILL_FAIL is true."
+  },
+  "WORKING_DIRECTORY": {
+    "name": "WORKING_DIRECTORY",
+    "description": "The directory from which the test executable will be called."
+  },
+  "AIX_EXPORT_ALL_SYMBOLS": {
+    "name": "AIX_EXPORT_ALL_SYMBOLS",
+    "description": "On AIX, CMake automatically exports all symbols from shared libraries, and from executables with the ENABLE_EXPORTS target property set. Explicitly disable this boolean property to suppress the behavior and export no symbols by default. In this case it is expected that the project will use other means to export some symbols."
+  },
+  "ALIASED_TARGET": {
+    "name": "ALIASED_TARGET",
+    "description": "Name of target aliased by this target."
+  },
+  "ALIAS_GLOBAL": {
+    "name": "ALIAS_GLOBAL",
+    "description": "Read-only property indicating of whether an ALIAS target  is globally visible."
+  },
+  "ANDROID_ANT_ADDITIONAL_OPTIONS": {
+    "name": "ANDROID_ANT_ADDITIONAL_OPTIONS",
+    "description": "Set the additional options for Android Ant build system. This is a string value containing all command line options for the Ant build. This property is initialized by the value of the CMAKE_ANDROID_ANT_ADDITIONAL_OPTIONS variable if it is set when a target is created."
+  },
+  "ANDROID_API": {
+    "name": "ANDROID_API",
+    "description": "When Cross Compiling for Android with NVIDIA Nsight Tegra Visual Studio Edition, this property sets the Android target API version (e.g. 15). The version number must be a positive decimal integer. This property is initialized by the value of the CMAKE_ANDROID_API variable if it is set when a target is created."
+  },
+  "ANDROID_API_MIN": {
+    "name": "ANDROID_API_MIN",
+    "description": "Set the Android MIN API version (e.g. 9). The version number must be a positive decimal integer. This property is initialized by the value of the CMAKE_ANDROID_API_MIN variable if it is set when a target is created. Native code builds using this API version."
+  },
+  "ANDROID_ARCH": {
+    "name": "ANDROID_ARCH",
+    "description": "When Cross Compiling for Android with NVIDIA Nsight Tegra Visual Studio Edition, this property sets the Android target architecture."
+  },
+  "ANDROID_ASSETS_DIRECTORIES": {
+    "name": "ANDROID_ASSETS_DIRECTORIES",
+    "description": "Set the Android assets directories to copy into the main assets folder before build. This a string property that contains the directory paths separated by semicolon. This property is initialized by the value of the CMAKE_ANDROID_ASSETS_DIRECTORIES variable if it is set when a target is created."
+  },
+  "ANDROID_GUI": {
+    "name": "ANDROID_GUI",
+    "description": "When Cross Compiling for Android with NVIDIA Nsight Tegra Visual Studio Edition, this property specifies whether to build an executable as an application package on Android."
+  },
+  "ANDROID_JAR_DEPENDENCIES": {
+    "name": "ANDROID_JAR_DEPENDENCIES",
+    "description": "Set the Android property that specifies JAR dependencies. This is a string value property. This property is initialized by the value of the CMAKE_ANDROID_JAR_DEPENDENCIES variable if it is set when a target is created."
+  },
+  "ANDROID_JAR_DIRECTORIES": {
+    "name": "ANDROID_JAR_DIRECTORIES",
+    "description": "Set the Android property that specifies directories to search for the JAR libraries."
+  },
+  "ANDROID_JAVA_SOURCE_DIR": {
+    "name": "ANDROID_JAVA_SOURCE_DIR",
+    "description": "Set the Android property that defines the Java source code root directories. This a string property that contains the directory paths separated by semicolon. This property is initialized by the value of the CMAKE_ANDROID_JAVA_SOURCE_DIR variable if it is set when a target is created."
+  },
+  "ANDROID_NATIVE_LIB_DEPENDENCIES": {
+    "name": "ANDROID_NATIVE_LIB_DEPENDENCIES",
+    "description": "Set the Android property that specifies the .so dependencies. This is a string property."
+  },
+  "ANDROID_NATIVE_LIB_DIRECTORIES": {
+    "name": "ANDROID_NATIVE_LIB_DIRECTORIES",
+    "description": "Set the Android property that specifies directories to search for the .so libraries."
+  },
+  "ANDROID_PROCESS_MAX": {
+    "name": "ANDROID_PROCESS_MAX",
+    "description": "Set the Android property that defines the maximum number of a parallel Android NDK compiler processes (e.g. 4). This property is initialized by the value of the CMAKE_ANDROID_PROCESS_MAX variable if it is set when a target is created."
+  },
+  "ANDROID_PROGUARD": {
+    "name": "ANDROID_PROGUARD",
+    "description": "When this property is set to true that enables the ProGuard tool to shrink, optimize, and obfuscate the code by removing unused code and renaming classes, fields, and methods with semantically obscure names. This property is initialized by the value of the CMAKE_ANDROID_PROGUARD variable if it is set when a target is created."
+  },
+  "ANDROID_PROGUARD_CONFIG_PATH": {
+    "name": "ANDROID_PROGUARD_CONFIG_PATH",
+    "description": "Set the Android property that specifies the location of the ProGuard config file. Leave empty to use the default one. This a string property that contains the path to ProGuard config file. This property is initialized by the value of the CMAKE_ANDROID_PROGUARD_CONFIG_PATH variable if it is set when a target is created."
+  },
+  "ANDROID_SECURE_PROPS_PATH": {
+    "name": "ANDROID_SECURE_PROPS_PATH",
+    "description": "Set the Android property that states the location of the secure properties file. This is a string property that contains the file path. This property is initialized by the value of the CMAKE_ANDROID_SECURE_PROPS_PATH variable if it is set when a target is created."
+  },
+  "ANDROID_SKIP_ANT_STEP": {
+    "name": "ANDROID_SKIP_ANT_STEP",
+    "description": "Set the Android property that defines whether or not to skip the Ant build step. This is a boolean property initialized by the value of the CMAKE_ANDROID_SKIP_ANT_STEP variable if it is set when a target is created."
+  },
+  "ANDROID_STL_TYPE": {
+    "name": "ANDROID_STL_TYPE",
+    "description": "When Cross Compiling for Android with NVIDIA Nsight Tegra Visual Studio Edition, this property specifies the type of STL support for the project. This is a string property that could set to the one of the following values:"
+  },
+  "ARCHIVE_OUTPUT_DIRECTORY": {
+    "name": "ARCHIVE_OUTPUT_DIRECTORY",
+    "description": "Output directory in which to build XXX target files."
+  },
+  "ARCHIVE_OUTPUT_DIRECTORY_<CONFIG>": {
+    "name": "ARCHIVE_OUTPUT_DIRECTORY_<CONFIG>",
+    "description": "Per-configuration output directory for ARCHIVE  target files."
+  },
+  "ARCHIVE_OUTPUT_NAME": {
+    "name": "ARCHIVE_OUTPUT_NAME",
+    "description": "Output name for XXX target files."
+  },
+  "ARCHIVE_OUTPUT_NAME_<CONFIG>": {
+    "name": "ARCHIVE_OUTPUT_NAME_<CONFIG>",
+    "description": "Per-configuration output name for ARCHIVE  target files."
+  },
+  "AUTOGEN_BETTER_GRAPH_MULTI_CONFIG": {
+    "name": "AUTOGEN_BETTER_GRAPH_MULTI_CONFIG",
+    "description": "AUTOGEN_BETTER_GRAPH_MULTI_CONFIG is a boolean property that can be set on a target to have better dependency graph for multi-configuration generators. When this property is enabled, CMake will generate more per-config targets. Thus, the dependency graph will be more accurate for multi-configuration generators and some recompilations will be avoided."
+  },
+  "AUTOGEN_BUILD_DIR": {
+    "name": "AUTOGEN_BUILD_DIR",
+    "description": "Directory where AUTOMOC, AUTOUIC and AUTORCC generate files for the target."
+  },
+  "AUTOGEN_COMMAND_LINE_LENGTH_MAX": {
+    "name": "AUTOGEN_COMMAND_LINE_LENGTH_MAX",
+    "description": "Command line length limit for autogen targets, i.e. moc or uic, that triggers the use of response files on Windows instead of passing all arguments to the command line."
+  },
+  "AUTOGEN_ORIGIN_DEPENDS": {
+    "name": "AUTOGEN_ORIGIN_DEPENDS",
+    "description": "Switch for forwarding origin target dependencies to the corresponding <ORIGIN>_autogen target."
+  },
+  "AUTOGEN_PARALLEL": {
+    "name": "AUTOGEN_PARALLEL",
+    "description": "Number of parallel moc or uic processes to start when using AUTOMOC and AUTOUIC."
+  },
+  "AUTOGEN_TARGET_DEPENDS": {
+    "name": "AUTOGEN_TARGET_DEPENDS",
+    "description": "Additional target dependencies of the corresponding <ORIGIN>_autogen target."
+  },
+  "AUTOGEN_USE_SYSTEM_INCLUDE": {
+    "name": "AUTOGEN_USE_SYSTEM_INCLUDE",
+    "description": "AUTOGEN_USE_SYSTEM_INCLUDE is a boolean property that can be set on a target to indicate that the autogen target include directory should be added as a system include directory or normal include directory to the target."
+  },
+  "AUTOMOC": {
+    "name": "AUTOMOC",
+    "description": "Should the target be processed with auto-moc (for Qt projects)."
+  },
+  "AUTOMOC_COMPILER_PREDEFINES": {
+    "name": "AUTOMOC_COMPILER_PREDEFINES",
+    "description": "Boolean value used by AUTOMOC to determine if the compiler pre definitions file moc_predefs.h should be generated."
+  },
+  "AUTOMOC_DEPEND_FILTERS": {
+    "name": "AUTOMOC_DEPEND_FILTERS",
+    "description": "Filter definitions used by AUTOMOC to extract file names from a source file that are registered as additional dependencies for the moc file of the source file."
+  },
+  "AUTOMOC_EXECUTABLE": {
+    "name": "AUTOMOC_EXECUTABLE",
+    "description": "AUTOMOC_EXECUTABLE is file path pointing to the moc executable to use for AUTOMOC enabled files. Setting this property will make CMake skip the automatic detection of the moc binary as well as the sanity-tests normally run to ensure that the binary is available and working as expected."
+  },
+  "AUTOMOC_MACRO_NAMES": {
+    "name": "AUTOMOC_MACRO_NAMES",
+    "description": "A semicolon-separated list  of macro names used by AUTOMOC to determine if a C++ file needs to be processed by moc."
+  },
+  "AUTOMOC_MOC_OPTIONS": {
+    "name": "AUTOMOC_MOC_OPTIONS",
+    "description": "Additional options for moc when using AUTOMOC"
+  },
+  "AUTOMOC_PATH_PREFIX": {
+    "name": "AUTOMOC_PATH_PREFIX",
+    "description": "When this property is ON, CMake will generate the -p path prefix option for moc on AUTOMOC enabled Qt targets."
+  },
+  "AUTORCC": {
+    "name": "AUTORCC",
+    "description": "Should the target be processed with auto-rcc (for Qt projects)."
+  },
+  "AUTORCC_EXECUTABLE": {
+    "name": "AUTORCC_EXECUTABLE",
+    "description": "AUTORCC_EXECUTABLE is file path pointing to the rcc executable to use for AUTORCC enabled files. Setting this property will make CMake skip the automatic detection of the rcc binary as well as the sanity-tests normally run to ensure that the binary is available and working as expected."
+  },
+  "AUTOUIC": {
+    "name": "AUTOUIC",
+    "description": "Should the target be processed with auto-uic (for Qt projects)."
+  },
+  "AUTOUIC_EXECUTABLE": {
+    "name": "AUTOUIC_EXECUTABLE",
+    "description": "AUTOUIC_EXECUTABLE is file path pointing to the uic executable to use for AUTOUIC enabled files. Setting this property will make CMake skip the automatic detection of the uic binary as well as the sanity-tests normally run to ensure that the binary is available and working as expected."
+  },
+  "AUTOUIC_SEARCH_PATHS": {
+    "name": "AUTOUIC_SEARCH_PATHS",
+    "description": "Search path list used by AUTOUIC to find included .ui files."
+  },
+  "BUILD_RPATH": {
+    "name": "BUILD_RPATH",
+    "description": "A semicolon-separated list  specifying runtime path (RPATH) entries to add to binaries linked in the build tree (for platforms that support it). By default, CMake sets the runtime path of binaries in the build tree to contain search paths it knows are needed to find the shared libraries they link. Projects may set BUILD_RPATH to specify additional search paths."
+  },
+  "BUILD_RPATH_USE_ORIGIN": {
+    "name": "BUILD_RPATH_USE_ORIGIN",
+    "description": "Whether to use relative paths for the build RPATH."
+  },
+  "BUILD_WITH_INSTALL_NAME_DIR": {
+    "name": "BUILD_WITH_INSTALL_NAME_DIR",
+    "description": "BUILD_WITH_INSTALL_NAME_DIR is a boolean specifying whether the macOS install_name of a target in the build tree uses the directory given by INSTALL_NAME_DIR. This setting only applies to targets on macOS."
+  },
+  "BUILD_WITH_INSTALL_RPATH": {
+    "name": "BUILD_WITH_INSTALL_RPATH",
+    "description": "BUILD_WITH_INSTALL_RPATH is a boolean specifying whether to link the target in the build tree with the INSTALL_RPATH. This takes precedence over SKIP_BUILD_RPATH and avoids the need for relinking before installation."
+  },
+  "BUNDLE": {
+    "name": "BUNDLE",
+    "description": "This target is a CFBundle on the macOS."
+  },
+  "BUNDLE_EXTENSION": {
+    "name": "BUNDLE_EXTENSION",
+    "description": "The file extension used to name a BUNDLE, a FRAMEWORK, or a MACOSX_BUNDLE target on the macOS and iOS."
+  },
+  "COMMON_LANGUAGE_RUNTIME": {
+    "name": "COMMON_LANGUAGE_RUNTIME",
+    "description": "By setting this target property, the target is configured to build with C++/CLI support."
+  },
+  "COMPATIBLE_INTERFACE_BOOL": {
+    "name": "COMPATIBLE_INTERFACE_BOOL",
+    "description": "Properties which must be compatible with their link interface"
+  },
+  "COMPATIBLE_INTERFACE_NUMBER_MAX": {
+    "name": "COMPATIBLE_INTERFACE_NUMBER_MAX",
+    "description": "Properties whose maximum value from the link interface will be used."
+  },
+  "COMPATIBLE_INTERFACE_NUMBER_MIN": {
+    "name": "COMPATIBLE_INTERFACE_NUMBER_MIN",
+    "description": "Properties whose minimum value from the link interface will be used."
+  },
+  "COMPATIBLE_INTERFACE_STRING": {
+    "name": "COMPATIBLE_INTERFACE_STRING",
+    "description": "Properties which must be string-compatible with their link interface"
+  },
+  "COMPILE_FEATURES": {
+    "name": "COMPILE_FEATURES",
+    "description": "Compiler features enabled for this target."
+  },
+  "COMPILE_PDB_NAME": {
+    "name": "COMPILE_PDB_NAME",
+    "description": "Output name for the MS debug symbol .pdb file generated by the compiler while building source files."
+  },
+  "COMPILE_PDB_NAME_<CONFIG>": {
+    "name": "COMPILE_PDB_NAME_<CONFIG>",
+    "description": "Per-configuration output name for the MS debug symbol .pdb file generated by the compiler while building source files."
+  },
+  "COMPILE_PDB_OUTPUT_DIRECTORY": {
+    "name": "COMPILE_PDB_OUTPUT_DIRECTORY",
+    "description": "Output directory for the MS debug symbol .pdb file generated by the compiler while building source files."
+  },
+  "COMPILE_PDB_OUTPUT_DIRECTORY_<CONFIG>": {
+    "name": "COMPILE_PDB_OUTPUT_DIRECTORY_<CONFIG>",
+    "description": "Per-configuration output directory for the MS debug symbol .pdb file generated by the compiler while building source files."
+  },
+  "COMPILE_WARNING_AS_ERROR": {
+    "name": "COMPILE_WARNING_AS_ERROR",
+    "description": "Specify whether to treat warnings on compile as errors. If enabled, adds a flag to treat warnings on compile as errors. If the cmake --compile-no-warning-as-error option is given on the cmake command line, this property is ignored."
+  },
+  "<CONFIG>_OUTPUT_NAME": {
+    "name": "<CONFIG>_OUTPUT_NAME",
+    "description": "Old per-configuration target file base name. Use OUTPUT_NAME_ instead."
+  },
+  "<CONFIG>_POSTFIX": {
+    "name": "<CONFIG>_POSTFIX",
+    "description": "Postfix to append to the target file name for configuration <CONFIG>."
+  },
+  "CROSSCOMPILING_EMULATOR": {
+    "name": "CROSSCOMPILING_EMULATOR",
+    "description": "Use the given emulator to run executables created when crosscompiling. This command will be added as a prefix to add_test, add_custom_command, and add_custom_target commands for built target system executables."
+  },
+  "CUDA_ARCHITECTURES": {
+    "name": "CUDA_ARCHITECTURES",
+    "description": "List of architectures to generate device code for."
+  },
+  "CUDA_CUBIN_COMPILATION": {
+    "name": "CUDA_CUBIN_COMPILATION",
+    "description": "Compile CUDA sources to .cubin files instead of .obj files within Object Libraries."
+  },
+  "CUDA_EXTENSIONS": {
+    "name": "CUDA_EXTENSIONS",
+    "description": "Boolean specifying whether compiler specific extensions are requested."
+  },
+  "CUDA_FATBIN_COMPILATION": {
+    "name": "CUDA_FATBIN_COMPILATION",
+    "description": "Compile CUDA sources to .fatbin files instead of .obj files within Object Libraries."
+  },
+  "CUDA_OPTIX_COMPILATION": {
+    "name": "CUDA_OPTIX_COMPILATION",
+    "description": "Compile CUDA sources to .optixir files instead of .obj files within Object Libraries."
+  },
+  "CUDA_PTX_COMPILATION": {
+    "name": "CUDA_PTX_COMPILATION",
+    "description": "Compile CUDA sources to .ptx files instead of .obj files within Object Libraries."
+  },
+  "CUDA_RESOLVE_DEVICE_SYMBOLS": {
+    "name": "CUDA_RESOLVE_DEVICE_SYMBOLS",
+    "description": "CUDA only: Enables device linking for the specific library target where required."
+  },
+  "CUDA_RUNTIME_LIBRARY": {
+    "name": "CUDA_RUNTIME_LIBRARY",
+    "description": "Select the CUDA runtime library for use by compilers targeting the CUDA language."
+  },
+  "CUDA_SEPARABLE_COMPILATION": {
+    "name": "CUDA_SEPARABLE_COMPILATION",
+    "description": "CUDA only: Enables separate compilation of device code"
+  },
+  "CUDA_STANDARD": {
+    "name": "CUDA_STANDARD",
+    "description": "The CUDA/C++ standard whose features are requested to build this target."
+  },
+  "CUDA_STANDARD_REQUIRED": {
+    "name": "CUDA_STANDARD_REQUIRED",
+    "description": "Boolean describing whether the value of CUDA_STANDARD is a requirement."
+  },
+  "CXX_EXTENSIONS": {
+    "name": "CXX_EXTENSIONS",
+    "description": "Boolean specifying whether compiler specific extensions are requested."
+  },
+  "CXX_MODULE_DIRS": {
+    "name": "CXX_MODULE_DIRS",
+    "description": "Semicolon-separated list of base directories of the target's default C++ module set (i.e. the file set with name and type CXX_MODULES). The property supports generator expressions <cmake-generator-expressions(7)>."
+  },
+  "CXX_MODULE_DIRS_<NAME>": {
+    "name": "CXX_MODULE_DIRS_<NAME>",
+    "description": "Semicolon-separated list of base directories of the target's <NAME> C++ module set, which has the set type CXX_MODULES. The property supports generator expressions <cmake-generator-expressions(7)>."
+  },
+  "CXX_MODULE_SET": {
+    "name": "CXX_MODULE_SET",
+    "description": "Semicolon-separated list of files in the target's default C++ module set, (i.e. the file set with name and type CXX_MODULES). If any of the paths are relative, they are computed relative to the target's source directory. The property supports generator expressions <cmake-generator-expressions(7)>."
+  },
+  "CXX_MODULE_SETS": {
+    "name": "CXX_MODULE_SETS",
+    "description": "Read-only list of the target's PRIVATE and PUBLIC C++ module sets (i.e. all file sets with the type CXX_MODULES). Files listed in these file sets are treated as source files for the purpose of IDE integration."
+  },
+  "CXX_MODULE_SET_<NAME>": {
+    "name": "CXX_MODULE_SET_<NAME>",
+    "description": "Semicolon-separated list of files in the target's <NAME> C++ module set, which has the set type CXX_MODULES. If any of the paths are relative, they are computed relative to the target's source directory. The property supports generator expressions <cmake-generator-expressions(7)>."
+  },
+  "CXX_MODULE_STD": {
+    "name": "CXX_MODULE_STD",
+    "description": "CXX_MODULE_STD is a boolean specifying whether the target may use import std; its C++ sources or not."
+  },
+  "CXX_STANDARD": {
+    "name": "CXX_STANDARD",
+    "description": "The C++ standard whose features are requested to build this target."
+  },
+  "CXX_STANDARD_REQUIRED": {
+    "name": "CXX_STANDARD_REQUIRED",
+    "description": "Boolean describing whether the value of CXX_STANDARD is a requirement."
+  },
+  "C_EXTENSIONS": {
+    "name": "C_EXTENSIONS",
+    "description": "Boolean specifying whether compiler specific extensions are requested."
+  },
+  "C_STANDARD": {
+    "name": "C_STANDARD",
+    "description": "The C standard whose features are requested to build this target."
+  },
+  "C_STANDARD_REQUIRED": {
+    "name": "C_STANDARD_REQUIRED",
+    "description": "Boolean describing whether the value of C_STANDARD is a requirement."
+  },
+  "DEBUG_POSTFIX": {
+    "name": "DEBUG_POSTFIX",
+    "description": "See target property <CONFIG>_POSTFIX."
+  },
+  "DEFINE_SYMBOL": {
+    "name": "DEFINE_SYMBOL",
+    "description": "Define a symbol when compiling this target's sources."
+  },
+  "DEPLOYMENT_ADDITIONAL_FILES": {
+    "name": "DEPLOYMENT_ADDITIONAL_FILES",
+    "description": "Set the WinCE project AdditionalFiles in DeploymentTool in .vcproj files generated by the Visual Studio Generators. This is useful when you want to debug on remote WinCE device. Specify additional files that will be copied to the device. For example:"
+  },
+  "DEPLOYMENT_REMOTE_DIRECTORY": {
+    "name": "DEPLOYMENT_REMOTE_DIRECTORY",
+    "description": "Set the WinCE project RemoteDirectory in DeploymentTool and RemoteExecutable in DebuggerTool in .vcproj files generated by the Visual Studio Generators. This is useful when you want to debug on remote WinCE device. For example:"
+  },
+  "DEPRECATION": {
+    "name": "DEPRECATION",
+    "description": "Deprecation message from imported target's developer."
+  },
+  "DISABLE_PRECOMPILE_HEADERS": {
+    "name": "DISABLE_PRECOMPILE_HEADERS",
+    "description": "Disables the precompilation of header files specified by PRECOMPILE_HEADERS property."
+  },
+  "DLL_NAME_WITH_SOVERSION": {
+    "name": "DLL_NAME_WITH_SOVERSION",
+    "description": "This property controls whether the SOVERSION target property is added to the filename of generated DLL filenames for the Windows platform, which is selected when the WIN32 variable is set."
+  },
+  "DOTNET_SDK": {
+    "name": "DOTNET_SDK",
+    "description": "Specify the .NET SDK for C# projects. For example: Microsoft.NET.Sdk."
+  },
+  "DOTNET_TARGET_FRAMEWORK": {
+    "name": "DOTNET_TARGET_FRAMEWORK",
+    "description": "Specify the .NET target framework."
+  },
+  "DOTNET_TARGET_FRAMEWORK_VERSION": {
+    "name": "DOTNET_TARGET_FRAMEWORK_VERSION",
+    "description": "Specify the .NET target framework version."
+  },
+  "EchoString": {
+    "name": "EchoString",
+    "description": "A message to be displayed when the target is built."
+  },
+  "ENABLE_EXPORTS": {
+    "name": "ENABLE_EXPORTS",
+    "description": "Specify whether an executable or a shared library exports symbols."
+  },
+  "EXCLUDE_FROM_DEFAULT_BUILD": {
+    "name": "EXCLUDE_FROM_DEFAULT_BUILD",
+    "description": "Exclude target from Build Solution."
+  },
+  "EXCLUDE_FROM_DEFAULT_BUILD_<CONFIG>": {
+    "name": "EXCLUDE_FROM_DEFAULT_BUILD_<CONFIG>",
+    "description": "Per-configuration version of target exclusion from Build Solution."
+  },
+  "EXPORT_COMPILE_COMMANDS": {
+    "name": "EXPORT_COMPILE_COMMANDS",
+    "description": "Enable/Disable output of compile commands during generation for a target."
+  },
+  "EXPORT_FIND_PACKAGE_NAME": {
+    "name": "EXPORT_FIND_PACKAGE_NAME",
+    "description": "Control the package name associated with a dependency target when exporting a find_dependency call in install or export. This can be used to assign a package name to a package that is built by CMake and exported, or to override the package in the find_package call that created the target."
+  },
+  "EXPORT_NAME": {
+    "name": "EXPORT_NAME",
+    "description": "Exported name for target files."
+  },
+  "EXPORT_NO_SYSTEM": {
+    "name": "EXPORT_NO_SYSTEM",
+    "description": "This property affects the behavior of the install and export commands when they install or export the target respectively. When EXPORT_NO_SYSTEM is set to true, those commands generate an imported target with SYSTEM property set to false."
+  },
+  "EXPORT_PROPERTIES": {
+    "name": "EXPORT_PROPERTIES",
+    "description": "List additional properties to export for a target."
+  },
+  "FOLDER": {
+    "name": "FOLDER",
+    "description": "For IDEs that present targets using a folder hierarchy, this property specifies the name of the folder to place the target under. To nest folders, use FOLDER values such as GUI/Dialogs with / characters separating folder levels. Targets with no FOLDER property will appear as top level entities. Targets with the same FOLDER property value will appear in the same folder as siblings."
+  },
+  "Fortran_BUILDING_INSTRINSIC_MODULES": {
+    "name": "Fortran_BUILDING_INSTRINSIC_MODULES",
+    "description": "Instructs the CMake Fortran preprocessor that the target is building Fortran intrinsics for building a Fortran compiler."
+  },
+  "Fortran_MODULE_DIRECTORY": {
+    "name": "Fortran_MODULE_DIRECTORY",
+    "description": "Specify output directory for Fortran modules provided by the target."
+  },
+  "FRAMEWORK": {
+    "name": "FRAMEWORK",
+    "description": "Build SHARED or STATIC library as Framework Bundle on the macOS and iOS."
+  },
+  "FRAMEWORK_MULTI_CONFIG_POSTFIX_<CONFIG>": {
+    "name": "FRAMEWORK_MULTI_CONFIG_POSTFIX_<CONFIG>",
+    "description": "Postfix to append to the framework file name for configuration <CONFIG>, when using a multi-config generator (like Xcode and Ninja Multi-Config)."
+  },
+  "FRAMEWORK_VERSION": {
+    "name": "FRAMEWORK_VERSION",
+    "description": "Version of a framework created using the FRAMEWORK target property (e.g. A)."
+  },
+  "GENERATOR_FILE_NAME": {
+    "name": "GENERATOR_FILE_NAME",
+    "description": "Generator's file for this target."
+  },
+  "GHS_INTEGRITY_APP": {
+    "name": "GHS_INTEGRITY_APP",
+    "description": "ON / OFF boolean to determine if an executable target should be treated as an Integrity Application."
+  },
+  "GHS_NO_SOURCE_GROUP_FILE": {
+    "name": "GHS_NO_SOURCE_GROUP_FILE",
+    "description": "ON / OFF boolean to control if the project file for a target should be one single file or multiple files."
+  },
+  "GNUtoMS": {
+    "name": "GNUtoMS",
+    "description": "Convert GNU import library (.dll.a) to MS format (.lib)."
+  },
+  "HAS_CXX": {
+    "name": "HAS_CXX",
+    "description": "Link the target using the C++ linker tool (obsolete)."
+  },
+  "HEADER_DIRS": {
+    "name": "HEADER_DIRS",
+    "description": "Semicolon-separated list of base directories of the target's default header set (i.e. the file set with name and type HEADERS). The property supports generator expressions <cmake-generator-expressions(7)>."
+  },
+  "HEADER_DIRS_<NAME>": {
+    "name": "HEADER_DIRS_<NAME>",
+    "description": "Semicolon-separated list of base directories of the target's <NAME> header set, which has the set type HEADERS. The property supports generator expressions <cmake-generator-expressions(7)>."
+  },
+  "HEADER_SET": {
+    "name": "HEADER_SET",
+    "description": "Semicolon-separated list of files in the target's default header set, (i.e. the file set with name and type HEADERS). If any of the paths are relative, they are computed relative to the target's source directory. The property supports generator expressions <cmake-generator-expressions(7)>."
+  },
+  "HEADER_SETS": {
+    "name": "HEADER_SETS",
+    "description": "Read-only list of the target's PRIVATE and PUBLIC header sets (i.e. all file sets with the type HEADERS). Files listed in these file sets are treated as source files for the purpose of IDE integration. The files also have their HEADER_FILE_ONLY property set to TRUE."
+  },
+  "HEADER_SET_<NAME>": {
+    "name": "HEADER_SET_<NAME>",
+    "description": "Semicolon-separated list of files in the target's <NAME> header set, which has the set type HEADERS. If any of the paths are relative, they are computed relative to the target's source directory. The property supports generator expressions <cmake-generator-expressions(7)>."
+  },
+  "HIP_ARCHITECTURES": {
+    "name": "HIP_ARCHITECTURES",
+    "description": "List of GPU architectures to for which to generate device code. Architecture names are interpreted based on CMAKE_HIP_PLATFORM."
+  },
+  "HIP_EXTENSIONS": {
+    "name": "HIP_EXTENSIONS",
+    "description": "Boolean specifying whether compiler specific extensions are requested."
+  },
+  "HIP_STANDARD": {
+    "name": "HIP_STANDARD",
+    "description": "The HIP/C++ standard requested to build this target."
+  },
+  "HIP_STANDARD_REQUIRED": {
+    "name": "HIP_STANDARD_REQUIRED",
+    "description": "Boolean describing whether the value of HIP_STANDARD is a requirement."
+  },
+  "IMPORTED": {
+    "name": "IMPORTED",
+    "description": "Read-only indication of whether a target is IMPORTED."
+  },
+  "IMPORTED_COMMON_LANGUAGE_RUNTIME": {
+    "name": "IMPORTED_COMMON_LANGUAGE_RUNTIME",
+    "description": "Property to define if the target uses C++/CLI."
+  },
+  "IMPORTED_CONFIGURATIONS": {
+    "name": "IMPORTED_CONFIGURATIONS",
+    "description": "Configurations provided for an imported target ."
+  },
+  "IMPORTED_CXX_MODULES_COMPILE_DEFINITIONS": {
+    "name": "IMPORTED_CXX_MODULES_COMPILE_DEFINITIONS",
+    "description": "Preprocessor definitions for compiling an IMPORTED target's C++ module sources."
+  },
+  "IMPORTED_CXX_MODULES_COMPILE_FEATURES": {
+    "name": "IMPORTED_CXX_MODULES_COMPILE_FEATURES",
+    "description": "Compiler features enabled for this IMPORTED target's C++ modules."
+  },
+  "IMPORTED_CXX_MODULES_COMPILE_OPTIONS": {
+    "name": "IMPORTED_CXX_MODULES_COMPILE_OPTIONS",
+    "description": "List of options to pass to the compiler for this IMPORTED target's C++ modules."
+  },
+  "IMPORTED_CXX_MODULES_INCLUDE_DIRECTORIES": {
+    "name": "IMPORTED_CXX_MODULES_INCLUDE_DIRECTORIES",
+    "description": "List of preprocessor include file search directories when compiling C++ modules for IMPORTED targets."
+  },
+  "IMPORTED_CXX_MODULES_LINK_LIBRARIES": {
+    "name": "IMPORTED_CXX_MODULES_LINK_LIBRARIES",
+    "description": "List of direct dependencies to use for usage requirements for C++ modules in the target's C++ modules."
+  },
+  "IMPORTED_GLOBAL": {
+    "name": "IMPORTED_GLOBAL",
+    "description": "Indication of whether an IMPORTED target  is globally visible."
+  },
+  "IMPORTED_IMPLIB": {
+    "name": "IMPORTED_IMPLIB",
+    "description": "Full path to the import library for an IMPORTED target."
+  },
+  "IMPORTED_IMPLIB_<CONFIG>": {
+    "name": "IMPORTED_IMPLIB_<CONFIG>",
+    "description": "<CONFIG>-specific version of IMPORTED_IMPLIB property."
+  },
+  "IMPORTED_LIBNAME": {
+    "name": "IMPORTED_LIBNAME",
+    "description": "Specify the link library name for an imported  Interface Library ."
+  },
+  "IMPORTED_LIBNAME_<CONFIG>": {
+    "name": "IMPORTED_LIBNAME_<CONFIG>",
+    "description": "<CONFIG>-specific version of IMPORTED_LIBNAME property."
+  },
+  "IMPORTED_LINK_DEPENDENT_LIBRARIES": {
+    "name": "IMPORTED_LINK_DEPENDENT_LIBRARIES",
+    "description": "Dependent shared libraries of an imported shared library."
+  },
+  "IMPORTED_LINK_DEPENDENT_LIBRARIES_<CONFIG>": {
+    "name": "IMPORTED_LINK_DEPENDENT_LIBRARIES_<CONFIG>",
+    "description": "<CONFIG>-specific version of IMPORTED_LINK_DEPENDENT_LIBRARIES."
+  },
+  "IMPORTED_LINK_INTERFACE_LANGUAGES": {
+    "name": "IMPORTED_LINK_INTERFACE_LANGUAGES",
+    "description": "Languages compiled into an IMPORTED static library."
+  },
+  "IMPORTED_LINK_INTERFACE_LANGUAGES_<CONFIG>": {
+    "name": "IMPORTED_LINK_INTERFACE_LANGUAGES_<CONFIG>",
+    "description": "<CONFIG>-specific version of IMPORTED_LINK_INTERFACE_LANGUAGES."
+  },
+  "IMPORTED_LINK_INTERFACE_LIBRARIES": {
+    "name": "IMPORTED_LINK_INTERFACE_LIBRARIES",
+    "description": "Transitive link interface of an IMPORTED target."
+  },
+  "IMPORTED_LINK_INTERFACE_LIBRARIES_<CONFIG>": {
+    "name": "IMPORTED_LINK_INTERFACE_LIBRARIES_<CONFIG>",
+    "description": "<CONFIG>-specific version of IMPORTED_LINK_INTERFACE_LIBRARIES."
+  },
+  "IMPORTED_LINK_INTERFACE_MULTIPLICITY": {
+    "name": "IMPORTED_LINK_INTERFACE_MULTIPLICITY",
+    "description": "Repetition count for cycles of IMPORTED static libraries."
+  },
+  "IMPORTED_LINK_INTERFACE_MULTIPLICITY_<CONFIG>": {
+    "name": "IMPORTED_LINK_INTERFACE_MULTIPLICITY_<CONFIG>",
+    "description": "<CONFIG>-specific version of IMPORTED_LINK_INTERFACE_MULTIPLICITY."
+  },
+  "IMPORTED_LOCATION": {
+    "name": "IMPORTED_LOCATION",
+    "description": "Full path to the main file on disk for an IMPORTED target."
+  },
+  "IMPORTED_LOCATION_<CONFIG>": {
+    "name": "IMPORTED_LOCATION_<CONFIG>",
+    "description": "<CONFIG>-specific version of IMPORTED_LOCATION property."
+  },
+  "IMPORTED_NO_SONAME": {
+    "name": "IMPORTED_NO_SONAME",
+    "description": "Specifies that an IMPORTED shared library target has no soname."
+  },
+  "IMPORTED_NO_SONAME_<CONFIG>": {
+    "name": "IMPORTED_NO_SONAME_<CONFIG>",
+    "description": "<CONFIG>-specific version of IMPORTED_NO_SONAME property."
+  },
+  "IMPORTED_NO_SYSTEM": {
+    "name": "IMPORTED_NO_SYSTEM",
+    "description": "Setting IMPORTED_NO_SYSTEM to true on an imported target  specifies that it is not a system target. This has the following effects:"
+  },
+  "IMPORTED_OBJECTS": {
+    "name": "IMPORTED_OBJECTS",
+    "description": "A semicolon-separated list  of absolute paths to the object files on disk for an imported  object library ."
+  },
+  "IMPORTED_OBJECTS_<CONFIG>": {
+    "name": "IMPORTED_OBJECTS_<CONFIG>",
+    "description": "<CONFIG>-specific version of IMPORTED_OBJECTS property."
+  },
+  "IMPORTED_SONAME": {
+    "name": "IMPORTED_SONAME",
+    "description": "The soname of an IMPORTED target of shared library type."
+  },
+  "IMPORTED_SONAME_<CONFIG>": {
+    "name": "IMPORTED_SONAME_<CONFIG>",
+    "description": "<CONFIG>-specific version of IMPORTED_SONAME property."
+  },
+  "IMPORT_PREFIX": {
+    "name": "IMPORT_PREFIX",
+    "description": "What comes before the import library name."
+  },
+  "IMPORT_SUFFIX": {
+    "name": "IMPORT_SUFFIX",
+    "description": "What comes after the import library name."
+  },
+  "INSTALL_NAME_DIR": {
+    "name": "INSTALL_NAME_DIR",
+    "description": "Directory name for installed targets on Apple platforms."
+  },
+  "INSTALL_REMOVE_ENVIRONMENT_RPATH": {
+    "name": "INSTALL_REMOVE_ENVIRONMENT_RPATH",
+    "description": "Controls whether toolchain-defined rpaths should be removed during installation."
+  },
+  "INSTALL_RPATH": {
+    "name": "INSTALL_RPATH",
+    "description": "The rpath to use for installed targets."
+  },
+  "INSTALL_RPATH_USE_LINK_PATH": {
+    "name": "INSTALL_RPATH_USE_LINK_PATH",
+    "description": "Add paths to linker search and installed rpath."
+  },
+  "INTERFACE_AUTOMOC_MACRO_NAMES": {
+    "name": "INTERFACE_AUTOMOC_MACRO_NAMES",
+    "description": "A semicolon-separated list  of macro names for AUTOMOC to be propagated to consumers."
+  },
+  "INTERFACE_AUTOUIC_OPTIONS": {
+    "name": "INTERFACE_AUTOUIC_OPTIONS",
+    "description": "List of interface options to pass to uic."
+  },
+  "INTERFACE_COMPILE_DEFINITIONS": {
+    "name": "INTERFACE_COMPILE_DEFINITIONS",
+    "description": "List of public property_name requirements for a library."
+  },
+  "INTERFACE_COMPILE_FEATURES": {
+    "name": "INTERFACE_COMPILE_FEATURES",
+    "description": "List of public property_name requirements for a library."
+  },
+  "INTERFACE_COMPILE_OPTIONS": {
+    "name": "INTERFACE_COMPILE_OPTIONS",
+    "description": "List of public property_name requirements for a library."
+  },
+  "INTERFACE_CXX_MODULE_SETS": {
+    "name": "INTERFACE_CXX_MODULE_SETS",
+    "description": "Read-only list of the target's PUBLIC C++ module sets (i.e. all file sets with the type CXX_MODULES). Files listed in these C++ module sets can be installed with install and exported with install and export."
+  },
+  "INTERFACE_HEADER_SETS": {
+    "name": "INTERFACE_HEADER_SETS",
+    "description": "Read-only list of the target's INTERFACE and PUBLIC header sets (i.e. all file sets with the type HEADERS). Files listed in these header sets can be installed with install and exported with install and export."
+  },
+  "INTERFACE_HEADER_SETS_TO_VERIFY": {
+    "name": "INTERFACE_HEADER_SETS_TO_VERIFY",
+    "description": "Used to specify which PUBLIC and INTERFACE header sets of a target should be verified."
+  },
+  "INTERFACE_INCLUDE_DIRECTORIES": {
+    "name": "INTERFACE_INCLUDE_DIRECTORIES",
+    "description": "List of public property_name requirements for a library."
+  },
+  "INTERFACE_LINK_DEPENDS": {
+    "name": "INTERFACE_LINK_DEPENDS",
+    "description": "Additional public interface files on which a target binary depends for linking."
+  },
+  "INTERFACE_LINK_DIRECTORIES": {
+    "name": "INTERFACE_LINK_DIRECTORIES",
+    "description": "List of public property_name requirements for a library."
+  },
+  "INTERFACE_LINK_LIBRARIES": {
+    "name": "INTERFACE_LINK_LIBRARIES",
+    "description": "List public interface libraries for a library."
+  },
+  "INTERFACE_LINK_LIBRARIES_DIRECT": {
+    "name": "INTERFACE_LINK_LIBRARIES_DIRECT",
+    "description": "List of libraries that consumers of this library should treat as direct link dependencies."
+  },
+  "INTERFACE_LINK_LIBRARIES_DIRECT_EXCLUDE": {
+    "name": "INTERFACE_LINK_LIBRARIES_DIRECT_EXCLUDE",
+    "description": "List of libraries that consumers of this library should not treat as direct link dependencies."
+  },
+  "INTERFACE_LINK_OPTIONS": {
+    "name": "INTERFACE_LINK_OPTIONS",
+    "description": "List of public property_name requirements for a library."
+  },
+  "INTERFACE_POSITION_INDEPENDENT_CODE": {
+    "name": "INTERFACE_POSITION_INDEPENDENT_CODE",
+    "description": "Whether consumers need to create a position-independent target"
+  },
+  "INTERFACE_PRECOMPILE_HEADERS": {
+    "name": "INTERFACE_PRECOMPILE_HEADERS",
+    "description": "List of interface header files to precompile into consuming targets."
+  },
+  "INTERFACE_SOURCES": {
+    "name": "INTERFACE_SOURCES",
+    "description": "List of interface sources to compile into consuming targets."
+  },
+  "INTERFACE_SYSTEM_INCLUDE_DIRECTORIES": {
+    "name": "INTERFACE_SYSTEM_INCLUDE_DIRECTORIES",
+    "description": "List of public system include directories for a library."
+  },
+  "IOS_INSTALL_COMBINED": {
+    "name": "IOS_INSTALL_COMBINED",
+    "description": "Build a combined (device and simulator) target when installing."
+  },
+  "ISPC_HEADER_DIRECTORY": {
+    "name": "ISPC_HEADER_DIRECTORY",
+    "description": "Specify relative output directory for ISPC headers provided by the target."
+  },
+  "ISPC_HEADER_SUFFIX": {
+    "name": "ISPC_HEADER_SUFFIX",
+    "description": "Specify output suffix to be used for ISPC generated headers provided by the target."
+  },
+  "ISPC_INSTRUCTION_SETS": {
+    "name": "ISPC_INSTRUCTION_SETS",
+    "description": "List of instruction set architectures to generate code for."
+  },
+  "JOB_POOL_COMPILE": {
+    "name": "JOB_POOL_COMPILE",
+    "description": "Ninja only: Pool used for compiling."
+  },
+  "JOB_POOL_LINK": {
+    "name": "JOB_POOL_LINK",
+    "description": "Ninja only: Pool used for linking."
+  },
+  "JOB_POOL_PRECOMPILE_HEADER": {
+    "name": "JOB_POOL_PRECOMPILE_HEADER",
+    "description": "Ninja only: Pool used for generating pre-compiled headers."
+  },
+  "<LANG>_CLANG_TIDY": {
+    "name": "<LANG>_CLANG_TIDY",
+    "description": "This property is implemented only when <LANG> is C, CXX, OBJC or OBJCXX."
+  },
+  "<LANG>_CLANG_TIDY_EXPORT_FIXES_DIR": {
+    "name": "<LANG>_CLANG_TIDY_EXPORT_FIXES_DIR",
+    "description": "This property is implemented only when <LANG> is C, CXX, OBJC or OBJCXX, and only has an effect when <LANG>_CLANG_TIDY is set."
+  },
+  "<LANG>_COMPILER_LAUNCHER": {
+    "name": "<LANG>_COMPILER_LAUNCHER",
+    "description": "This property is implemented only when <LANG> is C, CXX, Fortran, HIP, ISPC, OBJC, OBJCXX, or CUDA."
+  },
+  "<LANG>_CPPCHECK": {
+    "name": "<LANG>_CPPCHECK",
+    "description": "This property is supported only when <LANG> is C or CXX."
+  },
+  "<LANG>_CPPLINT": {
+    "name": "<LANG>_CPPLINT",
+    "description": "This property is supported only when <LANG> is C or CXX."
+  },
+  "<LANG>_EXTENSIONS": {
+    "name": "<LANG>_EXTENSIONS",
+    "description": "The variations are:"
+  },
+  "<LANG>_INCLUDE_WHAT_YOU_USE": {
+    "name": "<LANG>_INCLUDE_WHAT_YOU_USE",
+    "description": "This property is implemented only when <LANG> is C or CXX."
+  },
+  "<LANG>_LINKER_LAUNCHER": {
+    "name": "<LANG>_LINKER_LAUNCHER",
+    "description": "This property is implemented only when <LANG> is C, CXX, OBJC, or OBJCXX"
+  },
+  "<LANG>_STANDARD": {
+    "name": "<LANG>_STANDARD",
+    "description": "The variations are:"
+  },
+  "<LANG>_STANDARD_REQUIRED": {
+    "name": "<LANG>_STANDARD_REQUIRED",
+    "description": "The variations are:"
+  },
+  "<LANG>_VISIBILITY_PRESET": {
+    "name": "<LANG>_VISIBILITY_PRESET",
+    "description": "Value for symbol visibility compile flags"
+  },
+  "LIBRARY_OUTPUT_DIRECTORY": {
+    "name": "LIBRARY_OUTPUT_DIRECTORY",
+    "description": "Output directory in which to build XXX target files."
+  },
+  "LIBRARY_OUTPUT_DIRECTORY_<CONFIG>": {
+    "name": "LIBRARY_OUTPUT_DIRECTORY_<CONFIG>",
+    "description": "Per-configuration output directory for LIBRARY  target files."
+  },
+  "LIBRARY_OUTPUT_NAME": {
+    "name": "LIBRARY_OUTPUT_NAME",
+    "description": "Output name for XXX target files."
+  },
+  "LIBRARY_OUTPUT_NAME_<CONFIG>": {
+    "name": "LIBRARY_OUTPUT_NAME_<CONFIG>",
+    "description": "Per-configuration output name for LIBRARY  target files."
+  },
+  "LINKER_LANGUAGE": {
+    "name": "LINKER_LANGUAGE",
+    "description": "Specifies language whose compiler will invoke the linker."
+  },
+  "LINKER_TYPE": {
+    "name": "LINKER_TYPE",
+    "description": "Specify which linker will be used for the link step. The property value may use generator expressions <cmake-generator-expressions(7)>."
+  },
+  "LINK_DEPENDS": {
+    "name": "LINK_DEPENDS",
+    "description": "Additional files on which a target binary depends for linking."
+  },
+  "LINK_DEPENDS_NO_SHARED": {
+    "name": "LINK_DEPENDS_NO_SHARED",
+    "description": "Do not depend on linked shared library files."
+  },
+  "LINK_FLAGS": {
+    "name": "LINK_FLAGS",
+    "description": "Additional flags to use when linking this target if it is a shared library, module library, or an executable. Static libraries need to use STATIC_LIBRARY_OPTIONS or STATIC_LIBRARY_FLAGS properties."
+  },
+  "LINK_FLAGS_<CONFIG>": {
+    "name": "LINK_FLAGS_<CONFIG>",
+    "description": "Per-configuration linker flags for a SHARED library, MODULE or EXECUTABLE target."
+  },
+  "LINK_INTERFACE_LIBRARIES": {
+    "name": "LINK_INTERFACE_LIBRARIES",
+    "description": "List public interface libraries for a shared library or executable."
+  },
+  "LINK_INTERFACE_LIBRARIES_<CONFIG>": {
+    "name": "LINK_INTERFACE_LIBRARIES_<CONFIG>",
+    "description": "Per-configuration list of public interface libraries for a target."
+  },
+  "LINK_INTERFACE_MULTIPLICITY": {
+    "name": "LINK_INTERFACE_MULTIPLICITY",
+    "description": "Repetition count for STATIC libraries with cyclic dependencies."
+  },
+  "LINK_INTERFACE_MULTIPLICITY_<CONFIG>": {
+    "name": "LINK_INTERFACE_MULTIPLICITY_<CONFIG>",
+    "description": "Per-configuration repetition count for cycles of STATIC libraries."
+  },
+  "LINK_LIBRARIES": {
+    "name": "LINK_LIBRARIES",
+    "description": "List of direct link dependencies."
+  },
+  "LINK_LIBRARIES_ONLY_TARGETS": {
+    "name": "LINK_LIBRARIES_ONLY_TARGETS",
+    "description": "Enforce that link items that can be target names are actually existing targets."
+  },
+  "LINK_LIBRARY_OVERRIDE": {
+    "name": "LINK_LIBRARY_OVERRIDE",
+    "description": "Override the library features associated with libraries from LINK_LIBRARY generator expressions. This can be used to resolve incompatible library features that result from specifying different features for the same library in different LINK_LIBRARY generator expressions."
+  },
+  "LINK_LIBRARY_OVERRIDE_<LIBRARY>": {
+    "name": "LINK_LIBRARY_OVERRIDE_<LIBRARY>",
+    "description": "Override the library feature associated with <LIBRARY> from LINK_LIBRARY generator expressions. This can be used to resolve incompatible library features that result from specifying different features for <LIBRARY> in different LINK_LIBRARY generator expressions."
+  },
+  "LINK_SEARCH_END_STATIC": {
+    "name": "LINK_SEARCH_END_STATIC",
+    "description": "End a link line such that static system libraries are used."
+  },
+  "LINK_SEARCH_START_STATIC": {
+    "name": "LINK_SEARCH_START_STATIC",
+    "description": "Assume the linker looks for static libraries by default."
+  },
+  "LINK_WHAT_YOU_USE": {
+    "name": "LINK_WHAT_YOU_USE",
+    "description": "This is a boolean option that, when set to TRUE, will automatically run contents of variable CMAKE_LINK_WHAT_YOU_USE_CHECK on the target after it is linked. In addition, the linker flag specified by variable CMAKE_<LANG>_LINK_WHAT_YOU_USE_FLAG will be passed to the target with the link command so that all libraries specified on the command line will be linked into the target. This will result in the link producing a list of libraries that provide no symbols used by this target but are being linked to it."
+  },
+  "LOCATION_<CONFIG>": {
+    "name": "LOCATION_<CONFIG>",
+    "description": "Read-only property providing a target location on disk."
+  },
+  "MACHO_COMPATIBILITY_VERSION": {
+    "name": "MACHO_COMPATIBILITY_VERSION",
+    "description": "What compatibility version number is this target for Mach-O binaries."
+  },
+  "MACHO_CURRENT_VERSION": {
+    "name": "MACHO_CURRENT_VERSION",
+    "description": "What current version number is this target for Mach-O binaries."
+  },
+  "MACOSX_BUNDLE": {
+    "name": "MACOSX_BUNDLE",
+    "description": "Build an executable as an Application Bundle on macOS or iOS."
+  },
+  "MACOSX_BUNDLE_INFO_PLIST": {
+    "name": "MACOSX_BUNDLE_INFO_PLIST",
+    "description": "Specify a custom Info.plist template for a macOS and iOS Application Bundle."
+  },
+  "MACOSX_FRAMEWORK_INFO_PLIST": {
+    "name": "MACOSX_FRAMEWORK_INFO_PLIST",
+    "description": "Specify a custom Info.plist template for a macOS and iOS Framework."
+  },
+  "MACOSX_RPATH": {
+    "name": "MACOSX_RPATH",
+    "description": "Whether this target on macOS or iOS is located at runtime using rpaths."
+  },
+  "MANUALLY_ADDED_DEPENDENCIES": {
+    "name": "MANUALLY_ADDED_DEPENDENCIES",
+    "description": "Get manually added dependencies to other top-level targets."
+  },
+  "MAP_IMPORTED_CONFIG_<CONFIG>": {
+    "name": "MAP_IMPORTED_CONFIG_<CONFIG>",
+    "description": "Map from project configuration to imported target 's configuration."
+  },
+  "MSVC_DEBUG_INFORMATION_FORMAT": {
+    "name": "MSVC_DEBUG_INFORMATION_FORMAT",
+    "description": "Select debug information format when targeting the MSVC ABI."
+  },
+  "MSVC_RUNTIME_LIBRARY": {
+    "name": "MSVC_RUNTIME_LIBRARY",
+    "description": "Select the MSVC runtime library for use by compilers targeting the MSVC ABI."
+  },
+  "NAME": { "name": "NAME", "description": "Logical name for the target." },
+  "NO_SONAME": {
+    "name": "NO_SONAME",
+    "description": "Whether to set soname when linking a shared library."
+  },
+  "NO_SYSTEM_FROM_IMPORTED": {
+    "name": "NO_SYSTEM_FROM_IMPORTED",
+    "description": "Do not treat include directories from the interfaces of consumed imported targets as system directories."
+  },
+  "OBJCXX_EXTENSIONS": {
+    "name": "OBJCXX_EXTENSIONS",
+    "description": "Boolean specifying whether compiler specific extensions are requested."
+  },
+  "OBJCXX_STANDARD": {
+    "name": "OBJCXX_STANDARD",
+    "description": "The ObjC++ standard whose features are requested to build this target."
+  },
+  "OBJCXX_STANDARD_REQUIRED": {
+    "name": "OBJCXX_STANDARD_REQUIRED",
+    "description": "Boolean describing whether the value of OBJCXX_STANDARD is a requirement."
+  },
+  "OBJC_EXTENSIONS": {
+    "name": "OBJC_EXTENSIONS",
+    "description": "Boolean specifying whether compiler specific extensions are requested."
+  },
+  "OBJC_STANDARD": {
+    "name": "OBJC_STANDARD",
+    "description": "The OBJC standard whose features are requested to build this target."
+  },
+  "OBJC_STANDARD_REQUIRED": {
+    "name": "OBJC_STANDARD_REQUIRED",
+    "description": "Boolean describing whether the value of OBJC_STANDARD is a requirement."
+  },
+  "OPTIMIZE_DEPENDENCIES": {
+    "name": "OPTIMIZE_DEPENDENCIES",
+    "description": "Activates dependency optimization of static and object libraries."
+  },
+  "OSX_ARCHITECTURES": {
+    "name": "OSX_ARCHITECTURES",
+    "description": "Target specific architectures for macOS."
+  },
+  "OSX_ARCHITECTURES_<CONFIG>": {
+    "name": "OSX_ARCHITECTURES_<CONFIG>",
+    "description": "Per-configuration macOS and iOS binary architectures for a target."
+  },
+  "OUTPUT_NAME": {
+    "name": "OUTPUT_NAME",
+    "description": "Output name for target files."
+  },
+  "OUTPUT_NAME_<CONFIG>": {
+    "name": "OUTPUT_NAME_<CONFIG>",
+    "description": "Per-configuration target file base name."
+  },
+  "PCH_INSTANTIATE_TEMPLATES": {
+    "name": "PCH_INSTANTIATE_TEMPLATES",
+    "description": "When this property is set to true, the precompiled header compiler options will contain a flag to instantiate templates during the generation of the PCH if supported. This can significantly improve compile times. Supported in Clang since version 11."
+  },
+  "PCH_WARN_INVALID": {
+    "name": "PCH_WARN_INVALID",
+    "description": "When this property is set to true, the precompile header compiler options will contain a compiler flag which should warn about invalid precompiled headers e.g. -Winvalid-pch for GNU compiler."
+  },
+  "PDB_NAME": {
+    "name": "PDB_NAME",
+    "description": "Output name for the MS debug symbol .pdb file generated by the linker for an executable or shared library target."
+  },
+  "PDB_NAME_<CONFIG>": {
+    "name": "PDB_NAME_<CONFIG>",
+    "description": "Per-configuration output name for the MS debug symbol .pdb file generated by the linker for an executable or shared library target."
+  },
+  "PDB_OUTPUT_DIRECTORY": {
+    "name": "PDB_OUTPUT_DIRECTORY",
+    "description": "Output directory for the MS debug symbols .pdb file generated by the linker for an executable or shared library target."
+  },
+  "PDB_OUTPUT_DIRECTORY_<CONFIG>": {
+    "name": "PDB_OUTPUT_DIRECTORY_<CONFIG>",
+    "description": "Per-configuration output directory for the MS debug symbol .pdb file generated by the linker for an executable or shared library target."
+  },
+  "POSITION_INDEPENDENT_CODE": {
+    "name": "POSITION_INDEPENDENT_CODE",
+    "description": "Whether to create a position-independent target"
+  },
+  "POST_INSTALL_SCRIPT": {
+    "name": "POST_INSTALL_SCRIPT",
+    "description": "Deprecated install support."
+  },
+  "PRECOMPILE_HEADERS": {
+    "name": "PRECOMPILE_HEADERS",
+    "description": "List of header files to precompile."
+  },
+  "PRECOMPILE_HEADERS_REUSE_FROM": {
+    "name": "PRECOMPILE_HEADERS_REUSE_FROM",
+    "description": "Target from which to reuse the precompiled headers build artifact."
+  },
+  "PREFIX": {
+    "name": "PREFIX",
+    "description": "What comes before the library name."
+  },
+  "PRE_INSTALL_SCRIPT": {
+    "name": "PRE_INSTALL_SCRIPT",
+    "description": "Deprecated install support."
+  },
+  "PRIVATE_HEADER": {
+    "name": "PRIVATE_HEADER",
+    "description": "Specify private header files in a FRAMEWORK shared library target."
+  },
+  "PROJECT_LABEL": {
+    "name": "PROJECT_LABEL",
+    "description": "Change the name of a target in an IDE."
+  },
+  "PUBLIC_HEADER": {
+    "name": "PUBLIC_HEADER",
+    "description": "Specify public header files in a FRAMEWORK shared library target."
+  },
+  "RESOURCE": {
+    "name": "RESOURCE",
+    "description": "Specify resource files in a FRAMEWORK or BUNDLE."
+  },
+  "RUNTIME_OUTPUT_DIRECTORY": {
+    "name": "RUNTIME_OUTPUT_DIRECTORY",
+    "description": "Output directory in which to build XXX target files."
+  },
+  "RUNTIME_OUTPUT_DIRECTORY_<CONFIG>": {
+    "name": "RUNTIME_OUTPUT_DIRECTORY_<CONFIG>",
+    "description": "Per-configuration output directory for RUNTIME  target files."
+  },
+  "RUNTIME_OUTPUT_NAME": {
+    "name": "RUNTIME_OUTPUT_NAME",
+    "description": "Output name for XXX target files."
+  },
+  "RUNTIME_OUTPUT_NAME_<CONFIG>": {
+    "name": "RUNTIME_OUTPUT_NAME_<CONFIG>",
+    "description": "Per-configuration output name for RUNTIME  target files."
+  },
+  "SKIP_BUILD_RPATH": {
+    "name": "SKIP_BUILD_RPATH",
+    "description": "Should rpaths be used for the build tree."
+  },
+  "SOURCES": {
+    "name": "SOURCES",
+    "description": "This specifies the list of paths to source files for the target. The following commands all set or add to the SOURCES target property and are the usual way to manipulate it:"
+  },
+  "SOVERSION": {
+    "name": "SOVERSION",
+    "description": "ABI version number of a shared library target."
+  },
+  "STATIC_LIBRARY_FLAGS": {
+    "name": "STATIC_LIBRARY_FLAGS",
+    "description": "Archiver (or MSVC librarian) flags for a static library target. Targets that are shared libraries, modules, or executables need to use the LINK_OPTIONS or LINK_FLAGS target properties."
+  },
+  "STATIC_LIBRARY_FLAGS_<CONFIG>": {
+    "name": "STATIC_LIBRARY_FLAGS_<CONFIG>",
+    "description": "Per-configuration archiver (or MSVC librarian) flags for a static library target."
+  },
+  "STATIC_LIBRARY_OPTIONS": {
+    "name": "STATIC_LIBRARY_OPTIONS",
+    "description": "Archiver (or MSVC librarian) flags for a static library target. Targets that are shared libraries, modules, or executables need to use the LINK_OPTIONS target property."
+  },
+  "SUFFIX": {
+    "name": "SUFFIX",
+    "description": "What comes after the target name."
+  },
+  "Swift_COMPILATION_MODE": {
+    "name": "Swift_COMPILATION_MODE",
+    "description": "Specify how Swift compiles a target."
+  },
+  "Swift_LANGUAGE_VERSION": {
+    "name": "Swift_LANGUAGE_VERSION",
+    "description": "This property sets the language version for the Swift sources in the target. If one is not specified, it will default to CMAKE_Swift_LANGUAGE_VERSION if specified, otherwise it is the latest version supported by the compiler."
+  },
+  "Swift_MODULE_DIRECTORY": {
+    "name": "Swift_MODULE_DIRECTORY",
+    "description": "Specify output directory for Swift modules provided by the target."
+  },
+  "Swift_MODULE_NAME": {
+    "name": "Swift_MODULE_NAME",
+    "description": "This property specifies the name of the Swift module. It is defaulted to the name of the target."
+  },
+  "TEST_LAUNCHER": {
+    "name": "TEST_LAUNCHER",
+    "description": "Use the given launcher to run executables. This command will be added as a prefix to add_test commands for build target system executables and is meant to be run on the host machine."
+  },
+  "TRANSITIVE_COMPILE_PROPERTIES": {
+    "name": "TRANSITIVE_COMPILE_PROPERTIES",
+    "description": "Properties that the TARGET_PROPERTY generator expression, on the target and its dependents, evaluates as the union of values collected from the transitive closure of link dependencies, excluding entries guarded by LINK_ONLY."
+  },
+  "TRANSITIVE_LINK_PROPERTIES": {
+    "name": "TRANSITIVE_LINK_PROPERTIES",
+    "description": "Properties that the TARGET_PROPERTY generator expression, on the target and its dependents, evaluates as the union of values collected from the transitive closure of link dependencies, including entries guarded by LINK_ONLY."
+  },
+  "UNITY_BUILD": {
+    "name": "UNITY_BUILD",
+    "description": "When this property is set to true, the target source files will be combined into batches for faster compilation. This is done by creating a (set of) unity sources which #include the original sources, then compiling these unity sources instead of the originals. This is known as a Unity or Jumbo build."
+  },
+  "UNITY_BUILD_BATCH_SIZE": {
+    "name": "UNITY_BUILD_BATCH_SIZE",
+    "description": "Specifies the maximum number of source files that can be combined into any one unity source file when unity builds are enabled by the UNITY_BUILD target property. The original source files will be distributed across as many unity source files as necessary to honor this limit."
+  },
+  "UNITY_BUILD_CODE_AFTER_INCLUDE": {
+    "name": "UNITY_BUILD_CODE_AFTER_INCLUDE",
+    "description": "Code snippet which is included verbatim by the UNITY_BUILD feature just after every #include statement in the generated unity source files. For example:"
+  },
+  "UNITY_BUILD_CODE_BEFORE_INCLUDE": {
+    "name": "UNITY_BUILD_CODE_BEFORE_INCLUDE",
+    "description": "Code snippet which is included verbatim by the UNITY_BUILD feature just before every #include statement in the generated unity source files. For example:"
+  },
+  "UNITY_BUILD_MODE": {
+    "name": "UNITY_BUILD_MODE",
+    "description": "CMake provides different algorithms for selecting which sources are grouped together into a bucket. Selection is decided by this property, which has the following acceptable values:"
+  },
+  "UNITY_BUILD_UNIQUE_ID": {
+    "name": "UNITY_BUILD_UNIQUE_ID",
+    "description": "The name of a valid C-identifier which is set to a unique per-file value during unity builds."
+  },
+  "VERIFY_INTERFACE_HEADER_SETS": {
+    "name": "VERIFY_INTERFACE_HEADER_SETS",
+    "description": "Used to verify that all headers in a target's PUBLIC and INTERFACE header sets can be included on their own."
+  },
+  "VERSION": {
+    "name": "VERSION",
+    "description": "Version number of a shared library target."
+  },
+  "VISIBILITY_INLINES_HIDDEN": {
+    "name": "VISIBILITY_INLINES_HIDDEN",
+    "description": "Whether to add a compile flag to hide symbols of inline functions"
+  },
+  "VS_CONFIGURATION_TYPE": {
+    "name": "VS_CONFIGURATION_TYPE",
+    "description": "Visual Studio project configuration type."
+  },
+  "VS_DEBUGGER_COMMAND": {
+    "name": "VS_DEBUGGER_COMMAND",
+    "description": "Sets the local debugger command for Visual Studio C++ targets. The property value may use generator expressions <cmake-generator-expressions(7)>. This is defined in <LocalDebuggerCommand> in the Visual Studio project file. This property is initialized by the value of the variable CMAKE_VS_DEBUGGER_COMMAND if it is set when a target is created."
+  },
+  "VS_DEBUGGER_COMMAND_ARGUMENTS": {
+    "name": "VS_DEBUGGER_COMMAND_ARGUMENTS",
+    "description": "Sets the local debugger command line arguments for Visual Studio C++ targets. The property value may use generator expressions <cmake-generator-expressions(7)>. This is defined in <LocalDebuggerCommandArguments> in the Visual Studio project file. This property is initialized by the value of the variable CMAKE_VS_DEBUGGER_COMMAND_ARGUMENTS if it is set when a target is created."
+  },
+  "VS_DEBUGGER_ENVIRONMENT": {
+    "name": "VS_DEBUGGER_ENVIRONMENT",
+    "description": "Sets the local debugger environment for Visual Studio C++ targets. The property value may use generator expressions <cmake-generator-expressions(7)>. This is defined in <LocalDebuggerEnvironment> in the Visual Studio project file. This property is initialized by the value of the variable CMAKE_VS_DEBUGGER_ENVIRONMENT if it is set when a target is created."
+  },
+  "VS_DEBUGGER_WORKING_DIRECTORY": {
+    "name": "VS_DEBUGGER_WORKING_DIRECTORY",
+    "description": "Sets the local debugger working directory for Visual Studio C++ targets. The property value may use generator expressions <cmake-generator-expressions(7)>. This is defined in <LocalDebuggerWorkingDirectory> in the Visual Studio project file. This property is initialized by the value of the variable CMAKE_VS_DEBUGGER_WORKING_DIRECTORY if it is set when a target is created."
+  },
+  "VS_DESKTOP_EXTENSIONS_VERSION": {
+    "name": "VS_DESKTOP_EXTENSIONS_VERSION",
+    "description": "Visual Studio Windows 10 Desktop Extensions Version"
+  },
+  "VS_DOTNET_DOCUMENTATION_FILE": {
+    "name": "VS_DOTNET_DOCUMENTATION_FILE",
+    "description": "Visual Studio managed project .NET documentation output"
+  },
+  "VS_DOTNET_REFERENCEPROP_<refname>_TAG_<tagname>": {
+    "name": "VS_DOTNET_REFERENCEPROP_<refname>_TAG_<tagname>",
+    "description": "Defines an XML property <tagname> for a .NET reference <refname>."
+  },
+  "VS_DOTNET_REFERENCES": {
+    "name": "VS_DOTNET_REFERENCES",
+    "description": "Visual Studio managed project .NET references"
+  },
+  "VS_DOTNET_REFERENCES_COPY_LOCAL": {
+    "name": "VS_DOTNET_REFERENCES_COPY_LOCAL",
+    "description": "Sets the Copy Local property for all .NET hint references in the target"
+  },
+  "VS_DOTNET_REFERENCE_<refname>": {
+    "name": "VS_DOTNET_REFERENCE_<refname>",
+    "description": "Visual Studio managed project .NET reference with name <refname> and hint path."
+  },
+  "VS_DOTNET_STARTUP_OBJECT": {
+    "name": "VS_DOTNET_STARTUP_OBJECT",
+    "description": "Sets the startup object property in Visual Studio .NET targets. The property value defines a full qualified class name (including package name), for example: MyCompany.Package.MyStarterClass."
+  },
+  "VS_DOTNET_TARGET_FRAMEWORK_VERSION": {
+    "name": "VS_DOTNET_TARGET_FRAMEWORK_VERSION",
+    "description": "Specify the .NET target framework version."
+  },
+  "VS_DPI_AWARE": {
+    "name": "VS_DPI_AWARE",
+    "description": "Set the Manifest Tool -> Input and Output -> DPI Awareness in the Visual Studio target project properties."
+  },
+  "VS_FILTER_PROPS": {
+    "name": "VS_FILTER_PROPS",
+    "description": "Sets the filter props file to be included in the visual studio C++ project filter file."
+  },
+  "VS_GLOBAL_KEYWORD": {
+    "name": "VS_GLOBAL_KEYWORD",
+    "description": "Visual Studio project keyword."
+  },
+  "VS_GLOBAL_PROJECT_TYPES": {
+    "name": "VS_GLOBAL_PROJECT_TYPES",
+    "description": "Visual Studio project type(s)."
+  },
+  "VS_GLOBAL_ROOTNAMESPACE": {
+    "name": "VS_GLOBAL_ROOTNAMESPACE",
+    "description": "Visual Studio project root namespace."
+  },
+  "VS_GLOBAL_<variable>": {
+    "name": "VS_GLOBAL_<variable>",
+    "description": "Visual Studio project-specific global variable."
+  },
+  "VS_IOT_EXTENSIONS_VERSION": {
+    "name": "VS_IOT_EXTENSIONS_VERSION",
+    "description": "Visual Studio Windows 10 IoT Extensions Version"
+  },
+  "VS_IOT_STARTUP_TASK": {
+    "name": "VS_IOT_STARTUP_TASK",
+    "description": "Visual Studio Windows 10 IoT Continuous Background Task"
+  },
+  "VS_JUST_MY_CODE_DEBUGGING": {
+    "name": "VS_JUST_MY_CODE_DEBUGGING",
+    "description": "Enable Just My Code with Visual Studio debugger."
+  },
+  "VS_KEYWORD": {
+    "name": "VS_KEYWORD",
+    "description": "Removed. This once specified the Visual Studio project keyword for the Visual Studio 9 2008 generator, and older, but all of those generators have been removed."
+  },
+  "VS_MOBILE_EXTENSIONS_VERSION": {
+    "name": "VS_MOBILE_EXTENSIONS_VERSION",
+    "description": "Visual Studio Windows 10 Mobile Extensions Version"
+  },
+  "VS_NO_COMPILE_BATCHING": {
+    "name": "VS_NO_COMPILE_BATCHING",
+    "description": "Turn off compile batching for the target. Usually MSBuild calls the compiler with multiple c/cpp files and compiler starts subprocesses for each file to make the build parallel. If you want compiler to be invoked with one file at a time set VS_NO_COMPILE_BATCHING to ON. If this flag is set MSBuild will call compiler with one c/cpp file at a time. Useful when you want to use tool that replaces the compiler, for example some build caching tool."
+  },
+  "VS_NO_SOLUTION_DEPLOY": {
+    "name": "VS_NO_SOLUTION_DEPLOY",
+    "description": "Specify that the target should not be marked for deployment to a Windows CE or Windows Phone device in the generated Visual Studio solution."
+  },
+  "VS_PACKAGE_REFERENCES": {
+    "name": "VS_PACKAGE_REFERENCES",
+    "description": "Visual Studio package references for nuget."
+  },
+  "VS_PLATFORM_TOOLSET": {
+    "name": "VS_PLATFORM_TOOLSET",
+    "description": "Overrides the platform toolset used to build a target."
+  },
+  "VS_PROJECT_IMPORT": {
+    "name": "VS_PROJECT_IMPORT",
+    "description": "Visual Studio managed project imports"
+  },
+  "VS_SCC_AUXPATH": {
+    "name": "VS_SCC_AUXPATH",
+    "description": "Visual Studio Source Code Control Aux Path."
+  },
+  "VS_SCC_LOCALPATH": {
+    "name": "VS_SCC_LOCALPATH",
+    "description": "Visual Studio Source Code Control Local Path."
+  },
+  "VS_SCC_PROJECTNAME": {
+    "name": "VS_SCC_PROJECTNAME",
+    "description": "Visual Studio Source Code Control Project."
+  },
+  "VS_SCC_PROVIDER": {
+    "name": "VS_SCC_PROVIDER",
+    "description": "Visual Studio Source Code Control Provider."
+  },
+  "VS_SDK_REFERENCES": {
+    "name": "VS_SDK_REFERENCES",
+    "description": "Visual Studio project SDK references. Specify a semicolon-separated list  of SDK references to be added to a generated Visual Studio project, e.g. Microsoft.AdMediatorWindows81, Version=1.0."
+  },
+  "VS_SOLUTION_DEPLOY": {
+    "name": "VS_SOLUTION_DEPLOY",
+    "description": "Specify that the target should be marked for deployment when not targeting Windows CE, Windows Phone or a Windows Store application."
+  },
+  "VS_SOURCE_SETTINGS_<tool>": {
+    "name": "VS_SOURCE_SETTINGS_<tool>",
+    "description": "Set any item metadata on all non-built files that use <tool>."
+  },
+  "VS_USER_PROPS": {
+    "name": "VS_USER_PROPS",
+    "description": "Sets the user props file to be included in the visual studio C++ project file. The standard path is $(UserRootDir)\\\\Microsoft.Cpp.$(Platform).user.props, which is in most cases the same as %LOCALAPPDATA%\\\\Microsoft\\\\MSBuild\\\\v4.0\\\\Microsoft.Cpp.Win32.user.props or %LOCALAPPDATA%\\\\Microsoft\\\\MSBuild\\\\v4.0\\\\Microsoft.Cpp.x64.user.props."
+  },
+  "VS_USE_DEBUG_LIBRARIES": {
+    "name": "VS_USE_DEBUG_LIBRARIES",
+    "description": "Indicate to Visual Studio Generators what configurations are considered debug configurations. This controls the UseDebugLibraries setting in each configuration of a .vcxproj file."
+  },
+  "VS_WINDOWS_TARGET_PLATFORM_MIN_VERSION": {
+    "name": "VS_WINDOWS_TARGET_PLATFORM_MIN_VERSION",
+    "description": "Visual Studio Windows Target Platform Minimum Version"
+  },
+  "VS_WINRT_COMPONENT": {
+    "name": "VS_WINRT_COMPONENT",
+    "description": "Mark a target as a Windows Runtime component for the Visual Studio generator. Compile the target with C++/CX language extensions for Windows Runtime. For SHARED and MODULE libraries, this also defines the _WINRT_DLL preprocessor macro."
+  },
+  "VS_WINRT_EXTENSIONS": {
+    "name": "VS_WINRT_EXTENSIONS",
+    "description": "Deprecated. Use VS_WINRT_COMPONENT instead. This property was an experimental partial implementation of that one."
+  },
+  "VS_WINRT_REFERENCES": {
+    "name": "VS_WINRT_REFERENCES",
+    "description": "Visual Studio project Windows Runtime Metadata references"
+  },
+  "WATCOM_RUNTIME_LIBRARY": {
+    "name": "WATCOM_RUNTIME_LIBRARY",
+    "description": "Select the Watcom runtime library for use by compilers targeting the Watcom ABI."
+  },
+  "WIN32_EXECUTABLE": {
+    "name": "WIN32_EXECUTABLE",
+    "description": "Build an executable with a WinMain entry point on windows."
+  },
+  "WINDOWS_EXPORT_ALL_SYMBOLS": {
+    "name": "WINDOWS_EXPORT_ALL_SYMBOLS",
+    "description": "This property is implemented only for MS-compatible tools on Windows."
+  },
+  "XCODE_ATTRIBUTE_<an-attribute>": {
+    "name": "XCODE_ATTRIBUTE_<an-attribute>",
+    "description": "Set Xcode target attributes directly."
+  },
+  "XCODE_EMBED_FRAMEWORKS_CODE_SIGN_ON_COPY": {
+    "name": "XCODE_EMBED_FRAMEWORKS_CODE_SIGN_ON_COPY",
+    "description": "Tell the Xcode generator to perform code signing for all the frameworks and libraries that are embedded using the XCODE_EMBED_FRAMEWORKS <XCODE_EMBED_<type>> property."
+  },
+  "XCODE_EMBED_FRAMEWORKS_REMOVE_HEADERS_ON_COPY": {
+    "name": "XCODE_EMBED_FRAMEWORKS_REMOVE_HEADERS_ON_COPY",
+    "description": "Tell the Xcode generator to remove headers from all the frameworks that are embedded using the XCODE_EMBED_FRAMEWORKS <XCODE_EMBED_<type>> property."
+  },
+  "XCODE_EMBED_<type>": {
+    "name": "XCODE_EMBED_<type>",
+    "description": "Tell the Xcode generator to embed the specified list of items into the target bundle. <type> specifies the embed build phase to use. See the Xcode documentation for the base location of each <type>."
+  },
+  "XCODE_EMBED_<type>_CODE_SIGN_ON_COPY": {
+    "name": "XCODE_EMBED_<type>_CODE_SIGN_ON_COPY",
+    "description": "Boolean property used only by the Xcode generator. It specifies whether to perform code signing for the items that are embedded using the XCODE_EMBED_ property."
+  },
+  "XCODE_EMBED_<type>_PATH": {
+    "name": "XCODE_EMBED_<type>_PATH",
+    "description": "This property is used only by the Xcode generator. When defined, it specifies the relative path to use when embedding the items specified by XCODE_EMBED_. The path is relative to the base location of the Embed XXX build phase associated with <type>. See the Xcode documentation for the base location of each <type>."
+  },
+  "XCODE_EMBED_<type>_REMOVE_HEADERS_ON_COPY": {
+    "name": "XCODE_EMBED_<type>_REMOVE_HEADERS_ON_COPY",
+    "description": "Boolean property used only by the Xcode generator. It specifies whether to remove headers from all the frameworks that are embedded using the XCODE_EMBED_ property."
+  },
+  "XCODE_GENERATE_SCHEME": {
+    "name": "XCODE_GENERATE_SCHEME",
+    "description": "If enabled, the Xcode generator will generate schema files. These are useful to invoke analyze, archive, build-for-testing and test actions from the command line."
+  },
+  "XCODE_LINK_BUILD_PHASE_MODE": {
+    "name": "XCODE_LINK_BUILD_PHASE_MODE",
+    "description": "When using the Xcode generator, libraries to be linked will be specified in the Xcode project file using either the \"Link Binary With Libraries\" build phase or directly as linker flags. The former allows Xcode to manage build paths, which may be necessary when creating Xcode archives because it may use different build paths to a regular build."
+  },
+  "XCODE_PRODUCT_TYPE": {
+    "name": "XCODE_PRODUCT_TYPE",
+    "description": "Set the Xcode productType attribute on its reference to a target. CMake computes a default based on target type but can be told explicitly with this property."
+  },
+  "XCODE_SCHEME_ADDRESS_SANITIZER": {
+    "name": "XCODE_SCHEME_ADDRESS_SANITIZER",
+    "description": "Whether to enable Address Sanitizer in the Diagnostics section of the generated Xcode scheme."
+  },
+  "XCODE_SCHEME_ADDRESS_SANITIZER_USE_AFTER_RETURN": {
+    "name": "XCODE_SCHEME_ADDRESS_SANITIZER_USE_AFTER_RETURN",
+    "description": "Whether to enable Detect use of stack after return in the Diagnostics section of the generated Xcode scheme."
+  },
+  "XCODE_SCHEME_ARGUMENTS": {
+    "name": "XCODE_SCHEME_ARGUMENTS",
+    "description": "Specify command line arguments that should be added to the Arguments section of the generated Xcode scheme."
+  },
+  "XCODE_SCHEME_DEBUG_AS_ROOT": {
+    "name": "XCODE_SCHEME_DEBUG_AS_ROOT",
+    "description": "Whether to debug the target as 'root'."
+  },
+  "XCODE_SCHEME_DEBUG_DOCUMENT_VERSIONING": {
+    "name": "XCODE_SCHEME_DEBUG_DOCUMENT_VERSIONING",
+    "description": "Whether to enable Allow debugging when using document Versions Browser in the Options section of the generated Xcode scheme."
+  },
+  "XCODE_SCHEME_DISABLE_MAIN_THREAD_CHECKER": {
+    "name": "XCODE_SCHEME_DISABLE_MAIN_THREAD_CHECKER",
+    "description": "Whether to disable the Main Thread Checker in the Diagnostics section of the generated Xcode scheme."
+  },
+  "XCODE_SCHEME_DYNAMIC_LIBRARY_LOADS": {
+    "name": "XCODE_SCHEME_DYNAMIC_LIBRARY_LOADS",
+    "description": "Whether to enable Dynamic Library Loads in the Diagnostics section of the generated Xcode scheme."
+  },
+  "XCODE_SCHEME_DYNAMIC_LINKER_API_USAGE": {
+    "name": "XCODE_SCHEME_DYNAMIC_LINKER_API_USAGE",
+    "description": "Whether to enable Dynamic Linker API usage in the Diagnostics section of the generated Xcode scheme."
+  },
+  "XCODE_SCHEME_ENABLE_GPU_API_VALIDATION": {
+    "name": "XCODE_SCHEME_ENABLE_GPU_API_VALIDATION",
+    "description": "Property value for Metal: API Validation in the Options section of the generated Xcode scheme."
+  },
+  "XCODE_SCHEME_ENABLE_GPU_FRAME_CAPTURE_MODE": {
+    "name": "XCODE_SCHEME_ENABLE_GPU_FRAME_CAPTURE_MODE",
+    "description": "Property value for GPU Frame Capture in the Options section of the generated Xcode scheme. Example values are Metal and Disabled."
+  },
+  "XCODE_SCHEME_ENABLE_GPU_SHADER_VALIDATION": {
+    "name": "XCODE_SCHEME_ENABLE_GPU_SHADER_VALIDATION",
+    "description": "Property value for Metal: Shader Validation in the Options section of the generated Xcode scheme."
+  },
+  "XCODE_SCHEME_ENVIRONMENT": {
+    "name": "XCODE_SCHEME_ENVIRONMENT",
+    "description": "Specify environment variables that should be added to the Arguments section of the generated Xcode scheme."
+  },
+  "XCODE_SCHEME_EXECUTABLE": {
+    "name": "XCODE_SCHEME_EXECUTABLE",
+    "description": "Specify path to executable in the Info section of the generated Xcode scheme. If not set the schema generator will select the current target if it is actually executable."
+  },
+  "XCODE_SCHEME_GUARD_MALLOC": {
+    "name": "XCODE_SCHEME_GUARD_MALLOC",
+    "description": "Whether to enable Guard Malloc in the Diagnostics section of the generated Xcode scheme."
+  },
+  "XCODE_SCHEME_LAUNCH_CONFIGURATION": {
+    "name": "XCODE_SCHEME_LAUNCH_CONFIGURATION",
+    "description": "Set the build configuration to run the target."
+  },
+  "XCODE_SCHEME_LAUNCH_MODE": {
+    "name": "XCODE_SCHEME_LAUNCH_MODE",
+    "description": "Property value for Launch in the Info section of the generated Xcode scheme."
+  },
+  "XCODE_SCHEME_MAIN_THREAD_CHECKER_STOP": {
+    "name": "XCODE_SCHEME_MAIN_THREAD_CHECKER_STOP",
+    "description": "Whether to enable the Main Thread Checker option Pause on issues in the Diagnostics section of the generated Xcode scheme."
+  },
+  "XCODE_SCHEME_MALLOC_GUARD_EDGES": {
+    "name": "XCODE_SCHEME_MALLOC_GUARD_EDGES",
+    "description": "Whether to enable Malloc Guard Edges in the Diagnostics section of the generated Xcode scheme."
+  },
+  "XCODE_SCHEME_MALLOC_SCRIBBLE": {
+    "name": "XCODE_SCHEME_MALLOC_SCRIBBLE",
+    "description": "Whether to enable Malloc Scribble in the Diagnostics section of the generated Xcode scheme."
+  },
+  "XCODE_SCHEME_MALLOC_STACK": {
+    "name": "XCODE_SCHEME_MALLOC_STACK",
+    "description": "Whether to enable Malloc Stack in the Diagnostics section of the generated Xcode scheme."
+  },
+  "XCODE_SCHEME_THREAD_SANITIZER": {
+    "name": "XCODE_SCHEME_THREAD_SANITIZER",
+    "description": "Whether to enable Thread Sanitizer in the Diagnostics section of the generated Xcode scheme."
+  },
+  "XCODE_SCHEME_THREAD_SANITIZER_STOP": {
+    "name": "XCODE_SCHEME_THREAD_SANITIZER_STOP",
+    "description": "Whether to enable Thread Sanitizer - Pause on issues in the Diagnostics section of the generated Xcode scheme."
+  },
+  "XCODE_SCHEME_UNDEFINED_BEHAVIOUR_SANITIZER": {
+    "name": "XCODE_SCHEME_UNDEFINED_BEHAVIOUR_SANITIZER",
+    "description": "Whether to enable Undefined Behavior Sanitizer in the Diagnostics section of the generated Xcode scheme."
+  },
+  "XCODE_SCHEME_UNDEFINED_BEHAVIOUR_SANITIZER_STOP": {
+    "name": "XCODE_SCHEME_UNDEFINED_BEHAVIOUR_SANITIZER_STOP",
+    "description": "Whether to enable Undefined Behavior Sanitizer option Pause on issues in the Diagnostics section of the generated Xcode scheme."
+  },
+  "XCODE_SCHEME_WORKING_DIRECTORY": {
+    "name": "XCODE_SCHEME_WORKING_DIRECTORY",
+    "description": "Specify the Working Directory of the Run and Profile actions in the generated Xcode scheme. In case the value contains generator expressions those are evaluated."
+  },
+  "XCODE_SCHEME_ZOMBIE_OBJECTS": {
+    "name": "XCODE_SCHEME_ZOMBIE_OBJECTS",
+    "description": "Whether to enable Zombie Objects in the Diagnostics section of the generated Xcode scheme."
+  },
+  "XCODE_XCCONFIG": {
+    "name": "XCODE_XCCONFIG",
+    "description": "If set, the Xcode generator will register the specified file as a target-level XCConfig file. For global XCConfig files see the CMAKE_XCODE_XCCONFIG variable."
+  },
+  "XCTEST": {
+    "name": "XCTEST",
+    "description": "This target is a XCTest CFBundle on the Mac."
+  }
+}

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -255,6 +255,13 @@ const generateJsonSchemaLoc = () => {
 
 gulp.task('translations-generate', gulp.series(generatedSrcLocBundle, generatedAdditionalLocFiles, generateJsonSchemaLoc));
 
+// TODO: Insert task that grabs the language services assets and drops them in a folder, maybe called 'data'.
+
+const languageServices = () => {
+    return gulp.src(["assets/*.json"]).pipe(gulp.dest("assets"));
+}
+gulp.task('language-services', languageServices);
+
 const allTypeScript = [
     'src/**/*.ts',
     'test/**/*.ts',

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -26,6 +26,11 @@ const jsonSchemaFilesPatterns = [
     "*/*-schema.json"
 ];
 
+// Patterns to find language services json files. 
+const languageServicesFilesPatterns = [
+    "assets/*.json"
+];
+
 const languages = [
     { id: "zh-tw", folderName: "cht", transifexId: "zh-hant" },
     { id: "zh-cn", folderName: "chs", transifexId: "zh-hans" },
@@ -94,7 +99,7 @@ const traverseJson = (jsonTree, descriptionCallback, prefixPath) => {
 
 // Traverses schema json files looking for "description" fields to localized.
 // The path to the "description" field is used to create a localization key.
-const processJsonSchemaFiles = () => {
+const processJsonFiles = () => {
     return es.through(function (file) {
         let jsonTree = JSON.parse(file.contents.toString());
         let localizationJsonContents = {};
@@ -133,10 +138,13 @@ gulp.task("translations-export", (done) => {
 
     // Scan schema files
     let jsonSchemaStream = gulp.src(jsonSchemaFilesPatterns)
-        .pipe(processJsonSchemaFiles());
+        .pipe(processJsonFiles());
+
+    let jsonLanguageServicesStream = gulp.src(languageServicesFilesPatterns)
+        .pipe(processJsonFiles());
 
     // Merge files from all source streams
-    es.merge(jsStream, jsonSchemaStream)
+    es.merge(jsStream, jsonSchemaStream, jsonLanguageServicesStream)
 
     // Filter down to only the files we need
     .pipe(filter(['**/*.nls.json', '**/*.nls.metadata.json']))
@@ -214,7 +222,7 @@ const generatedSrcLocBundle = () => {
         .pipe(gulp.dest('dist'));
 };
 
-const generateLocalizedJsonSchemaFiles = () => {
+const generateLocalizedJsonFiles = (paths) => {
     return es.through(function (file) {
         let jsonTree = JSON.parse(file.contents.toString());
         languages.map((language) => {
@@ -237,7 +245,7 @@ const generateLocalizedJsonSchemaFiles = () => {
             traverseJson(jsonTree, descriptionCallback, "");
             let newContent = JSON.stringify(jsonTree, null, '\t');
             this.queue(new vinyl({
-                path: path.join("schema", language.id, relativePath),
+                path: path.join(...paths, language.id, relativePath),
                 contents: Buffer.from(newContent, 'utf8')
             }));
         });
@@ -249,18 +257,17 @@ const generateLocalizedJsonSchemaFiles = () => {
 // Generate new version of the JSON schema file in dist/schema/<language_id>/<path>
 const generateJsonSchemaLoc = () => {
     return gulp.src(jsonSchemaFilesPatterns)
-        .pipe(generateLocalizedJsonSchemaFiles())
+        .pipe(generateLocalizedJsonFiles(["schema"]))
         .pipe(gulp.dest('dist'));
 };
 
-gulp.task('translations-generate', gulp.series(generatedSrcLocBundle, generatedAdditionalLocFiles, generateJsonSchemaLoc));
+const generateJsonLanguageServicesLoc = () => {
+    return gulp.src(languageServicesFilesPatterns)
+        .pipe(generateLocalizedJsonFiles(["languageServices"]))
+        .pipe(gulp.dest('dist'));
+};
 
-// TODO: Insert task that grabs the language services assets and drops them in a folder, maybe called 'data'.
-
-const languageServices = () => {
-    return gulp.src(["assets/*.json"]).pipe(gulp.dest("assets"));
-}
-gulp.task('language-services', languageServices);
+gulp.task('translations-generate', gulp.series(generatedSrcLocBundle, generatedAdditionalLocFiles, generateJsonSchemaLoc, generateJsonLanguageServicesLoc));
 
 const allTypeScript = [
     'src/**/*.ts',

--- a/package.json
+++ b/package.json
@@ -3735,7 +3735,7 @@
   "scripts": {
     "compile": "yarn install && webpack --mode development",
     "compile-watch": "yarn install && webpack --mode development --watch --progress",
-    "compile-production": "yarn install && yarn run translations-generate && yarn run language-services && webpack --env BUILD_VSCODE_NLS=true --mode production",
+    "compile-production": "yarn install && yarn run translations-generate && webpack --env BUILD_VSCODE_NLS=true --mode production",
     "translations-export": "gulp translations-export",
     "translations-generate": "gulp translations-generate",
     "translations-import": "gulp translations-import",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
   },
   "categories": [
     "Other",
-    "Debuggers"
+    "Debuggers",
+    "Programming Languages"
   ],
   "galleryBanner": {
     "color": "#13578c",
@@ -63,7 +64,9 @@
     "workspaceContains:*/*/CMakeLists.txt",
     "workspaceContains:*/*/*/CMakeLists.txt",
     "workspaceContains:.vscode/cmake-kits.json",
-    "onFileSystem:cmake-tools-schema"
+    "onFileSystem:cmake-tools-schema",
+    "onLanguage:cmake",
+    "onLanguage:cmake-cache"
   ],
   "main": "./dist/main",
   "contributes": {
@@ -111,6 +114,31 @@
         }
       }
     },
+    "languages": [
+        {
+            "id": "cmake",
+            "extensions": [".cmake"],
+            "filenames": ["CMakelists.txt"],
+            "aliases": ["CMake"]
+        },
+        {
+            "id": "cmake-cache",
+            "filenames": ["CMakeCache.txt"],
+            "aliases": ["CMake Cache"]
+        }
+    ],
+    "grammars": [
+        {
+            "language": "cmake",
+            "scopeName": "source.cmake",
+            "path": "./syntaxes/CMake.tmLanguage."
+        },
+        {
+            "language": "cmake-cache",
+            "scopeName": "source.cmakecache",
+            "path": "./syntaxes/CMakeCache.tmLanguage."
+        }
+    ],
     "commands": [
       {
         "command": "cmake.openCMakePresets",
@@ -3817,8 +3845,5 @@
     "minimatch": "^3.0.5",
     "**/braces": "^3.0.3"
   },
-  "extensionPack": [
-    "twxs.cmake"
-  ],
   "packageManager": "yarn@1.22.19"
 }

--- a/package.json
+++ b/package.json
@@ -131,12 +131,12 @@
         {
             "language": "cmake",
             "scopeName": "source.cmake",
-            "path": "./syntaxes/CMake.tmLanguage."
+            "path": "./syntaxes/CMake.tmLanguage"
         },
         {
             "language": "cmake-cache",
             "scopeName": "source.cmakecache",
-            "path": "./syntaxes/CMakeCache.tmLanguage."
+            "path": "./syntaxes/CMakeCache.tmLanguage"
         }
     ],
     "commands": [
@@ -3735,7 +3735,7 @@
   "scripts": {
     "compile": "yarn install && webpack --mode development",
     "compile-watch": "yarn install && webpack --mode development --watch --progress",
-    "compile-production": "yarn install && yarn run translations-generate && webpack --env BUILD_VSCODE_NLS=true --mode production",
+    "compile-production": "yarn install && yarn run translations-generate && yarn run language-services && webpack --env BUILD_VSCODE_NLS=true --mode production",
     "translations-export": "gulp translations-export",
     "translations-generate": "gulp translations-generate",
     "translations-import": "gulp translations-import",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2357,6 +2357,57 @@ export async function activate(context: vscode.ExtensionContext): Promise<api.CM
         await vscode.window.showWarningMessage(localize('uninstall.old.cmaketools', 'Please uninstall any older versions of the CMake Tools extension. It is now published by Microsoft starting with version 1.2.0.'));
     }
 
+    const CMAKE_LANGUAGE = "cmake";
+
+    vscode.languages.setLanguageConfiguration(CMAKE_LANGUAGE, {
+        indentationRules: {
+            // ^(.*\*/)?\s*\}.*$
+            decreaseIndentPattern: /^(.*\*\/)?\s*\}.*$/,
+            // ^.*\{[^}"']*$
+            increaseIndentPattern: /^.*\{[^}"']*$/
+        },
+        wordPattern: /(-?\d*\.\d\w*)|([^\`\~\!\@\#\%\^\&\*\(\)\-\=\+\[\{\]\}\\\|\;\:\'\"\,\.\<\>\/\?\s]+)/g,
+        comments: {
+            lineComment: '#'
+        },
+        brackets: [
+            ['{', '}'],
+            ['(', ')']
+        ],
+
+        __electricCharacterSupport: {
+            brackets: [
+                { tokenType: 'delimiter.curly.ts', open: '{', close: '}', isElectric: true },
+                { tokenType: 'delimiter.square.ts', open: '[', close: ']', isElectric: true },
+                { tokenType: 'delimiter.paren.ts', open: '(', close: ')', isElectric: true }
+            ]
+        },
+
+        __characterPairSupport: {
+            autoClosingPairs: [
+                { open: '{', close: '}' },
+                { open: '(', close: ')' },
+                { open: '"', close: '"', notIn: ['string'] }
+            ]
+        }
+    });
+
+    if (vscode.workspace.getConfiguration('cmake').get('showOptionsMovedNotification')) {
+        void vscode.window.showInformationMessage(
+            localize('options.moved.notification.body', "Some status bar options in CMake Tools have now moved to the Project Status View in the CMake Tools sidebar. You can customize your view with the 'cmake.options' property in settings."),
+            localize('options.moved.notification.configure.cmake.options', 'Configure CMake Options Visibility'),
+            localize('options.moved.notification.do.not.show', "Do Not Show Again")
+        ).then(async (selection) => {
+            if (selection !== undefined) {
+                if (selection === localize('options.moved.notification.configure.cmake.options', 'Configure CMake Options Visibility')) {
+                    await vscode.commands.executeCommand('workbench.action.openSettings', 'cmake.options');
+                } else if (selection === localize('options.moved.notification.do.not.show', "Do Not Show Again")) {
+                    await vscode.workspace.getConfiguration('cmake').update('showOptionsMovedNotification', false, vscode.ConfigurationTarget.Global);
+                }
+            }
+        });
+    }
+
     // Start with a partial feature set view. The first valid CMake project will cause a switch to full feature set.
     await enableFullFeatureSet(false);
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -49,6 +49,8 @@ import { getCMakeExecutableInformation } from '@cmt/cmakeExecutable';
 import { DebuggerInformation, getDebuggerPipeName } from '@cmt/debug/cmakeDebugger/debuggerConfigureDriver';
 import { DebugConfigurationProvider, DynamicDebugConfigurationProvider } from '@cmt/debug/cmakeDebugger/debugConfigurationProvider';
 import { deIntegrateTestExplorer } from "@cmt/ctest";
+import { LanguageServiceData } from './languageServices/languageServiceData';
+import { file } from 'tmp';
 
 nls.config({ messageFormat: nls.MessageFormat.bundle, bundleFormat: nls.BundleFormat.standalone })();
 const localize: nls.LocalizeFunc = nls.loadMessageBundle();
@@ -2358,6 +2360,14 @@ export async function activate(context: vscode.ExtensionContext): Promise<api.CM
     }
 
     const CMAKE_LANGUAGE = "cmake";
+    const CMAKE_SELECTOR: vscode.DocumentSelector = [
+        { language: CMAKE_LANGUAGE, scheme: 'file'},
+        { language: CMAKE_LANGUAGE, scheme: 'untitled'}
+    ];
+
+    const languageServices = await LanguageServiceData.create();
+    vscode.languages.registerHoverProvider(CMAKE_SELECTOR, languageServices);
+    vscode.languages.registerCompletionItemProvider(CMAKE_SELECTOR, languageServices);
 
     vscode.languages.setLanguageConfiguration(CMAKE_LANGUAGE, {
         indentationRules: {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -50,7 +50,6 @@ import { DebuggerInformation, getDebuggerPipeName } from '@cmt/debug/cmakeDebugg
 import { DebugConfigurationProvider, DynamicDebugConfigurationProvider } from '@cmt/debug/cmakeDebugger/debugConfigurationProvider';
 import { deIntegrateTestExplorer } from "@cmt/ctest";
 import { LanguageServiceData } from './languageServices/languageServiceData';
-import { file } from 'tmp';
 
 nls.config({ messageFormat: nls.MessageFormat.bundle, bundleFormat: nls.BundleFormat.standalone })();
 const localize: nls.LocalizeFunc = nls.loadMessageBundle();
@@ -2365,9 +2364,13 @@ export async function activate(context: vscode.ExtensionContext): Promise<api.CM
         { language: CMAKE_LANGUAGE, scheme: 'untitled'}
     ];
 
-    const languageServices = await LanguageServiceData.create();
-    vscode.languages.registerHoverProvider(CMAKE_SELECTOR, languageServices);
-    vscode.languages.registerCompletionItemProvider(CMAKE_SELECTOR, languageServices);
+    try {
+        const languageServices = await LanguageServiceData.create();
+        vscode.languages.registerHoverProvider(CMAKE_SELECTOR, languageServices);
+        vscode.languages.registerCompletionItemProvider(CMAKE_SELECTOR, languageServices);
+    } catch {
+        log.error(localize('language.service.failed', 'Failed to initialize language services'));
+    }
 
     vscode.languages.setLanguageConfiguration(CMAKE_LANGUAGE, {
         indentationRules: {

--- a/src/languageServices/languageServiceData.ts
+++ b/src/languageServices/languageServiceData.ts
@@ -1,0 +1,68 @@
+import * as vscode from "vscode";
+import * as path from "path";
+import { fs } from "@cmt/pr";
+import { thisExtensionPath } from "@cmt/util";
+
+interface Commands {
+    [key: string]: Command;
+}
+
+interface Command {
+    name: string;
+    description: string;
+    syntax_examples: string;
+}
+
+interface Variables {
+    [key: string]: Variable;
+}
+
+interface Variable {
+    name: string;
+    description: string;
+}
+
+export class LanguageServiceData implements vscode.HoverProvider, vscode.CompletionItemProvider {
+    private commandsJson: Commands = {};
+    private variablesJson: Variables = {};
+
+    private constructor() {
+    }
+
+    private async load(): Promise<void> {
+        const test = thisExtensionPath();
+        console.log(test);
+        this.commandsJson = JSON.parse(await fs.readFile(path.join(thisExtensionPath(), 'assets', 'commands.json')));
+        this.variablesJson = JSON.parse(await fs.readFile(path.join(thisExtensionPath(), 'assets', 'variables.json')));
+    }
+
+    public static async create(): Promise<LanguageServiceData> {
+        const data = new LanguageServiceData();
+        await data.load();
+        return data;
+    }
+
+    provideCompletionItems(_document: vscode.TextDocument, _position: vscode.Position, _token: vscode.CancellationToken, _context: vscode.CompletionContext): vscode.ProviderResult<vscode.CompletionItem[] | vscode.CompletionList> {
+        return null;
+    }
+
+    resolveCompletionItem?(_item: vscode.CompletionItem, _token: vscode.CancellationToken): vscode.ProviderResult<vscode.CompletionItem> {
+        return null;
+    }
+
+    provideHover(document: vscode.TextDocument, position: vscode.Position, token: vscode.CancellationToken): vscode.ProviderResult<vscode.Hover> {
+        const range = document.getWordRangeAtPosition(position);
+        const value = document.getText(range);
+
+        if (token.isCancellationRequested) {
+            return null;
+        }
+
+        const hoverSuggestions = this.commandsJson[value] || this.variablesJson[value];
+        if (hoverSuggestions) {
+            return new vscode.Hover({language: 'md', value: hoverSuggestions.description });
+        }
+
+        return null;
+    }
+}

--- a/src/languageServices/languageServiceData.ts
+++ b/src/languageServices/languageServiceData.ts
@@ -52,8 +52,6 @@ export class LanguageServiceData implements vscode.HoverProvider, vscode.Complet
     }
 
     private async load(): Promise<void> {
-        const test = thisExtensionPath();
-        console.log(test);
         const locale: string = util.getLocaleId();
         this.commands = JSON.parse(await this.getFile("commands.json", locale));
         this.variables = JSON.parse(await this.getFile("variables.json", locale));

--- a/src/languageServices/languageServiceData.ts
+++ b/src/languageServices/languageServiceData.ts
@@ -24,7 +24,7 @@ interface Variable {
 
 export class LanguageServiceData implements vscode.HoverProvider, vscode.CompletionItemProvider {
     private commandsJson: Commands = {};
-    private variablesJson: Variables = {};
+    private variablesJson: Variables = {}; // variables and properties
 
     private constructor() {
     }
@@ -59,6 +59,7 @@ export class LanguageServiceData implements vscode.HoverProvider, vscode.Complet
             if (this.commandsJson[key].name.includes(currentWord)) {
                 const completionItem = new vscode.CompletionItem(this.commandsJson[key].name);
                 completionItem.insertText = (this.commandsJson[key].name);
+                completionItem.kind = vscode.CompletionItemKind.Function;
                 return completionItem;
             }
             return null;
@@ -66,6 +67,7 @@ export class LanguageServiceData implements vscode.HoverProvider, vscode.Complet
             if (this.variablesJson[key].name.includes(currentWord)) {
                 const completionItem = new vscode.CompletionItem(this.variablesJson[key].name);
                 completionItem.insertText = (this.variablesJson[key].name);
+                completionItem.kind = vscode.CompletionItemKind.Variable;
                 return completionItem;
             }
             return null;
@@ -74,8 +76,8 @@ export class LanguageServiceData implements vscode.HoverProvider, vscode.Complet
         return suggestions as vscode.CompletionItem[];
     }
 
-    resolveCompletionItem?(_item: vscode.CompletionItem, _token: vscode.CancellationToken): vscode.ProviderResult<vscode.CompletionItem> {
-        return null;
+    resolveCompletionItem?(item: vscode.CompletionItem, _token: vscode.CancellationToken): vscode.ProviderResult<vscode.CompletionItem> {
+        return item;
     }
 
     provideHover(document: vscode.TextDocument, position: vscode.Position, token: vscode.CancellationToken): vscode.ProviderResult<vscode.Hover> {
@@ -90,7 +92,7 @@ export class LanguageServiceData implements vscode.HoverProvider, vscode.Complet
 
         const markdown: vscode.MarkdownString = new vscode.MarkdownString();
         markdown.appendMarkdown(hoverSuggestions.description);
-        hoverSuggestions.syntax_examples.forEach((example) => {
+        hoverSuggestions.syntax_examples?.forEach((example) => {
             markdown.appendCodeblock(`\t${example}`, "cmake");
         });
 

--- a/src/languageServices/languageServiceData.ts
+++ b/src/languageServices/languageServiceData.ts
@@ -2,6 +2,7 @@ import * as vscode from "vscode";
 import * as path from "path";
 import { fs } from "@cmt/pr";
 import { thisExtensionPath } from "@cmt/util";
+import * as util from "@cmt/util";
 
 interface Commands {
     [key: string]: Command;
@@ -35,12 +36,22 @@ export class LanguageServiceData implements vscode.HoverProvider, vscode.Complet
     private constructor() {
     }
 
+    private async getFile(fileEnding: string, locale: string): Promise<string> {
+        let filePath: string = path.join(thisExtensionPath(), 'dist/languageServices', locale, 'assets', fileEnding);
+        const fileExists: boolean = await util.checkFileExists(filePath);
+        if (!fileExists) {
+            filePath = path.join(thisExtensionPath(), 'assets', fileEnding);
+        }
+        return fs.readFile(filePath);
+    }
+
     private async load(): Promise<void> {
         const test = thisExtensionPath();
         console.log(test);
-        this.commands = JSON.parse(await fs.readFile(path.join(thisExtensionPath(), 'assets', 'commands.json')));
-        this.variables = JSON.parse(await fs.readFile(path.join(thisExtensionPath(), 'assets', 'variables.json')));
-        this.modules = JSON.parse(await fs.readFile(path.join(thisExtensionPath(), 'assets', 'modules.json')));
+        const locale: string = util.getLocaleId();
+        this.commands = JSON.parse(await this.getFile('commands.json', locale));
+        this.variables = JSON.parse(await this.getFile('variables.json', locale));
+        this.modules = JSON.parse(await this.getFile('modules.json', locale));
     }
 
     public static async create(): Promise<LanguageServiceData> {


### PR DESCRIPTION
This PR accomplishes the following: 
- Removes the dependency on the third party `twxs.cmake` extension. Thanks @twxs for your work in that extension!
- Add support into our extension for the following:
    - Quick Info for built-in modules, variables, properties, and functions.
    - Completions for built-in modules, variables, properties, and functions.

This does this by including JSON files in our repository that house information for language services and we load these on activation of the extension. This enhances the performance of providing completions and quick info information. 

The main implementation points in this PR: 
- Bundling the language services json assets into the vsix (gulpfile.js, etc.)
- Integrating with the VS Code Language Service API to implement quick hover and completions (src/languageServices)

Fixes #3559. Fixes #534. Fixes #3560