### PR TITLE
Fix lowercase include paths on Mac

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # What's New?
 
+## 1.20.x
+
+Improvements:
+
+- No longer convert paths on lowercase on MacOS to enable cpp tools to resolve them. [#4325](https://github.com/microsoft/vscode-cmake-tools/pull/4325) [@tringenbach](https://github.com/tringenbach)
+
 ## 1.20.53
 
 Improvements:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # What's New?
 
-## 1.20.x
+## 1.21
 
 Improvements:
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -111,7 +111,7 @@ export function normalizePath(p: string, opt: PathNormalizationOptions): string 
             norm = norm.toLocaleLowerCase();
             break;
         case 'platform':
-            if (process.platform === 'win32' || process.platform === 'darwin') {
+            if (process.platform === 'win32') {
                 norm = norm.toLocaleLowerCase();
             }
             break;


### PR DESCRIPTION
<!-- Thanks for your contribution! To make things easier, please fill out the template below. -->

<!-- Please delete any unused sections. -->

<!-- Delete the following heading if there is no corresponding issue -->
## This change addresses item #1596

### This changes the path normalization to not lowercase paths on Mac (darwin).

## The purpose of this change

The C++ extension treats paths as case sensitive on MacOS. (In reality, sometimes they are, but it depends, usually not).

When CMakeTools converts them to lowercase and sends the include paths over, they don't work, and all the `#include`'s that reference files in those paths get red squiggles. 

I do not understand why converting to lower case would be desirable, even if it didn't break. The OS is at least case preserving, so the"normalized or canonical form really is the form the mixed case.

