### PR TITLE
feat: add `cmake.ctest.testSuiteDelimiter.debugLaunchTarget`

### DIFF
--- a/docs/debug-launch.md
+++ b/docs/debug-launch.md
@@ -227,6 +227,8 @@ A couple of examples:
 
 Depending on your configuration or your settings, there may need to be additional configuration options set.
 
+To use a specific launch configuration when debugging tests, set `cmake.ctest.testSuiteDelimiter.debugLaunchTarget` to the desired name of the configuration (e.g. `(ctest) Launch`).
+
 ## Run without debugging
 
 You can run a target without debugging it, by running the *CMake: Run Without Debugging* from VS Code's command palette, by selecting the play button in the status bar or the play button to the left of the Launch node, or by pressing the keyboard shortcut (**Shift+Ctrl+F5**).

--- a/package.json
+++ b/package.json
@@ -2255,6 +2255,12 @@
           "markdownDescription": "%cmake-tools.configuration.cmake.ctest.testSuiteDelimiter.markdownDescription%",
           "scope": "machine-overridable"
         },
+        "cmake.ctest.debugLaunchTarget": {
+          "type": "string",
+          "default": null,
+          "description": "%cmake-tools.configuration.cmake.ctest.debugLaunchTarget.description%",
+          "scope": "resource"
+        },
         "cmake.parseBuildDiagnostics": {
           "type": "boolean",
           "default": true,

--- a/package.nls.json
+++ b/package.nls.json
@@ -112,6 +112,7 @@
             "Markdown text between `` should not be translated or localized (they represent literal text) and the capitalization, spacing, and punctuation (including the ``) should not be altered."
         ]
     }, 
+	"cmake-tools.configuration.cmake.ctest.testSuiteDelimiter.debugLaunchTarget": "Target name from launch.json to start when debugging a test with CTest. By default and in case of a non-existing target, this will show a picker with all available targets.",
     "cmake-tools.configuration.cmake.parseBuildDiagnostics.description": "Parse compiler output for warnings and errors.",
     "cmake-tools.configuration.cmake.enabledOutputParsers.description": {
         "message": "Output parsers to use. Supported parsers `cmake`, `gcc`, `gnuld` for GNULD-style linker output, `msvc` for Microsoft Visual C++, `ghs` for the Green Hills compiler with --no_wrap_diagnostics --brief_diagnostics, and `diab` for the Wind River Diab compiler.",

--- a/src/config.ts
+++ b/src/config.ts
@@ -173,7 +173,7 @@ export interface ExtensionConfigurationSettings {
     buildToolArgs: string[];
     parallelJobs: number | undefined;
     ctestPath: string;
-    ctest: { parallelJobs: number; allowParallelJobs: boolean; testExplorerIntegrationEnabled: boolean; testSuiteDelimiter: string };
+    ctest: { parallelJobs: number; allowParallelJobs: boolean; testExplorerIntegrationEnabled: boolean; testSuiteDelimiter: string; debugLaunchTarget: string | null };
     parseBuildDiagnostics: boolean;
     enabledOutputParsers: string[];
     debugConfig: CppDebugConfiguration;
@@ -386,6 +386,9 @@ export class ConfigurationReader implements vscode.Disposable {
     }
     get testSuiteDelimiter(): string {
         return this.configData.ctest.testSuiteDelimiter;
+    }
+    get ctestDebugLaunchTarget(): string | null {
+        return this.configData.ctest.debugLaunchTarget;
     }
     get parseBuildDiagnostics(): boolean {
         return !!this.configData.parseBuildDiagnostics;
@@ -602,7 +605,7 @@ export class ConfigurationReader implements vscode.Disposable {
         parallelJobs: new vscode.EventEmitter<number>(),
         ctestPath: new vscode.EventEmitter<string>(),
         cpackPath: new vscode.EventEmitter<string>(),
-        ctest: new vscode.EventEmitter<{ parallelJobs: number; allowParallelJobs: boolean; testExplorerIntegrationEnabled: boolean; testSuiteDelimiter: string }>(),
+        ctest: new vscode.EventEmitter<{ parallelJobs: number; allowParallelJobs: boolean; testExplorerIntegrationEnabled: boolean; testSuiteDelimiter: string; debugLaunchTarget: string | null }>(),
         parseBuildDiagnostics: new vscode.EventEmitter<boolean>(),
         enabledOutputParsers: new vscode.EventEmitter<string[]>(),
         debugConfig: new vscode.EventEmitter<CppDebugConfiguration>(),

--- a/src/ctest.ts
+++ b/src/ctest.ts
@@ -1074,7 +1074,12 @@ export class CTestDriver implements vscode.Disposable {
         let chosenConfig: ConfigItem | undefined;
         if (allConfigItems.length === 1) {
             chosenConfig = allConfigItems[0];
-        } else {
+        }
+        if (!chosenConfig && this.ws.config.ctestDebugLaunchTarget) {
+            chosenConfig = allConfigItems.find(x => x.label === this.ws.config.ctestDebugLaunchTarget);
+        }
+
+        if (!chosenConfig) {
             // TODO: we can remember the last choice once the CMake side panel work is done
             const chosen = await vscode.window.showQuickPick(allConfigItems, { placeHolder: localize('choose.launch.config', 'Choose a launch configuration to debug the test with.') });
             if (chosen) {

--- a/test/unit-tests/config.test.ts
+++ b/test/unit-tests/config.test.ts
@@ -28,7 +28,8 @@ function createConfig(conf: Partial<ExtensionConfigurationSettings>): Configurat
             parallelJobs: 0,
             allowParallelJobs: false,
             testExplorerIntegrationEnabled: true,
-            testSuiteDelimiter: ''
+            testSuiteDelimiter: '',
+            debugLaunchTarget: null
         },
         parseBuildDiagnostics: true,
         enabledOutputParsers: [],


### PR DESCRIPTION
<!-- Thanks for your contribution! To make things easier, please fill out the template below. -->

<!-- Please delete any unused sections. -->

<!-- Delete the following heading if there is no corresponding issue -->
## This change addresses item #3940

### This changes debugging of tests

The following changes are proposed:

- The setting `cmake.ctest.testSuiteDelimiter.debugLaunchTarget` is added, which specifies a launch configuration to be used when debugging tests.

## The purpose of this change

When repeatedly debugging tests (something fails → fix → recompile → test → something else fails → ...), one usually uses the same launch configuration. Often, multiple launch configurations are present in a project (e.g. a specific one for tests that has `"args": ["${cmake.testArgs}"]`). The popup to select a test can get distracting.
