### PR TITLE
Correct usage of toolset and architecture when no `configurepreset.generator` is defined in the preset. 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Bug Fixes:
 - Ensure that tests are updated after a build. [#4148](https://github.com/microsoft/vscode-cmake-tools/pull/4148)
 - Fix various GCC compiler errors and GCC linker errors not showing up in Problems View [#2864](https://github.com/microsoft/vscode-cmake-tools/issues/2864)
 - Fix reloading presets when included files are changed or renamed and updated. [#3963](https://github.com/microsoft/vscode-cmake-tools/issues/3963)
+- Fix the usage of toolset and archiecture in presets without generator set. [#4181](https://github.com/microsoft/vscode-cmake-tools/issues/4181)
 
 ## 1.19.52
 

--- a/src/drivers/cmakeDriver.ts
+++ b/src/drivers/cmakeDriver.ts
@@ -390,7 +390,7 @@ export abstract class CMakeDriver implements vscode.Disposable {
         return this._useCMakePresets;
     }
 
-    private _configurePreset: preset.ConfigurePreset | null = null;
+    protected _configurePreset: preset.ConfigurePreset | null = null;
 
     private _buildPreset: preset.BuildPreset | null = null;
 

--- a/src/drivers/cmakeDriver.ts
+++ b/src/drivers/cmakeDriver.ts
@@ -390,7 +390,15 @@ export abstract class CMakeDriver implements vscode.Disposable {
         return this._useCMakePresets;
     }
 
-    protected _configurePreset: preset.ConfigurePreset | null = null;
+    get configurePresetArchitecture(): string | preset.ValueStrategy | undefined {
+        return this._configurePreset?.architecture;
+    }
+
+    get configurePresetToolset(): string | preset.ValueStrategy | undefined {
+        return this._configurePreset?.toolset;
+    }
+
+    private _configurePreset: preset.ConfigurePreset | null = null;
 
     private _buildPreset: preset.BuildPreset | null = null;
 

--- a/src/drivers/cmakeFileApiDriver.ts
+++ b/src/drivers/cmakeFileApiDriver.ts
@@ -32,6 +32,7 @@ import { DebuggerInformation } from '@cmt/debug/cmakeDebugger/debuggerConfigureD
 import { CMakeOutputConsumer, StateMessage } from '@cmt/diagnostics/cmake';
 import { ConfigureTrigger } from '@cmt/cmakeProject';
 import { onConfigureSettingsChange } from '@cmt/ui/util';
+import { targetArchFromGeneratorPlatform } from '@cmt/installs/visualStudio';
 
 nls.config({ messageFormat: nls.MessageFormat.bundle, bundleFormat: nls.BundleFormat.standalone })();
 const localize: nls.LocalizeFunc = nls.loadMessageBundle();
@@ -249,6 +250,17 @@ export class CMakeFileApiDriver extends CMakeDriver {
                 if (generator.platform) {
                     args.push('-A');
                     args.push(generator.platform);
+                }
+            } else {
+                const platform = this._configurePreset?.architecture ? getValue(this._configurePreset.architecture) : undefined;
+                const toolset = this._configurePreset?.toolset ? getValue(this._configurePreset.toolset) : undefined;
+                if (toolset) {
+                    args.push('-T');
+                    args.push(toolset);
+                }
+                if (platform) {
+                    args.push("-A");
+                    args.push(platform);
                 }
             }
         }

--- a/src/drivers/cmakeFileApiDriver.ts
+++ b/src/drivers/cmakeFileApiDriver.ts
@@ -252,15 +252,19 @@ export class CMakeFileApiDriver extends CMakeDriver {
                     args.push(generator.platform);
                 }
             } else {
-                const platform = this._configurePreset?.architecture ? getValue(this._configurePreset.architecture) : undefined;
-                const toolset = this._configurePreset?.toolset ? getValue(this._configurePreset.toolset) : undefined;
-                if (toolset) {
-                    args.push('-T');
-                    args.push(toolset);
-                }
-                if (platform) {
-                    args.push("-A");
-                    args.push(platform);
+                if (this.useCMakePresets) {
+                    const presetArchitecture = this.configurePresetArchitecture;
+                    const presetToolset = this.configurePresetToolset;
+                    const platform = presetArchitecture ? getValue(presetArchitecture) : undefined;
+                    const toolset = presetToolset ? getValue(presetToolset) : undefined;
+                    if (toolset) {
+                        args.push('-T');
+                        args.push(toolset);
+                    }
+                    if (platform) {
+                        args.push("-A");
+                        args.push(platform);
+                    }
                 }
             }
         }

--- a/src/installs/visualStudio.ts
+++ b/src/installs/visualStudio.ts
@@ -135,7 +135,7 @@ export function targetArchFromGeneratorPlatform(generatorPlatform?: string) {
     if (!generatorPlatform) {
         return undefined;
     }
-    return vsArchFromGeneratorPlatform[generatorPlatform] || generatorPlatform;
+    return vsArchFromGeneratorPlatform[generatorPlatform.toLowerCase()] || generatorPlatform;
 }
 
 /**


### PR DESCRIPTION
In CMake Presets versions greater than v3, the `generator` field is optional. Therefore, we needed to improve our logic to handle this case for the `toolset` and `architecture` fields.

Fixes #4181 