### PR TITLE
Remove -T from ctest default arguments

### DIFF
--- a/package.json
+++ b/package.json
@@ -2505,8 +2505,6 @@
           },
           "description": "%cmake-tools.configuration.cmake.ctestDefaultArgs.description%",
           "default": [
-            "-T",
-            "test",
             "--output-on-failure"
           ],
           "scope": "machine-overridable"


### PR DESCRIPTION
The ctest -T <action> option is part of the Dashboard Client Mode, and is not necessary for simply running tests locally.

closes #4327