### PR TITLE
add notification for uninstalling twxs.cmake

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,6 @@ Bug Fixes:
 
 - Fix regression where we weren't properly expanding copyCompileCommands path. [#4294](https://github.com/microsoft/vscode-cmake-tools/issues/4294)
 
-
 ## 1.20.52
 
 Features:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # What's New?
 
-## 1.20
+## 1.20.x
+
+Improvements:
+
+- Add notification suggesting users to uninstall twxs.cmake now that we have built-in Language Services. [#4288](https://github.com/microsoft/vscode-cmake-tools/issues/4288)
+
+## 1.20.52
 
 Features:
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2358,6 +2358,29 @@ export async function activate(context: vscode.ExtensionContext): Promise<api.CM
         await vscode.window.showWarningMessage(localize('uninstall.old.cmaketools', 'Please uninstall any older versions of the CMake Tools extension. It is now published by Microsoft starting with version 1.2.0.'));
     }
 
+    const twxsExtension = vscode.extensions.getExtension('twxs.cmake');
+    const key = "ms-vscode.cmake-tools.twxs.cmake.showWarning";
+    const showTwxsWarning = context.globalState.get(key, true);
+    if (twxsExtension && showTwxsWarning) {
+        const twxsUninstallString = localize('uninstall.twxs.uninstall', 'Uninstall twxs.cmake');
+        void vscode.window.showWarningMessage(localize('uninstall.twxs.cmaketools', 'We recommend that you uninstall the twxs.cmake extension. The CMake Tools extension now provides Language Services and no longer depends on twxs.cmake.'),
+            twxsUninstallString).then(async (selection) => {
+            // Uninstall twxs.cmake if the user clicked the button or cancelled
+            if (selection === twxsUninstallString || selection === undefined) {
+                if (selection === twxsUninstallString) {
+                    // Open extensions pane so user can uninstall the extension.
+                    void vscode.commands.executeCommand(
+                        "workbench.extensions.search",
+                        "twxs.cmake"
+                    );
+                }
+
+                // Don't show this warning again.
+                await context.globalState.update(key, false);
+            }
+        });
+    }
+
     const CMAKE_LANGUAGE = "cmake";
     const CMAKE_SELECTOR: vscode.DocumentSelector = [
         { language: CMAKE_LANGUAGE, scheme: 'file'},


### PR DESCRIPTION
Now that we've removed our dependency on the twxs.cmake extension, we should suggest for users to uninstall it if they are no longer interested in using it, since removing the dependency doesn't automatically uninstall the extension. 

The notification looks like this: 

![image](https://github.com/user-attachments/assets/5d2be56c-68e7-496d-8606-4bcc41d8b8eb)

And if you click "uninstall twxs.cmake", it will direct you to the extensions pane where you can uninstall the extension yourself. 
![image](https://github.com/user-attachments/assets/f2d011dd-7b90-4041-a1b6-0f7d654d5024)
