### PR TITLE
Don't nullify driver on cancel of configure or build

### DIFF
--- a/src/cmakeProject.ts
+++ b/src/cmakeProject.ts
@@ -2401,7 +2401,6 @@ export class CMakeProject {
 
         return drv.stopCurrentProcess().then(async () => {
             await this.activeBuild;
-            this.cmakeDriver = Promise.resolve(null);
             this.isBusy.set(false);
             return true;
         }, () => false);

--- a/src/cmakeProject.ts
+++ b/src/cmakeProject.ts
@@ -2414,7 +2414,6 @@ export class CMakeProject {
 
         return drv.stopCurrentProcess().then(async () => {
             await this.activeBuild;
-            this.cmakeDriver = Promise.resolve(null);
             return true;
         }, () => false);
     }

--- a/src/drivers/cmakeFileApiDriver.ts
+++ b/src/drivers/cmakeFileApiDriver.ts
@@ -81,8 +81,6 @@ export class CMakeFileApiDriver extends CMakeDriver {
             preferredGenerators);
     }
 
-    private _needsReconfigure = true;
-
     /**
      * Watcher for the CMake cache file on disk.
      */
@@ -162,9 +160,6 @@ export class CMakeFileApiDriver extends CMakeDriver {
         this._needsReconfigure = true;
         await onConfigureSettingsChange();
     }
-    async checkNeedsReconfigure(): Promise<boolean> {
-        return this._needsReconfigure;
-    }
 
     async doSetKit(cb: () => Promise<void>): Promise<void> {
         this._needsReconfigure = true;
@@ -208,7 +203,6 @@ export class CMakeFileApiDriver extends CMakeDriver {
     }
 
     async doCacheConfigure(): Promise<number> {
-        this._needsReconfigure = true;
         await this.updateCodeModel();
         return 0;
     }

--- a/src/drivers/cmakeLegacyDriver.ts
+++ b/src/drivers/cmakeLegacyDriver.ts
@@ -43,13 +43,9 @@ export class CMakeLegacyDriver extends CMakeDriver {
         super(cmake, config, sourceDir, isMultiProject, workspaceFolder, preconditionHandler);
     }
 
-    private _needsReconfigure = true;
     async doConfigureSettingsChange(): Promise<void> {
         this._needsReconfigure = true;
         await onConfigureSettingsChange();
-    }
-    async checkNeedsReconfigure(): Promise<boolean> {
-        return this._needsReconfigure;
     }
 
     async doSetKit(cb: () => Promise<void>): Promise<void> {


### PR DESCRIPTION
Fixes #3147.

There isn't any obvious need to nullify the driver simply because of cancelling a configure or build. 

For those wanting to confirm this works, please test with this vsix: 
[cmake-tools.zip](https://github.com/user-attachments/files/18608751/cmake-tools.zip)


To test the above vsix, download the file and rename the extension from .zip to .vsix and install it manually in VS Code. 