### PR TITLE
Normalize the case before comparing compilation database paths (#4207)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Bug Fixes:
 - Ensure that tests are updated after a build. [#4148](https://github.com/microsoft/vscode-cmake-tools/pull/4148)
 - Fix various GCC compiler errors and GCC linker errors not showing up in Problems View [#2864](https://github.com/microsoft/vscode-cmake-tools/issues/2864)
 - Fix reloading presets when included files are changed or renamed and updated. [#3963](https://github.com/microsoft/vscode-cmake-tools/issues/3963)
+- Fix compilation database path comparison with the `cmake.copyCompileCommands` that could otherwise overwrite that file. [#4207](https://github.com/microsoft/vscode-cmake-tools/issues/4207) [@k0zmo](https://github.com/k0zmo)
 
 ## 1.19.52
 

--- a/src/cmakeProject.ts
+++ b/src/cmakeProject.ts
@@ -1541,13 +1541,13 @@ export class CMakeProject {
             }
         } else {
             // single file with known path
-            const compdbPath = util.lightNormalizePath(path.join(await this.binaryDir, 'compile_commands.json'));
+            const compdbPath = util.platformNormalizePath(path.join(await this.binaryDir, 'compile_commands.json'));
             if (await fs.exists(compdbPath)) {
                 compdbPaths.push(compdbPath);
                 if (this.workspaceContext.config.copyCompileCommands) {
                     // Now try to copy the compdb to the user-requested path
                     const copyDest = util.lightNormalizePath(this.workspaceContext.config.copyCompileCommands);
-                    const expandedDest = util.lightNormalizePath(await expandString(copyDest, opts));
+                    const expandedDest = util.platformNormalizePath(await expandString(copyDest, opts));
                     if (compdbPath !== expandedDest) {
                         const parentDir = path.dirname(expandedDest);
                         try {


### PR DESCRIPTION
## This change addresses item #4207

### This changes

Before comparing the compilation database path with the contents of `cmake.copyCompileCommands` make sure to platform-normalize the cases of both values.
