### PR TITLE
Path fix for lcov coverage implementation

### DIFF
--- a/src/coverage.ts
+++ b/src/coverage.ts
@@ -2,6 +2,7 @@ import * as vscode from 'vscode';
 import { lcovParser } from "@friedemannsommer/lcov-parser";
 import * as nls from 'vscode-nls';
 import * as logging from '@cmt/logging';
+import { platformNormalizePath } from './util';
 
 nls.config({ messageFormat: nls.MessageFormat.bundle, bundleFormat: nls.BundleFormat.standalone })();
 const localize: nls.LocalizeFunc = nls.loadMessageBundle();
@@ -32,7 +33,7 @@ export async function handleCoverageInfoFiles(run: vscode.TestRun, coverageInfoF
         }
         const sections = await lcovParser({ from: contents });
         for (const section of sections) {
-            const coverage = new vscode.FileCoverage(vscode.Uri.file(section.path),
+            const coverage = new vscode.FileCoverage(vscode.Uri.file(platformNormalizePath(section.path.trim())),
                 new vscode.TestCoverageCount(
                     section.lines.hit,
                     section.lines.instrumented


### PR DESCRIPTION
I was able to reproduce the issue @makas005 encountered when using the coverage implementation on Windows. With this fix, I was able to get proper coverage population within the source files themselves. Linux still works with this change as well.

The path returned by the lcov parser could contain a carriage return in the case where it's a windows path. I'm guessing the parser was not written with the expectation of encountering windows paths. We now trim the path to ensure that any leading or trailing whitespaces or line terminator characters are removed from the path before calling the VS Code coverage API.

<!-- Delete the following heading if there is no corresponding issue -->
This change addresses the discussion at https://github.com/microsoft/vscode-cmake-tools/discussions/4302

@gcampbell-msft 
