### PR TITLE
fix close-issue-reason

### DIFF
--- a/.github/workflows/close-old-issues.yml
+++ b/.github/workflows/close-old-issues.yml
@@ -21,7 +21,7 @@ jobs:
       stale-label: stale-old
       stale-exempt-label: stale-exempt
     steps:
-    - uses: actions/stale@v4.1.1
+    - uses: actions/stale@v5.1.0
       with:
         stale-issue-label: ${{ env.stale-label }}
         exempt-issue-labels: ${{ env.stale-exempt-label }}

--- a/.github/workflows/close-stale-issues.yml
+++ b/.github/workflows/close-stale-issues.yml
@@ -13,7 +13,7 @@ jobs:
       stale-exempt-label: stale-exempt
       only-label: more info needed
     steps:
-    - uses: actions/stale@v4.1.1
+    - uses: actions/stale@v5.1.0
       with:
         stale-issue-label: ${{ env.stale-label }}
         exempt-issue-labels: ${{ env.stale-exempt-label }}


### PR DESCRIPTION
Addresses: #4381

The stale issues were being closed as "completed" when they should've been closed as "not planned". This version update should make sure that the correct close reason is used for stale issues.