### PR TITLE
fix getProjectForFolder

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1846,7 +1846,7 @@ export class ExtensionManager implements vscode.Disposable {
      * @returns The CMake project for the folder
      */
     async getProjectForFolder(folder: vscode.WorkspaceFolder): Promise<CMakeProject | undefined> {
-        return this.projectController.getProjectForFolder(folder.uri.path);
+        return this.projectController.getProjectForFolder(folder.uri.fsPath);
     }
 
     activeConfigurePresetName(): string {


### PR DESCRIPTION
Fixes the error in `getProjectForFolder`, it should be using `folder.uri.fsPath`. It was breaking the ability to test locally. 

Originated in #4223 

@hippo91 FYI, please confirm that this still fixes what you intended to fix with your PR. 