### PR TITLE
Fix localization pipeline

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -19,7 +19,6 @@ const tsProject = ts.createProject('./tsconfig.json', { typescript });
 const filter = require('gulp-filter');
 const vinyl = require('vinyl');
 const jsonc = require('jsonc-parser');
-const lodash = require("lodash");
 
 // Patterns to find schema files
 const jsonSchemaFilesPatterns = [

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -99,7 +99,7 @@ const traverseJson = (jsonTree, descriptionCallback, prefixPath) => {
 
 // remove invalid characters that aren't allowed in xlf.
 const removeInvalidXLFCharacters = (str) => {
-    return str.replace(/(<)|(>)/g, "");
+    return str.replace(/<|>/g, "");
 }
 
 // Traverses schema json files looking for "description" fields to localized.

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -116,8 +116,7 @@ const processJsonFiles = () => {
             filePath: filePath
         };
         let descriptionCallback = (path, value, parent) => {
-            let locId = filePath + "." + path;
-            locId = removeInvalidXLFCharacters(locId);
+            let locId = filePath + "." + removeInvalidXLFCharacters(path);
             localizationJsonContents[locId] = value;
             localizationMetadataContents.keys.push(locId);
             localizationMetadataContents.messages.push(value);

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -19,7 +19,7 @@ const tsProject = ts.createProject('./tsconfig.json', { typescript });
 const filter = require('gulp-filter');
 const vinyl = require('vinyl');
 const jsonc = require('jsonc-parser');
-
+const lodash = require("lodash");
 
 // Patterns to find schema files
 const jsonSchemaFilesPatterns = [
@@ -114,7 +114,7 @@ const processJsonFiles = () => {
             let locId = filePath + "." + path;
             localizationJsonContents[locId] = value;
             localizationMetadataContents.keys.push(locId);
-            localizationMetadataContents.messages.push(value);
+            localizationMetadataContents.messages.push(lodash.escape(value));
         };
         traverseJson(jsonTree, descriptionCallback, "");
         this.queue(new vinyl({

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -99,7 +99,9 @@ const traverseJson = (jsonTree, descriptionCallback, prefixPath) => {
 
 // Traverses schema json files looking for "description" fields to localized.
 // The path to the "description" field is used to create a localization key.
-const processJsonFiles = () => {
+// escape is a boolean regarding whether we want to escape the string with lodash. We only want to do this with the
+// language service files. 
+const processJsonFiles = (escape = false) => {
     return es.through(function (file) {
         let jsonTree = JSON.parse(file.contents.toString());
         let localizationJsonContents = {};
@@ -113,8 +115,8 @@ const processJsonFiles = () => {
         let descriptionCallback = (path, value, parent) => {
             let locId = filePath + "." + path;
             localizationJsonContents[locId] = value;
-            localizationMetadataContents.keys.push(lodash.escape(locId));
-            localizationMetadataContents.messages.push(lodash.escape(value));
+            localizationMetadataContents.keys.push(escape ? lodash.escape(locId) : locId);
+            localizationMetadataContents.messages.push(escape ? lodash.escape(value) : value);
         };
         traverseJson(jsonTree, descriptionCallback, "");
         this.queue(new vinyl({
@@ -141,7 +143,7 @@ gulp.task("translations-export", (done) => {
         .pipe(processJsonFiles());
 
     let jsonLanguageServicesStream = gulp.src(languageServicesFilesPatterns)
-        .pipe(processJsonFiles());
+        .pipe(processJsonFiles(true));
 
     // Merge files from all source streams
     es.merge(jsStream, jsonSchemaStream, jsonLanguageServicesStream)

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -20,6 +20,7 @@ const filter = require('gulp-filter');
 const vinyl = require('vinyl');
 const jsonc = require('jsonc-parser');
 
+
 // Patterns to find schema files
 const jsonSchemaFilesPatterns = [
     "*/*-schema.json"

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -104,8 +104,6 @@ const removeInvalidXLFCharacters = (str) => {
 
 // Traverses schema json files looking for "description" fields to localized.
 // The path to the "description" field is used to create a localization key.
-// escape is a boolean regarding whether we want to escape the string with lodash. We only want to do this with the
-// language service files. 
 const processJsonFiles = () => {
     return es.through(function (file) {
         let jsonTree = JSON.parse(file.contents.toString());

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -99,7 +99,7 @@ const traverseJson = (jsonTree, descriptionCallback, prefixPath) => {
 
 // remove invalid characters that aren't allowed in xlf.
 const removeInvalidXLFCharacters = (str) => {
-    return str.replace(/[^a-zA-Z_]/g, "");
+    return str.replace(/(<)|(>)/g, "");
 }
 
 // Traverses schema json files looking for "description" fields to localized.

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -113,7 +113,7 @@ const processJsonFiles = () => {
         let descriptionCallback = (path, value, parent) => {
             let locId = filePath + "." + path;
             localizationJsonContents[locId] = value;
-            localizationMetadataContents.keys.push(locId);
+            localizationMetadataContents.keys.push(lodash.escape(locId));
             localizationMetadataContents.messages.push(lodash.escape(value));
         };
         traverseJson(jsonTree, descriptionCallback, "");

--- a/jobs/loc/TranslationsImportExport.yml
+++ b/jobs/loc/TranslationsImportExport.yml
@@ -89,3 +89,7 @@ extends:
             LclSource: lclFilesfromPackage
             LclPackageId: 'LCL-JUNO-PROD-VCMAKE'
             lsBuildXLocPackageVersion: '7.0.30510'
+        
+        - task: CmdLine@2
+          inputs:
+            script: 'node ./translations_auto_pr.js microsoft vscode-cmake-tools csigs $(csigsPat) csigs csigs@users.noreply.github.com "$(Build.ArtifactStagingDirectory)/loc" vscode-extensions-localization-export/vscode-extensions'

--- a/jobs/loc/TranslationsImportExport.yml
+++ b/jobs/loc/TranslationsImportExport.yml
@@ -89,7 +89,3 @@ extends:
             LclSource: lclFilesfromPackage
             LclPackageId: 'LCL-JUNO-PROD-VCMAKE'
             lsBuildXLocPackageVersion: '7.0.30510'
-        
-        - task: CmdLine@2
-          inputs:
-            script: 'node ./translations_auto_pr.js microsoft vscode-cmake-tools csigs $(csigsPat) csigs csigs@users.noreply.github.com "$(Build.ArtifactStagingDirectory)/loc" vscode-extensions-localization-export/vscode-extensions'


### PR DESCRIPTION
After adding the language service information to get localized, we needed to adjust the locid to not have invalid characters that were coming from some of the language service data. 

This fixes it such that it removes it both before and after the xlf generation so that we don't have to modify the code, but we get around the issue in the localization step. 