### PR TITLE
add extensibility doc

### DIFF
--- a/EXTENSIBILITY.md
+++ b/EXTENSIBILITY.md
@@ -1,0 +1,10 @@
+# CMake Tools Extensibility
+
+We provide an API in order to get information from the CMake Tools extension from other VS Code extension.
+
+NPM: <https://www.npmjs.com/package/vscode-cmake-tools?activeTab=readme>
+GitHub: <https://github.com/microsoft/vscode-cmake-tools-api>
+
+## CMake Tools API sample extension
+
+We have created a simple sample extension that showcases how simple it is to interact with this API. You can find it in the GitHub for the CMake Tools API here: <https://github.com/microsoft/vscode-cmake-tools-api/tree/main/sample-extension>

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
 - [FAQ](docs/faq.md)
 - [Read the online documentation](docs/README.md)
 - [Contribute](CONTRIBUTING.md)
+- [Extensibility](EXTENSIBILITY.md)
 
 ## Issues? Questions? Feature requests?
 


### PR DESCRIPTION
Add doc detailing the cmake tools api and pointing to the sample extension that showcases hooking into the API. 