### PR TITLE
chore(CTestDriver): skip project building according to `cmake.buildBeforeRun` config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Improvements:
 - Ensure that stopping tests actually forces the tests to stop running. [#2095](https://github.com/microsoft/vscode-cmake-tools/issues/2095)
 - Retire the Show Options Moved Notification [#4039](https://github.com/microsoft/vscode-cmake-tools/issues/4039)
 - Improve the pinned commands experience by defaulting settings and using VS Code state rather than modifying user settings. [#3977](https://github.com/microsoft/vscode-cmake-tools/issues/3977)
+- Skip project building in the CTest test explorer when `cmake.buildBeforeRun` is set to `false`. [#4241](https://github.com/microsoft/vscode-cmake-tools/pull/4241) [@Dabsunter](https://github.com/Dabsunter)
 
 Bug Fixes:
 

--- a/src/ctest.ts
+++ b/src/ctest.ts
@@ -1248,6 +1248,11 @@ export class CTestDriver implements vscode.Disposable {
     }
 
     private async buildTests(tests: vscode.TestItem[], run: vscode.TestRun): Promise<boolean> {
+        // If buildBeforeRun is set to false, we skip the build step
+        if (!this.ws.config.buildBeforeRun) {
+            return true;
+        }
+
         // Folder => status
         const builtFolder = new Map<string, number>();
         let status: number = 0;


### PR DESCRIPTION
<!-- Delete the following heading if there is no corresponding issue -->
## This change addresses item #3919

### This changes auto-build behavior when launching/debugging tests from the test explorer view.

The following changes are proposed in the CTest driver:

- Skip project building if `cmake.buildBeforeRun` is set to `false` (`true` by default, meaning the default installation will keep the current behavior)

## The purpose of this change

Sometime during debugging sessions, we might want to run/debug tests multiple time without any code change, and those unnecessary re-build steps can be very time consuming in big projects.

Having the auto-build feature on by default is fine, but we should be able to disable it.

## Other Notes/Information

<!-- Write whatever you feel is relevant -->

I relied on the already existing `cmake.buildBeforeRun` config, but we could introduce a dedicated `cmake.ctest.buildBeforeTest` to give the user more granularity in their choice...
