### PR TITLE
Fix no error and inability to stop debug session when configure in progress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Bug Fixes:
 - Fix compilation database path comparison with the `cmake.copyCompileCommands` that could otherwise overwrite that file. [#4207](https://github.com/microsoft/vscode-cmake-tools/issues/4207) [@k0zmo](https://github.com/k0zmo)
 - Fix parsing of CMakeUserPresets.json containing configure preset that is referenced in workflow preset. [#4202](https://github.com/microsoft/vscode-cmake-tools/pull/4202)
 - Fix auto select active project corner case. [#4146](https://github.com/microsoft/vscode-cmake-tools/issues/4146) Contributed by STMicroelectronics
+- Fix issue where starting a CMake Configure with CMake Debugger while there was already a configure process running left a debug session going without a way to stop it. [#4230](https://github.com/microsoft/vscode-cmake-tools/issues/4230)
 
 ## 1.19.52
 

--- a/src/cmakeProject.ts
+++ b/src/cmakeProject.ts
@@ -1639,11 +1639,14 @@ export class CMakeProject {
             }
             await this.cTestController.refreshTests(drv);
             this.onReconfiguredEmitter.fire();
+            debuggerInformation?.debuggerStoppedDueToPreconditions(localize('no.debug.configured.with.cache', "Configured CMake with cache. CMake debugger is not supported with cache."));
             return result;
         }
 
         if (trigger === ConfigureTrigger.configureWithCache) {
-            log.debug(localize('no.cache.available', 'Unable to configure with existing cache'));
+            const message = localize('no.cache.available', 'Unable to configure with existing cache');
+            log.debug(message);
+            debuggerInformation?.debuggerStoppedDueToPreconditions(message);
             return { result: -1, resultType: ConfigureResultType.NoCache };
         }
 
@@ -1760,6 +1763,8 @@ export class CMakeProject {
                                                 }
                                             }
                                         });
+                                } else if (result.result !== 0) {
+                                    debuggerInformation?.debuggerStoppedDueToPreconditions(localize("no.configure.with.debug.due.to.preconditions", "Cannot configure with CMake debugger due to reason: \"{0}\"", ConfigureResultType[result.resultType]));
                                 }
 
                                 await this.cTestController.refreshTests(drv);
@@ -1772,12 +1777,14 @@ export class CMakeProject {
                             }
                         } else {
                             progress.report({ message: localize('configure.failed', 'Failed to configure project') });
+                            debuggerInformation?.debuggerStoppedDueToPreconditions(localize('no.driver.available.no.debug', 'Cannot configure with CMake debugger due to no CMake driver being available.'));
                             return { result: -1, resultType: ConfigureResultType.NormalOperation };
                         }
                     });
                 } catch (e: any) {
                     const error = e as Error;
                     progress.report({ message: error.message });
+                    debuggerInformation?.debuggerStoppedDueToPreconditions(localize('no.debug.configured.due.to.error', 'Cannot configure with CMake debugger due to error: {0}', error.message));
                     return { result: -1, resultType: ConfigureResultType.NormalOperation };
                 }
             }

--- a/src/cmakeProject.ts
+++ b/src/cmakeProject.ts
@@ -1764,7 +1764,7 @@ export class CMakeProject {
                                             }
                                         });
                                 } else if (result.result !== 0) {
-                                    debuggerInformation?.debuggerStoppedDueToPreconditions(localize("no.configure.with.debug.due.to.preconditions", "Cannot configure with CMake debugger due to reason: \"{0}\"", ConfigureResultType[result.resultType]));
+                                    debuggerInformation?.debuggerStoppedDueToPreconditions(localize("no.configure.with.debug.due.to.preconditions", "Cannot configure with CMake debugger due to: \"{0}\"", ConfigureResultType[result.resultType]));
                                 }
 
                                 await this.cTestController.refreshTests(drv);

--- a/src/debug/cmakeDebugger/debuggerConfigureDriver.ts
+++ b/src/debug/cmakeDebugger/debuggerConfigureDriver.ts
@@ -5,6 +5,7 @@ export interface DebuggerInformation {
     pipeName: string;
     dapLog?: string;
     debuggerIsReady(): void;
+    debuggerStoppedDueToPreconditions(message: string): void;
 }
 
 export function getDebuggerPipeName(): string {


### PR DESCRIPTION
Fixes #4230. 

Adds a resolution to the debug session when we actually cancelled it due to the fact that we are already configuring, already building, or other reasons. 

This will pop up an error for the debug session and notify you why it couldn't start. 
![image](https://github.com/user-attachments/assets/b5d600a1-d4d7-49d7-bb4a-a7993edf6314)
