### PR TITLE
Fix cmake_minimum_required() deprecation warning

### DIFF
--- a/src/cmakeProject.ts
+++ b/src/cmakeProject.ts
@@ -3114,7 +3114,7 @@ export class CMakeProject {
         }
 
         let init = [
-            'cmake_minimum_required(VERSION 3.5.0)',
+            'cmake_minimum_required(VERSION 3.10.0)',
             `project(${projectName} VERSION 0.1.0 LANGUAGES ${langName})`,
             '\n'
         ].join('\n');


### PR DESCRIPTION
The following changes are proposed:

- Changed CMake version in template to < 3.10

## The purpose of this change

```
[build] CMake Deprecation Warning at CMakeLists.txt:1 (cmake_minimum_required):
[build]   Compatibility with CMake < 3.10 will be removed from a future version of
[build]   CMake.
[build] 
[build]   Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
[build]   to tell CMake that the project requires at least <min> but has been updated
[build]   to work with policies introduced by <max> or earlier.
[build] 
[build] 
```
