### PR TITLE
Only normalize the path after expanding. 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # What's New?
 
-## 1.20
+## 1.20.x
+
+Bug Fixes:
+
+- Fix regression where we weren't properly expanding copyCompileCommands path. [#4294](https://github.com/microsoft/vscode-cmake-tools/issues/4294)
+
+## 1.20.52
 
 Features:
 

--- a/src/cmakeProject.ts
+++ b/src/cmakeProject.ts
@@ -1546,7 +1546,7 @@ export class CMakeProject {
                 compdbPaths.push(compdbPath);
                 if (this.workspaceContext.config.copyCompileCommands) {
                     // Now try to copy the compdb to the user-requested path
-                    const copyDest = util.lightNormalizePath(this.workspaceContext.config.copyCompileCommands);
+                    const copyDest = this.workspaceContext.config.copyCompileCommands;
                     const expandedDest = util.platformNormalizePath(await expandString(copyDest, opts));
                     if (compdbPath !== expandedDest) {
                         const parentDir = path.dirname(expandedDest);


### PR DESCRIPTION
Trying to normalize the path prior to expanding any macros was causing an edge case to fail. 

Fixes #4294 