### PR TITLE
Don't mix generated and non-generated files in same group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Improvements:
 
 Bug Fixes:
 
+- Fix issue where files don't show up in the outline if any in the group are generated. [#4099](https://github.com/microsoft/vscode-cmake-tools/issues/4099)
 - Fix issue where setting test suite delimiter prevent execution of all tests. [#4092](https://github.com/microsoft/vscode-cmake-tools/issues/4092)
 - Fix our setting of `isUserPreset` for presets, only set it to `true` if it's defined in a user presets file. [#4059](https://github.com/microsoft/vscode-cmake-tools/issues/4059)
 - Fix issue where duplicate presets are being listed in dropdown. [#4104](https://github.com/microsoft/vscode-cmake-tools/issues/4104)

--- a/src/drivers/cmakeFileApi.ts
+++ b/src/drivers/cmakeFileApi.ts
@@ -478,6 +478,7 @@ function convertToExtCodeModelFileGroup(targetObject: CodeModelKind.TargetObject
     });
     // Collection all without compilegroup like headers
     const defaultIndex = fileGroup.push({ sources: [], isGenerated: false } as CodeModelFileGroup) - 1;
+    const generatedIndex = fileGroup.push({ sources: [], isGenerated: true } as CodeModelFileGroup) - 1;
 
     const targetRootSource = convertToAbsolutePath(targetObject.paths.source, rootPaths.source);
     targetObject.sources.forEach(sourceFile => {
@@ -486,10 +487,8 @@ function convertToExtCodeModelFileGroup(targetObject: CodeModelKind.TargetObject
         if (sourceFile.compileGroupIndex !== undefined) {
             fileGroup[sourceFile.compileGroupIndex].sources.push(fileRelativePath);
         } else {
-            fileGroup[defaultIndex].sources.push(fileRelativePath);
-            if (!!sourceFile.isGenerated) {
-                fileGroup[defaultIndex].isGenerated = sourceFile.isGenerated;
-            }
+            const i = !!sourceFile.isGenerated ? generatedIndex : defaultIndex;
+            fileGroup[i].sources.push(fileRelativePath);
         }
     });
     return fileGroup;

--- a/src/drivers/cmakeFileApi.ts
+++ b/src/drivers/cmakeFileApi.ts
@@ -491,6 +491,13 @@ function convertToExtCodeModelFileGroup(targetObject: CodeModelKind.TargetObject
             fileGroup[i].sources.push(fileRelativePath);
         }
     });
+
+    if (fileGroup[generatedIndex].sources.length === 0) {
+        fileGroup.splice(generatedIndex, 1);
+    } else if (fileGroup[defaultIndex].sources.length === 0) {
+        fileGroup.splice(defaultIndex, 1);
+    }
+
     return fileGroup;
 }
 

--- a/src/drivers/cmakeFileApi.ts
+++ b/src/drivers/cmakeFileApi.ts
@@ -492,6 +492,7 @@ function convertToExtCodeModelFileGroup(targetObject: CodeModelKind.TargetObject
         }
     });
 
+    // TODO: Update code model interface so that the fileapi source file isGenerated property is plumbed through.
     if (fileGroup[generatedIndex].sources.length === 0) {
         fileGroup.splice(generatedIndex, 1);
     } else if (fileGroup[defaultIndex].sources.length === 0) {

--- a/test/unit-tests/driver/driver-codemodel-tests.ts
+++ b/test/unit-tests/driver/driver-codemodel-tests.ts
@@ -231,7 +231,8 @@ export function makeCodeModelDriverTestsuite(driverName: string, driver_generato
             expect(target).to.be.not.undefined;
 
             // maybe could be used to exclude file list from utility targets
-            expect(target!.fileGroups![0].isGenerated).to.be.true;
+            const last = target!.fileGroups!.length - 1;
+            expect(target!.fileGroups![last].isGenerated).to.be.true;
         }).timeout(90000);
 
         test('Test sysroot access', async () => {


### PR DESCRIPTION
<!-- Thanks for your contribution! To make things easier, please fill out the template below. -->

<!-- Please delete any unused sections. -->

<!-- Delete the following heading if there is no corresponding issue -->
## This change addresses item #4099 

### This changes visibility of files in the project outline in the presence of generated files.

The following changes are proposed:

Create two default file groups. One for generated files and one for non-generated files.
