### PR TITLE
Don't require LCOV to be found in test project

### DIFF
--- a/test/end-to-end-tests/single-root-UI/project-folder/CMakeLists.txt
+++ b/test/end-to-end-tests/single-root-UI/project-folder/CMakeLists.txt
@@ -48,7 +48,7 @@ add_custom_target(runTestTarget DEPENDS TestBuildProcess
     COMMENT "Run test target"
 )
 
-find_program(LCOV lcov REQUIRED)
+find_program(LCOV lcov)
 set(LCOV_BASE lcov-base.info)
 set(LCOV_TEST lcov-test.info)
 set(LCOV_TOTAL lcov.info)


### PR DESCRIPTION
@gcampbell-msft This I believe would resolve the issue of running the single-root-ui tests on windows locally. Sorry for missing this. I don't think any other change I did in #4094 should affect Windows, since those things should only be triggered in Linux presets, and the tests should only be executed on Linux.

Can you let me know if this resolves your issue? Otherwise, could you send me the error you encounter?