### PR TITLE
Fix_3598

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Features:
 
 Improvements:
 
+- Add ability to pass custom target to "CMake: Build Target" command as argument. [#3598](https://github.com/microsoft/vscode-cmake-tools/issues/3598)
 - Fix "Unable to resolve configuration with compilerPath" issue for Swift. [#4097](https://github.com/microsoft/vscode-cmake-tools/issues/4097)
 - Ensure that any uses of `proc.spawn` work, especially for .bat and .cmd files, due to VS Code updating to Node 20. [#4037](https://github.com/microsoft/vscode-cmake-tools/issues/4037)
 - Fix "Test output isn't visible when failed" and also mark skipped tests as so. [#4116](https://github.com/microsoft/vscode-cmake-tools/issues/4116)

--- a/src/cmakeProject.ts
+++ b/src/cmakeProject.ts
@@ -2228,8 +2228,8 @@ export class CMakeProject {
         return 0;
     }
 
-    async buildWithTarget(specified_target: string | null = null): Promise<number> {
-        const target_selector = async (spec_target: string | null) => {
+    async buildWithTarget(specified_target?: string): Promise<number> {
+        const target_selector = async (spec_target: string | undefined) => {
             if (!spec_target) {
                 return this.showTargetSelector();
             }

--- a/src/cmakeProject.ts
+++ b/src/cmakeProject.ts
@@ -75,7 +75,7 @@ export enum ConfigureTrigger {
     api = "api",
     runTests = "runTests",
     package = "package",
-    workflow =  "workflow",
+    workflow = "workflow",
     badHomeDir = "badHomeDir",
     configureOnOpen = "configureOnOpen",
     configureWithCache = "configureWithCache",
@@ -314,7 +314,7 @@ export class CMakeProject {
         preset.updateCachedExpandedPreset(this.folderPath, expandedConfigurePreset, "configurePresets");
 
         // Make sure we pass CMakeDriver the preset defined env as well as the parent env
-        expandedConfigurePreset.environment =  EnvironmentUtils.mergePreserveNull([expandedConfigurePreset.__parentEnvironment, expandedConfigurePreset.environment]);
+        expandedConfigurePreset.environment = EnvironmentUtils.mergePreserveNull([expandedConfigurePreset.__parentEnvironment, expandedConfigurePreset.environment]);
 
         return expandedConfigurePreset;
     }
@@ -411,7 +411,7 @@ export class CMakeProject {
         }
 
         // Make sure we pass CMakeDriver the preset defined env as well as the parent env
-        expandedBuildPreset.environment =  EnvironmentUtils.mergePreserveNull([expandedBuildPreset.__parentEnvironment, expandedBuildPreset.environment]);
+        expandedBuildPreset.environment = EnvironmentUtils.mergePreserveNull([expandedBuildPreset.__parentEnvironment, expandedBuildPreset.environment]);
 
         return expandedBuildPreset;
     }
@@ -505,7 +505,7 @@ export class CMakeProject {
         }
 
         // Make sure we pass CMakeDriver the preset defined env as well as the parent env
-        expandedTestPreset.environment =  EnvironmentUtils.mergePreserveNull([expandedTestPreset.__parentEnvironment, expandedTestPreset.environment]);
+        expandedTestPreset.environment = EnvironmentUtils.mergePreserveNull([expandedTestPreset.__parentEnvironment, expandedTestPreset.environment]);
 
         return expandedTestPreset;
     }
@@ -599,7 +599,7 @@ export class CMakeProject {
         }
 
         // Make sure we pass CMakeDriver the preset defined env as well as the parent env
-        expandedPackagePreset.environment =  EnvironmentUtils.mergePreserveNull([expandedPackagePreset.__parentEnvironment, expandedPackagePreset.environment]);
+        expandedPackagePreset.environment = EnvironmentUtils.mergePreserveNull([expandedPackagePreset.__parentEnvironment, expandedPackagePreset.environment]);
 
         return expandedPackagePreset;
     }
@@ -1002,7 +1002,7 @@ export class CMakeProject {
                             // Keep the absolute path for CMakeLists.txt files that are located outside of the workspace folder.
                             selectedFile = cmakeListsFile[0].fsPath;
                         }
-                    } else if (selection.label === dontAskAgain)  {
+                    } else if (selection.label === dontAskAgain) {
                         await vscode.workspace.getConfiguration('cmake', this.workspaceFolder).update('ignoreCMakeListsMissing', true, vscode.ConfigurationTarget.WorkspaceFolder);
                     } else {
                         // Keep the relative path for CMakeLists.txt files that are located inside of the workspace folder.
@@ -1740,9 +1740,9 @@ export class CMakeProject {
                                     const doNotShowAgainTitle = localize('options.configureWithDebuggerOnFail.do.not.show', "Don't Show Again");
                                     void vscode.window.showErrorMessage<MessageItem>(
                                         localize('configure.failed.tryWithDebugger', 'Configure failed. Would you like to attempt to configure with the CMake Debugger?'),
-                                        {title: yesButtonTitle},
-                                        {title: localize('no.configureWithDebugger.button', 'Cancel')},
-                                        {title: doNotShowAgainTitle})
+                                        { title: yesButtonTitle },
+                                        { title: localize('no.configureWithDebugger.button', 'Cancel') },
+                                        { title: doNotShowAgainTitle })
                                         .then(async chosen => {
                                             if (chosen) {
                                                 if (chosen.title === yesButtonTitle) {
@@ -2228,8 +2228,14 @@ export class CMakeProject {
         return 0;
     }
 
-    async buildWithTarget(): Promise<number> {
-        const target = await this.showTargetSelector();
+    async buildWithTarget(specified_target: string | null = null): Promise<number> {
+        const target_selector = async (spec_target: string | null) => {
+            if (!spec_target) {
+                return this.showTargetSelector();
+            }
+            return spec_target;
+        };
+        const target = await target_selector(specified_target);
         if (target === null) {
             return -1;
         }
@@ -2795,7 +2801,7 @@ export class CMakeProject {
         env = EnvironmentUtils.merge([configureEnv, env]);
 
         if (debugEnv) {
-            const options = {... await this.getExpansionOptions(), envOverride: env, penvOverride: configureEnv };
+            const options = { ... await this.getExpansionOptions(), envOverride: env, penvOverride: configureEnv };
             for (const envPair of debugEnv) {
                 env[envPair.name] = await expandString(envPair.value, options);
             }
@@ -3084,7 +3090,7 @@ export class CMakeProject {
                 label: 'CTest',
                 description: localize('ctest.support', 'CTest support')
             }
-        ], { canPickMany: true, placeHolder: localize('select.additional.options', 'Select additional options')}));
+        ], { canPickMany: true, placeHolder: localize('select.additional.options', 'Select additional options') }));
 
         // select current c/cpp files to add as targets, if any. If none, or none are selected, create a new one
         const files = await fs.readdir(this.sourceDir);
@@ -3101,7 +3107,7 @@ export class CMakeProject {
         const type = targetType.label;
         const lang = targetLang.label;
         const langName = lang === "C++" ? "C CXX" : "C";
-        const langExt  = lang === "C++" ? "cpp" : "c";
+        const langExt = lang === "C++" ? "cpp" : "c";
 
         let failedToCreate = false;
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1428,7 +1428,7 @@ export class ExtensionManager implements vscode.Disposable {
         return this.runCMakeCommandForAll(cmakeProject => cmakeProject.cleanRebuild(), this.ensureActiveBuildPreset, true);
     }
 
-    async buildWithTarget() {
+    async buildWithTarget(target?: string) {
         telemetry.logEvent("build", { command: "buildWithTarget", all: "false"});
         this.cleanOutputChannel();
         let activeProject: CMakeProject | undefined = this.getActiveProject();
@@ -1438,7 +1438,7 @@ export class ExtensionManager implements vscode.Disposable {
                 return; // Error or nothing is opened
             }
         } else {
-            return activeProject.buildWithTarget();
+            return activeProject.buildWithTarget(target);
         }
     }
 


### PR DESCRIPTION
## This change addresses item #3598

### This changes visible behavior

The following changes are proposed:

- Add optional argument to `buildWithTarget` method of the `CMakeProject` class;
- Add optional argument to `buildWithTarget` method of the `ExtensionManager` class.

## Other Notes/Information

This MR enable the use of a custom task that executes `buildWithTarget` command given an argument.
The video below show this:

[BuildWithTarget.webm](https://github.com/user-attachments/assets/acf24660-8feb-4cce-8d67-3ff56f167df0)

Please note two things:
- I get a "Cannot substitute input variable ..." warning message
- This MR does not override the `CMake: Build Target` palette command whereas it was probably the original demand in #3598. Please not that this would probably require to solve #1601 ?

I did not add test for this. Please let me know if it is necessary.
