### PR TITLE
Lower defaultNumJobs to prevent UI freezing and stop using --parallel when CMakePresets is used and parallelJobs is not set

### DIFF
--- a/src/cmakeProject.ts
+++ b/src/cmakeProject.ts
@@ -389,7 +389,7 @@ export class CMakeProject {
             buildPreset,
             lightNormalizePath(this.folderPath || '.'),
             this.sourceDir,
-            this.workspaceContext.config.parallelJobs,
+            this.workspaceContext.config.isDefaultValue("parallelJobs") ? undefined : this.workspaceContext.config.parallelJobs,
             this.getPreferredGeneratorName(),
             true,
             this.configurePreset?.name);

--- a/src/cmakeProject.ts
+++ b/src/cmakeProject.ts
@@ -389,7 +389,7 @@ export class CMakeProject {
             buildPreset,
             lightNormalizePath(this.folderPath || '.'),
             this.sourceDir,
-            this.workspaceContext.config.isDefaultValue("parallelJobs") ? undefined : this.workspaceContext.config.parallelJobs,
+            this.workspaceContext.config.numJobs,
             this.getPreferredGeneratorName(),
             true,
             this.configurePreset?.name);

--- a/src/config.ts
+++ b/src/config.ts
@@ -485,7 +485,7 @@ export class ConfigurationReader implements vscode.Disposable {
     }
 
     get numJobs(): number | undefined {
-        if (this.parallelJobs === undefined) {
+        if (this.isDefaultValue("parallelJobs")) {
             return undefined;
         } else if (this.parallelJobs === 0) {
             return defaultNumJobs();

--- a/src/config.ts
+++ b/src/config.ts
@@ -171,7 +171,7 @@ export interface ExtensionConfigurationSettings {
     configureArgs: string[];
     buildArgs: string[];
     buildToolArgs: string[];
-    parallelJobs: number | undefined;
+    parallelJobs: number;
     ctestPath: string;
     ctest: { parallelJobs: number; allowParallelJobs: boolean; testExplorerIntegrationEnabled: boolean; testSuiteDelimiter: string };
     parseBuildDiagnostics: boolean;
@@ -372,7 +372,7 @@ export class ConfigurationReader implements vscode.Disposable {
     get buildToolArgs(): string[] {
         return this.configData.buildToolArgs;
     }
-    get parallelJobs(): number | undefined {
+    get parallelJobs(): number {
         return this.configData.parallelJobs;
     }
     get ctestParallelJobs(): number | null {

--- a/src/config.ts
+++ b/src/config.ts
@@ -16,7 +16,7 @@ import { Environment } from '@cmt/environmentVariables';
 nls.config({ messageFormat: nls.MessageFormat.bundle, bundleFormat: nls.BundleFormat.standalone })();
 const localize: nls.LocalizeFunc = nls.loadMessageBundle();
 export function defaultNumJobs (): number {
-    return os.cpus().length + 2;
+    return os.cpus().length;
 }
 
 const log = logging.createLogger('config');

--- a/src/presets/preset.ts
+++ b/src/presets/preset.ts
@@ -1585,7 +1585,7 @@ async function getBuildPresetInheritsImpl(folder: string, name: string, workspac
             name: defaultBuildPreset.name,
             displayName: defaultBuildPreset.displayName,
             description: defaultBuildPreset.description,
-            jobs: parallelJobs || defaultNumJobs(),
+            jobs: parallelJobs,
             configurePreset
         };
         return getBuildPresetInheritsHelper(folder, preset, workspaceFolder, sourceDir, parallelJobs, preferredGeneratorName, true, usePresetsPlusIncluded, errorHandler);

--- a/src/presets/preset.ts
+++ b/src/presets/preset.ts
@@ -11,7 +11,7 @@ import { errorHandlerHelper, expandString, ExpansionErrorHandler, ExpansionOptio
 import paths from '@cmt/paths';
 import { compareVersions, VSInstallation, vsInstallations, enumerateMsvcToolsets, varsForVSInstallation, getVcVarsBatScript } from '@cmt/installs/visualStudio';
 import { EnvironmentUtils, EnvironmentWithNull } from '@cmt/environmentVariables';
-import { defaultNumJobs, UseVsDeveloperEnvironment } from '@cmt/config';
+import { UseVsDeveloperEnvironment } from '@cmt/config';
 
 nls.config({ messageFormat: nls.MessageFormat.bundle, bundleFormat: nls.BundleFormat.standalone })();
 const localize: nls.LocalizeFunc = nls.loadMessageBundle();


### PR DESCRIPTION
Fixes (or at least improves) [4296](https://github.com/microsoft/vscode-cmake-tools/issues/4296)

Seems like a regression from https://github.com/microsoft/vscode-cmake-tools/pull/2817 -- it started using defaultNumJobs if parallelJobs is not set.

I see recommendations to use logical core count * 2 - 1, but I would avoid doing that unless users continue to hit UI freezing.

There may be an issue still with --parallel being used by ctest, but I would say leave that to fix later if anyone complains about it.