### PR TITLE
Fix gnuld error parsing false positive on make errors, false negative due to trailing \r, and false parsing of new "multiple definitions" error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Improvements:
 Bug Fixes:
 
 - Fix regression where we weren't properly expanding copyCompileCommands path. [#4294](https://github.com/microsoft/vscode-cmake-tools/issues/4294)
+- Fix gnuld error parsing false positive on make errors, false negative due to trailing \r, and false parsing of new "multiple definitions" error [#2864](https://github.com/microsoft/vscode-cmake-tools/issues/2864) [@0xemgy](https://github.com/0xemgy)
 
 ## 1.20.52
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Bug Fixes:
 
 - Fix bug that makes `Configure Task` lists only first folder in workspace. [#3232](https//github.com/microsoft/vscode-cmake-tools/issues/3232)
 - Fix displaying "Go to Test" in the Test Explorer when the DEF_SOURCE_LINE property is set, but there is no backtrace information present. [4321](https://github.com/microsoft/vscode-cmake-tools/pull/4321) [@rjaegers](https://github.com/rjaegers)
+- Fix gnuld error parsing false positive on make errors, false negative due to trailing \r, and false parsing of new "multiple definitions" error [#2864](https://github.com/microsoft/vscode-cmake-tools/issues/2864) [@0xemgy](https://github.com/0xemgy)
 
 ## 1.20.53
 
@@ -25,7 +26,6 @@ Improvements:
 Bug Fixes:
 
 - Fix regression where we weren't properly expanding copyCompileCommands path. [#4294](https://github.com/microsoft/vscode-cmake-tools/issues/4294)
-- Fix gnuld error parsing false positive on make errors, false negative due to trailing \r, and false parsing of new "multiple definitions" error [#2864](https://github.com/microsoft/vscode-cmake-tools/issues/2864) [@0xemgy](https://github.com/0xemgy)
 
 ## 1.20.52
 

--- a/src/diagnostics/gnu-ld.ts
+++ b/src/diagnostics/gnu-ld.ts
@@ -12,6 +12,10 @@ const regexPatterns: RegexPattern[] = [
         regexPattern: /^(?:.*ld(?:\.exe)?:)(?:\s*)?(.+):(\d+):\s+(?:fatal )?(\w+):\s+(.+)/,
         matchTypes: [MatchType.Full, MatchType.File, MatchType.Line, MatchType.Severity, MatchType.Message]
     },
+    {   // path/to/ld[.exe]:[ ]path/to/file.obj:path/to/file:line: message
+        regexPattern: /^(?:.*ld(?:\.exe)?\:)(?:\s*)(?:.+?\.obj:)(.+?):(\d+):\s+(.+)/,
+        matchTypes: [MatchType.Full, MatchType.File, MatchType.Line, MatchType.Message]
+    },
     {   // path/to/ld[.exe]:[ ]path/to/file:line: message
         regexPattern: /^(?:.*ld(?:\.exe)?\:)(?:\s*)?(.+):(\d+):\s+(.+)/,
         matchTypes: [MatchType.Full, MatchType.File, MatchType.Line, MatchType.Message]
@@ -21,11 +25,11 @@ const regexPatterns: RegexPattern[] = [
         matchTypes: [MatchType.Full, MatchType.File, MatchType.Severity, MatchType.Message]
     },
     {   // path/to/ld[.exe]: message (without trailing colon)
-        regexPattern: /^(.*ld(?:\.exe)?):\s+(.+)(?<!:)$/,
+        regexPattern: /^(.*ld(?:\.exe)?):\s+(.+)(?<!:)\s*$/,
         matchTypes: [MatchType.Full, MatchType.File, MatchType.Message]
     },
-    {   // /path/to/file:line: message (without "[fatal] severity:" or trailing colon)
-        regexPattern: /^(.+?):(\d+):\s+(?!fatal\s+\w+:)(?!\w+:)(.+)(?<!:)$/,
+    {   // path/to/file:line: message (with neither "[fatal] severity:" nor trailing colon nor leading "make: *** [" nor leading "make[line]: *** [")
+        regexPattern: /^(?!\s*make.*:\s\*\*\*\s\[)(.+?):(\d+):\s+(?!fatal\s+\w+:)(?!\w+:)(.+)(?<!:)\s*$/,
         matchTypes: [MatchType.Full, MatchType.File, MatchType.Line, MatchType.Message]
     }
 ];

--- a/test/unit-tests/diagnostics.test.ts
+++ b/test/unit-tests/diagnostics.test.ts
@@ -323,6 +323,34 @@ suite('Diagnostics', () => {
         expect(path.posix.normalize(diag.file)).to.eq(diag.file);
         expect(path.posix.isAbsolute(diag.file)).to.be.false;
     });
+    test('Parsing linker error of type "/path/to/ld: path/to/file.obj:path/to/file:line: message"', () => {
+        const lines = ['/path/to/ld: path/to/file.obj:path/to/file:42: message'];
+        feedLines(build_consumer, [], lines);
+        expect(build_consumer.compilers.gnuld.diagnostics).to.have.length(1);
+        const diag = build_consumer.compilers.gnuld.diagnostics[0];
+
+        expect(diag.location.start.line).to.eq(41);
+        expect(diag.location.start.character).to.eq(0);
+        expect(diag.message).to.eq('message');
+        expect(diag.file).to.eq('path/to/file');
+        expect(diag.severity).to.eq('error');
+        expect(path.posix.normalize(diag.file)).to.eq(diag.file);
+        expect(path.posix.isAbsolute(diag.file)).to.be.false;
+    });
+    test('Parsing linker error of type "/path/to/ld.exe: path/to/file.obj:path/to/file:line: message"', () => {
+        const lines = ['/path/to/ld.exe: path/to/file.obj:path/to/file:42: message'];
+        feedLines(build_consumer, [], lines);
+        expect(build_consumer.compilers.gnuld.diagnostics).to.have.length(1);
+        const diag = build_consumer.compilers.gnuld.diagnostics[0];
+
+        expect(diag.location.start.line).to.eq(41);
+        expect(diag.location.start.character).to.eq(0);
+        expect(diag.message).to.eq('message');
+        expect(diag.file).to.eq('path/to/file');
+        expect(diag.severity).to.eq('error');
+        expect(path.posix.normalize(diag.file)).to.eq(diag.file);
+        expect(path.posix.isAbsolute(diag.file)).to.be.false;
+    });
     test('Parsing linker error of type "/path/to/ld: path/to/file:line: message"', () => {
         const lines = ['/path/to/ld: path/to/file:42: message'];
         feedLines(build_consumer, [], lines);
@@ -663,6 +691,7 @@ suite('Diagnostics', () => {
         ];
         feedLines(build_consumer, [], lines);
         expect(build_consumer.compilers.gcc.diagnostics).to.have.length(0);
+        expect(build_consumer.compilers.gnuld.diagnostics).to.have.length(0);
     });
 
     test('Parse MSVC single proc error', () => {


### PR DESCRIPTION
Fix GNULD parsing issues:
1. Do not detect false positive make errors when using Unix Makefiles as a generator.
2. Detect "undefined reference" error with a trailing "\r". 
3. Parse "multiple definitions" error correctly with the first c file as file reference, and the second file as part of the error message.