### PR TITLE
feat: Limit number of splits by the delimiter

### DIFF
--- a/package.json
+++ b/package.json
@@ -2255,6 +2255,12 @@
           "markdownDescription": "%cmake-tools.configuration.cmake.ctest.testSuiteDelimiter.markdownDescription%",
           "scope": "machine-overridable"
         },
+        "cmake.ctest.testSuiteDelimiterMaxOccurrence": {
+          "type": "number",
+          "default": 0,
+          "markdownDescription": "%cmake-tools.configuration.cmake.ctest.testSuiteDelimiterMaxOccurrence.markdownDescription%",
+          "scope": "machine-overridable"
+        },
         "cmake.ctest.debugLaunchTarget": {
           "type": "string",
           "default": null,

--- a/package.nls.json
+++ b/package.nls.json
@@ -112,6 +112,9 @@
             "Markdown text between `` should not be translated or localized (they represent literal text) and the capitalization, spacing, and punctuation (including the ``) should not be altered."
         ]
     }, 
+    "cmake-tools.configuration.cmake.ctest.testSuiteDelimiterMaxOccurrence.markdownDescription": {
+        "message": "Maxmimum number of times the delimiter may be used to split the name of the test. `0` means no limit.",
+    },
 	"cmake-tools.configuration.cmake.ctest.debugLaunchTarget.description": "Target name from launch.json to start when debugging a test with CTest. By default and in case of a non-existing target, this will show a picker with all available targets.",
     "cmake-tools.configuration.cmake.parseBuildDiagnostics.description": "Parse compiler output for warnings and errors.",
     "cmake-tools.configuration.cmake.enabledOutputParsers.description": {

--- a/src/config.ts
+++ b/src/config.ts
@@ -173,7 +173,7 @@ export interface ExtensionConfigurationSettings {
     buildToolArgs: string[];
     parallelJobs: number;
     ctestPath: string;
-    ctest: { parallelJobs: number; allowParallelJobs: boolean; testExplorerIntegrationEnabled: boolean; testSuiteDelimiter: string; debugLaunchTarget: string | null };
+    ctest: { parallelJobs: number; allowParallelJobs: boolean; testExplorerIntegrationEnabled: boolean; testSuiteDelimiter: string; testSuiteDelimiterMaxOccurrence: number; debugLaunchTarget: string | null };
     parseBuildDiagnostics: boolean;
     enabledOutputParsers: string[];
     debugConfig: CppDebugConfiguration;
@@ -386,6 +386,9 @@ export class ConfigurationReader implements vscode.Disposable {
     }
     get testSuiteDelimiter(): string {
         return this.configData.ctest.testSuiteDelimiter;
+    }
+    get testSuiteDelimiterMaxOccurrence(): number {
+        return this.configData.ctest.testSuiteDelimiterMaxOccurrence;
     }
     get ctestDebugLaunchTarget(): string | null {
         return this.configData.ctest.debugLaunchTarget;
@@ -605,7 +608,7 @@ export class ConfigurationReader implements vscode.Disposable {
         parallelJobs: new vscode.EventEmitter<number>(),
         ctestPath: new vscode.EventEmitter<string>(),
         cpackPath: new vscode.EventEmitter<string>(),
-        ctest: new vscode.EventEmitter<{ parallelJobs: number; allowParallelJobs: boolean; testExplorerIntegrationEnabled: boolean; testSuiteDelimiter: string; debugLaunchTarget: string | null }>(),
+        ctest: new vscode.EventEmitter<{ parallelJobs: number; allowParallelJobs: boolean; testExplorerIntegrationEnabled: boolean; testSuiteDelimiter: string; testSuiteDelimiterMaxOccurrence: number, debugLaunchTarget: string | null }>(),
         parseBuildDiagnostics: new vscode.EventEmitter<boolean>(),
         enabledOutputParsers: new vscode.EventEmitter<string[]>(),
         debugConfig: new vscode.EventEmitter<CppDebugConfiguration>(),

--- a/src/ctest.ts
+++ b/src/ctest.ts
@@ -694,10 +694,30 @@ export class CTestDriver implements vscode.Disposable {
         let parentSuiteItem = testExplorerRoot;
         let testLabel = testName;
 
+        function limited_split(regexString: string, subject: string, maxCount: number): string[]
+        {
+            if(maxCount === 0)
+                maxCount = Number.MAX_SAFE_INTEGER;
+            const delimiterRegExp = new RegExp(regexString, 'dg');
+            const parts = [];
+            let lastStart = 0;
+            while(parts.length < maxCount)
+            {
+                const match : any = delimiterRegExp.exec(subject);
+                if(match === null || match.indices === null)
+                    break;
+
+                parts.push(subject.substring(lastStart, match.indices[0][0]));
+                lastStart = match.indices[0][1];
+            }
+
+            parts.push(subject.substring(lastStart));
+            return parts;
+        }
+
         // If a suite delimiter is set, create a suite tree
         if (this.ws.config.testSuiteDelimiter) {
-            const delimiterRegExp = new RegExp(this.ws.config.testSuiteDelimiter);
-            const parts = testName.split(delimiterRegExp);
+            const parts = limited_split(this.ws.config.testSuiteDelimiter, testName, this.ws.config.testSuiteDelimiterMaxOccurrence);
             testLabel = parts.pop() || testName; // The last part is the test label
 
             // Create a suite item for each suite ID part if it doesn't exist yet at that tree level

--- a/test/unit-tests/config.test.ts
+++ b/test/unit-tests/config.test.ts
@@ -29,6 +29,7 @@ function createConfig(conf: Partial<ExtensionConfigurationSettings>): Configurat
             allowParallelJobs: false,
             testExplorerIntegrationEnabled: true,
             testSuiteDelimiter: '',
+            testSuiteDelimiterMaxOccurrence: 0,
             debugLaunchTarget: null
         },
         parseBuildDiagnostics: true,


### PR DESCRIPTION

## This change addresses item #4355

### This changes visible behavior/documentation

The following changes are proposed:

- specify the maximum number of times the ctest.testSuiteDelimiter regex can be applied to split a string
- adds an option ctest.testSuiteDelimiterMaxOccurrence

## The purpose of this change

Prevent empty/unwanted hierarchy levels in Test Explorer Hierarchy