### PR TITLE
Fix 3232

### DIFF
--- a/src/cmakeTaskProvider.ts
+++ b/src/cmakeTaskProvider.ts
@@ -187,6 +187,10 @@ export class CMakeTaskProvider implements vscode.TaskProvider {
 
     public static async provideTask(commandType: CommandType, workspaceFolder: vscode.WorkspaceFolder, useCMakePresets?: boolean, targets?: string[], presetName?: string): Promise<CMakeTask> {
         const taskName: string = localizeCommandType(commandType);
+        const project = await extensionManager?.projectController.getProjectForFolder(workspaceFolder.uri.path);
+        if (!project) {
+            log.error(localize("project.not.found", 'Project not found.'));
+        }
         let buildTargets: string[] | undefined;
         let preset: string | undefined;
         if (commandType === CommandType.build || commandType === CommandType.cleanRebuild) {
@@ -195,7 +199,7 @@ export class CMakeTaskProvider implements vscode.TaskProvider {
         if (presetName) {
             preset = presetName;
         } else if (useCMakePresets) {
-            preset = await getDefaultPresetName(commandType);
+            preset = getDefaultPresetNameForProject(project, commandType);
         }
 
         const definition: CMakeTaskDefinition = {

--- a/src/cmakeTaskProvider.ts
+++ b/src/cmakeTaskProvider.ts
@@ -84,6 +84,39 @@ const localizeCommandType = (cmd: CommandType): string => {
     };
 };
 
+/**
+ * Returns the default preset name for the given project and command type.
+ *
+ * @param project Project to get the default preset name for.
+ * @param commandType Command type to get the default preset name for.
+ * @returns The default preset name for the given project and command type.
+ */
+function getDefaultPresetNameForProject(project: CMakeProject | undefined, commandType: CommandType): string | undefined {
+    if (!project) {
+        return undefined;
+    }
+    switch (commandType) {
+        case CommandType.config:
+            return project.configurePreset?.name;
+        case CommandType.build:
+            return project.buildPreset?.name;
+        case CommandType.install:
+            return project.buildPreset?.name;
+        case CommandType.clean:
+            return project.buildPreset?.name;
+        case CommandType.cleanRebuild:
+            return project.buildPreset?.name;
+        case CommandType.test:
+            return project.testPreset?.name;
+        case CommandType.package:
+            return project.packagePreset?.name;
+        case CommandType.workflow:
+            return project.workflowPreset?.name;
+        default:
+            return undefined;
+    }
+}
+
 async function getDefaultPresetName(commandType: CommandType, resolve: boolean = false): Promise<string | undefined> {
     let result: string | undefined;
     switch (commandType) {

--- a/src/cmakeTaskProvider.ts
+++ b/src/cmakeTaskProvider.ts
@@ -460,6 +460,10 @@ export class CustomBuildTaskTerminal implements vscode.Pseudoterminal, proc.Outp
         return useCMakePresets ? getDefaultPresetNameForActiveProject(commandType, true) : undefined;
     }
 
+    /**
+     * 
+     * @returns The CMake project for the current workspace folder if the workspace folder is defined, otherwise the active project.
+     */
     private async getProject(): Promise<CMakeProject | undefined> {
         let project: CMakeProject | undefined = getActiveProject();
         if (this.workspaceFolder !== undefined) {

--- a/src/cmakeTaskProvider.ts
+++ b/src/cmakeTaskProvider.ts
@@ -187,7 +187,7 @@ export class CMakeTaskProvider implements vscode.TaskProvider {
 
     public static async provideTask(commandType: CommandType, workspaceFolder: vscode.WorkspaceFolder, useCMakePresets?: boolean, targets?: string[], presetName?: string): Promise<CMakeTask> {
         const taskName: string = localizeCommandType(commandType);
-        const project = await extensionManager?.projectController.getProjectForFolder(workspaceFolder.uri.path);
+        const project = await extensionManager?.getProjectForFolder(workspaceFolder);
         if (!project) {
             log.error(localize("project.not.found", 'Project not found.'));
         }
@@ -472,7 +472,7 @@ export class CustomBuildTaskTerminal implements vscode.Pseudoterminal, proc.Outp
         let project: CMakeProject | undefined = getActiveProject();
         if (this.workspaceFolder !== undefined) {
             this.writeEmitter.fire("Workspace is " + this.workspaceFolder.uri.path + endOfLine);
-            project = await extensionManager?.projectController.getProjectForFolder(this.workspaceFolder.uri.path);
+            project = await extensionManager?.getProjectForFolder(this.workspaceFolder);
         }
         if (!project) {
             log.debug(localize("cmake.tools.not.found", 'CMake Tools not found.'));

--- a/src/cmakeTaskProvider.ts
+++ b/src/cmakeTaskProvider.ts
@@ -465,7 +465,7 @@ export class CustomBuildTaskTerminal implements vscode.Pseudoterminal, proc.Outp
     }
 
     /**
-     * 
+     *
      * @returns The CMake project for the current workspace folder if the workspace folder is defined, otherwise the active project.
      */
     private async getProject(): Promise<CMakeProject | undefined> {

--- a/src/cmakeTaskProvider.ts
+++ b/src/cmakeTaskProvider.ts
@@ -460,7 +460,7 @@ export class CustomBuildTaskTerminal implements vscode.Pseudoterminal, proc.Outp
         return useCMakePresets ? getDefaultPresetNameForActiveProject(commandType, true) : undefined;
     }
 
-    private async getActiveProject(): Promise<CMakeProject | undefined> {
+    private async getProject(): Promise<CMakeProject | undefined> {
         let project: CMakeProject | undefined = getActiveProject();
         if (this.workspaceFolder !== undefined) {
             this.writeEmitter.fire("Workspace is " + this.workspaceFolder.uri.path + endOfLine);
@@ -476,7 +476,7 @@ export class CustomBuildTaskTerminal implements vscode.Pseudoterminal, proc.Outp
 
     private async runConfigTask(): Promise<any> {
         this.writeEmitter.fire(localize("config.started", "Config task started...") + endOfLine);
-        const project: CMakeProject | undefined = await this.getActiveProject();
+        const project: CMakeProject | undefined = await this.getProject();
         if (!project || !await this.isTaskCompatibleWithPresets(project)) {
             return;
         }
@@ -513,7 +513,7 @@ export class CustomBuildTaskTerminal implements vscode.Pseudoterminal, proc.Outp
         let args: string[] = [];
 
         if (!project) {
-            project = await this.getActiveProject();
+            project = await this.getProject();
             if (!project || !await this.isTaskCompatibleWithPresets(project)) {
                 return -1;
             }
@@ -592,7 +592,7 @@ export class CustomBuildTaskTerminal implements vscode.Pseudoterminal, proc.Outp
     private async runTestTask(): Promise<any> {
         this.writeEmitter.fire(localize("test.started", "Test task started...") + endOfLine);
 
-        const project: CMakeProject | undefined = await this.getActiveProject();
+        const project: CMakeProject | undefined = await this.getProject();
         if (!project || !await this.isTaskCompatibleWithPresets(project)) {
             return;
         }
@@ -630,7 +630,7 @@ export class CustomBuildTaskTerminal implements vscode.Pseudoterminal, proc.Outp
     private async runPackageTask(): Promise<any> {
         this.writeEmitter.fire(localize("package.started", "Package task started...") + endOfLine);
 
-        const project: CMakeProject | undefined = await this.getActiveProject();
+        const project: CMakeProject | undefined = await this.getProject();
         if (!project || !await this.isTaskCompatibleWithPresets(project)) {
             return;
         }
@@ -668,7 +668,7 @@ export class CustomBuildTaskTerminal implements vscode.Pseudoterminal, proc.Outp
     private async runWorkflowTask(): Promise<any> {
         this.writeEmitter.fire(localize("workflow.started", "Workflow task started...") + endOfLine);
 
-        const project: CMakeProject | undefined = await this.getActiveProject();
+        const project: CMakeProject | undefined = await this.getProject();
         if (!project || !await this.isTaskCompatibleWithPresets(project)) {
             return;
         }
@@ -704,7 +704,7 @@ export class CustomBuildTaskTerminal implements vscode.Pseudoterminal, proc.Outp
     }
 
     private async runCleanRebuildTask(): Promise<any> {
-        const project: CMakeProject | undefined = await this.getActiveProject();
+        const project: CMakeProject | undefined = await this.getProject();
         if (!project || !await this.isTaskCompatibleWithPresets(project)) {
             return;
         }

--- a/src/cmakeTaskProvider.ts
+++ b/src/cmakeTaskProvider.ts
@@ -117,7 +117,7 @@ function getDefaultPresetNameForProject(project: CMakeProject | undefined, comma
     }
 }
 
-async function getDefaultPresetName(commandType: CommandType, resolve: boolean = false): Promise<string | undefined> {
+async function getDefaultPresetNameForActiveProject(commandType: CommandType, resolve: boolean = false): Promise<string | undefined> {
     let result: string | undefined;
     switch (commandType) {
         case CommandType.config:
@@ -457,7 +457,7 @@ export class CustomBuildTaskTerminal implements vscode.Pseudoterminal, proc.Outp
         if (preset !== undefined) {
             return preset;
         }
-        return useCMakePresets ? getDefaultPresetName(commandType, true) : undefined;
+        return useCMakePresets ? getDefaultPresetNameForActiveProject(commandType, true) : undefined;
     }
 
     private async getActiveProject(): Promise<CMakeProject | undefined> {

--- a/src/drivers/cmakeDriver.ts
+++ b/src/drivers/cmakeDriver.ts
@@ -1990,7 +1990,7 @@ export abstract class CMakeDriver implements vscode.Disposable {
             }
             const useBuildTask: boolean = this.config.buildTask && isBuildCommand === true;
             if (useBuildTask) {
-                const task: CMakeTask | undefined = await CMakeTaskProvider.findBuildTask(this._buildPreset?.name, targets, this.expansionOptions);
+                const task: CMakeTask | undefined = await CMakeTaskProvider.findBuildTask(this.workspaceFolder, this._buildPreset?.name, targets, this.expansionOptions);
                 if (task) {
                     const resolvedTask: CMakeTask | undefined = await CMakeTaskProvider.resolveInternalTask(task);
                     if (resolvedTask) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1830,11 +1830,7 @@ export class ExtensionManager implements vscode.Disposable {
     }
 
     getAllCMakeProjects(): CMakeProject[] {
-        const projects: CMakeProject[] | undefined = this.projectController.getAllCMakeProjects();
-        if (!projects || projects.length === 0) {
-            return [];
-        }
-        return projects;
+        return this.projectController.getAllCMakeProjects();
     }
 
     activeConfigurePresetName(): string {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1838,6 +1838,16 @@ export class ExtensionManager implements vscode.Disposable {
         return this.projectController.getAllCMakeProjects();
     }
 
+    /**
+     * Get the CMake project for the given folder
+     *
+     * @param folder The folder to get the project for
+     * @returns The CMake project for the folder
+     */
+    async getProjectForFolder(folder: vscode.WorkspaceFolder): Promise<CMakeProject | undefined> {
+        return this.projectController.getProjectForFolder(folder.uri.path);
+    }
+
     activeConfigurePresetName(): string {
         telemetry.logEvent("substitution", { command: "activeConfigurePresetName" });
         return this.getActiveProject()?.configurePreset?.name || '';

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1829,6 +1829,14 @@ export class ExtensionManager implements vscode.Disposable {
         return projects.some(project => project.hasCMakeLists());
     }
 
+    getAllCMakeProjects(): CMakeProject[] {
+        const projects: CMakeProject[] | undefined = this.projectController.getAllCMakeProjects();
+        if (!projects || projects.length === 0) {
+            return [];
+        }
+        return projects;
+    }
+
     activeConfigurePresetName(): string {
         telemetry.logEvent("substitution", { command: "activeConfigurePresetName" });
         return this.getActiveProject()?.configurePreset?.name || '';

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1829,6 +1829,11 @@ export class ExtensionManager implements vscode.Disposable {
         return projects.some(project => project.hasCMakeLists());
     }
 
+    /**
+     * Get all CMake projects in the workspace
+     *
+     * @returns All CMake projects in the workspace
+     */
     getAllCMakeProjects(): CMakeProject[] {
         return this.projectController.getAllCMakeProjects();
     }


### PR DESCRIPTION
<!-- Thanks for your contribution! To make things easier, please fill out the template below. -->

<!-- Please delete any unused sections. -->

<!-- Delete the following heading if there is no corresponding issue -->
## This change addresses item #3232

### This changes visible behavior

The following changes are proposed:

- Two methods are added to the `ExtensionManager` class (`getAllCMakeProjects`, `getProjectForFolder`). They are just delegations to the `projectController` object.
- The `findBuildTask` method of the `CMakeTaskProvider` is expecting a workspace folder (under string form) as first argument. Its call site in the `cmakeDriver.ts`  file is updated accordingly
- The `provideTasks` method of the `CMakeTaskProvider` does not deal with the active project anymore but loop over all the CMake projects of the workspace to build the task list. 
- Accordingly, the `provideTask` method of the `CMakeTaskProvider` is expecting a workspace folder as 2nd argument so that the scope of each task is the given workspace folder. This folder is also used to specialize the task definition label in order for the definition to be unique for each task (even for the same task type of two different workspace folders). Last but not least, the workspace folder is also passed to the constructor of the `CustomBuildTaskTerminal` 
- The `CustomBuildTaskTerminal` does not rely only on the `activeProject` anymore. Instead, if a `workspaceFolder` member is defined, then the `getProject` method (formerly `getActiveProject` method) return the project associated to the workspace folder.

At first sight solving #3232 should have been as easy as looping over each `CMake` project of the workspace to build the list of available tasks (in the `provideTasks` method). But as lot of pieces of the `CMakeTaskProvider` and `CustomBuildTaskTerminal` were relying on working on the active project, i had no other choice that modifying them so that they could work on any project the workspace folder is given.

 
## Other Notes/Information
Please tell me if it is possible to add tests for task selection. I will be pleased to implement them.
