### PR TITLE
Updated Issue Template Selection

### DIFF
--- a/.github/ISSUE_TEMPLATE/bugreport.yml
+++ b/.github/ISSUE_TEMPLATE/bugreport.yml
@@ -1,5 +1,9 @@
 name: Issue form
 description: Create an issue for the CMake Tools extension.
+title: "[Bug] "
+labels:
+  - "bug"
+  - "triage"
 body:
 - type: markdown
   attributes:

--- a/.github/ISSUE_TEMPLATE/bugreport.yml
+++ b/.github/ISSUE_TEMPLATE/bugreport.yml
@@ -1,5 +1,5 @@
-name: Issue form
-description: Create an issue for the CMake Tools extension.
+name: Bug report form
+description: Create a bug report for the CMake Tools extension.
 title: "[Bug] "
 labels:
   - "bug"
@@ -8,21 +8,21 @@ body:
 - type: markdown
   attributes:
     value: |
-      ### Is there an existing issue for this?
-      Please search our [existing issues](https://github.com/microsoft/vscode-cmake-tools/issues) to see if an issue already exists for the issue you'd like to report.
+      ### Is there an existing bug report for this?
+      Please search our [existing issues](https://github.com/microsoft/vscode-cmake-tools/issues) to see if an issue already exists for the bug you'd like to report.
 - type: textarea
   attributes:
     label: Brief Issue Summary
     description: |
       Put a short summary here.
-      If this is a bug, please provide clear instructions as to how we can reproduce the issue on our end.
+      Please provide clear instructions as to how we can reproduce the bug on our end.
   validations:
     required: true
 - type: textarea
   attributes:
     label: CMake Tools Diagnostics
     description: |
-      For bugs, please run the `CMake: Log Diagnostics` command and paste the output here.
+      Please run the `CMake: Log Diagnostics` command and paste the output here.
     render: shell
   validations:
     required: false
@@ -30,7 +30,7 @@ body:
   attributes:
     label: Debug Log
     description: |
-      For bugs, we would also appreciate it if you used the `"cmake.loggingLevel": "debug"` setting and paste the CMake/Build output from the OUTPUT window.
+      We would also appreciate it if you used the `"cmake.loggingLevel": "debug"` setting and paste the CMake/Build output from the OUTPUT window.
     render: shell
   validations:
     required: false

--- a/.github/ISSUE_TEMPLATE/bugreport.yml
+++ b/.github/ISSUE_TEMPLATE/bugreport.yml
@@ -25,7 +25,7 @@ body:
       Please run the `CMake: Log Diagnostics` command and paste the output here.
     render: shell
   validations:
-    required: false
+    required: true
 - type: textarea
   attributes:
     label: Debug Log
@@ -33,7 +33,7 @@ body:
       We would also appreciate it if you used the `"cmake.loggingLevel": "debug"` setting and paste the CMake/Build output from the OUTPUT window.
     render: shell
   validations:
-    required: false
+    required: true
 - type: textarea
   attributes:
     label: Additional Information

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,4 @@
-blank_issues_enabled: true
+blank_issues_enabled: false
 contact_links:
   - name: Discussion or question
     url: https://github.com/microsoft/vscode-cmake-tools/discussions/new

--- a/.github/ISSUE_TEMPLATE/docrequest.yml
+++ b/.github/ISSUE_TEMPLATE/docrequest.yml
@@ -8,8 +8,8 @@ body:
 - type: markdown
   attributes:
     value: |
-      ### Is there an existing request for this?
-      Please search our [existing issues](https://github.com/microsoft/vscode-cmake-tools/issues) to see if an issue already exists for the issue you'd like to report.
+      ### Is there an existing documentation request for this?
+      Please search our [existing issues](https://github.com/microsoft/vscode-cmake-tools/issues) to see if an issue already exists for the documentation request you'd like to create.
 - type: textarea
   attributes:
     label: Request Overview

--- a/.github/ISSUE_TEMPLATE/docrequest.yml
+++ b/.github/ISSUE_TEMPLATE/docrequest.yml
@@ -1,0 +1,36 @@
+name: Documentation request form
+description: Create a documentation request for the CMake Tools extension.
+title: "[Docs] "
+labels:
+  - "documentation"
+  - "triage"
+body:
+- type: markdown
+  attributes:
+    value: |
+      ### Is there an existing request for this?
+      Please search our [existing issues](https://github.com/microsoft/vscode-cmake-tools/issues) to see if an issue already exists for the issue you'd like to report.
+- type: textarea
+  attributes:
+    label: Request Overview
+    description: |
+      Please give us an overview of what information you would like to see added to the documentation.
+  validations:
+    required: true
+- type: textarea
+  attributes:
+    label: Existing Documentation URL
+    description: |
+      If you believe an existing doc needs to be updated, please provide the URL of the page here.
+    render: shell
+  validations:
+    required: false
+- type: textarea
+  attributes:
+    label: Additional Information
+    description: |
+      Optionally provide other information that will give us more context about the documentation you are requesting.
+
+      Tip: You can attach images or log files by clicking this area to highlight it and then dragging files in.
+  validations:
+    required: false

--- a/.github/ISSUE_TEMPLATE/featurerequest.yml
+++ b/.github/ISSUE_TEMPLATE/featurerequest.yml
@@ -8,8 +8,8 @@ body:
 - type: markdown
   attributes:
     value: |
-      ### Is there an existing request for this?
-      Please search our [existing issues](https://github.com/microsoft/vscode-cmake-tools/issues) to see if an issue already exists for the issue you'd like to report.
+      ### Is there an existing feature request for this?
+      Please search our [existing issues](https://github.com/microsoft/vscode-cmake-tools/issues) to see if an issue already exists for the feature request you'd like to create.
 - type: textarea
   attributes:
     label: Request Overview

--- a/.github/ISSUE_TEMPLATE/featurerequest.yml
+++ b/.github/ISSUE_TEMPLATE/featurerequest.yml
@@ -1,0 +1,28 @@
+name: Feature request form
+description: Create a feature request for the CMake Tools extension.
+title: "[Feature] "
+labels:
+  - "enhancement"
+  - "triage"
+body:
+- type: markdown
+  attributes:
+    value: |
+      ### Is there an existing request for this?
+      Please search our [existing issues](https://github.com/microsoft/vscode-cmake-tools/issues) to see if an issue already exists for the issue you'd like to report.
+- type: textarea
+  attributes:
+    label: Request Overview
+    description: |
+      Please give us an overview of the feature you would like to see added to the CMake Tools extension.
+  validations:
+    required: true
+- type: textarea
+  attributes:
+    label: Additional Information
+    description: |
+      Optionally provide other information that will give us more context about the feature you are requesting.
+
+      Tip: You can attach images or log files by clicking this area to highlight it and then dragging files in.
+  validations:
+    required: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 Improvements:
 
 - Add notification suggesting users to uninstall twxs.cmake now that we have built-in Language Services. [#4288](https://github.com/microsoft/vscode-cmake-tools/issues/4288)
+- Add templates for feature and documentation requests. [#4334](https://github.com/microsoft/vscode-cmake-tools/issues/4334)
 
 Bug Fixes:
 


### PR DESCRIPTION
Now we have 3 templates for docs, feature requests, and bugs. I also added automatic labels to the templates and turned off blank templates.