### PR TITLE
Fix #4304 #2903: Unrelated symlink files showing as variants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Bug Fixes:
 - Fixes for small bug string bugs. [#4319](https://github.com/microsoft/vscode-cmake-tools/issues/4319), [#4317](https://github.com/microsoft/vscode-cmake-tools/issues/4317), [#4312](https://github.com/microsoft/vscode-cmake-tools/issues/4312)
 - Fixes localization for "workspace is" string. [#4374](https://github.com/microsoft/vscode-cmake-tools/issues/4374)
 - Make tooltips for selecting Launch/Debug Target. [#4373](https://github.com/microsoft/vscode-cmake-tools/issues/4373)
+- Fix bug where unrelated symlinks are read as variant files [#4304](https://github.com/microsoft/vscode-cmake-tools/issues/4304) [@vitorramos](https://github.com/vitorramos).
 
 ## 1.20.53
 

--- a/src/kits/variant.ts
+++ b/src/kits/variant.ts
@@ -253,13 +253,17 @@ export class VariantManager implements vscode.Disposable {
         ];
 
         if (!filepath || !await fs.exists(filepath) || !candidates.includes(filepath)) {
+            let foundCandidate = false;
             for (const testpath of candidates) {
                 if (await fs.exists(testpath)) {
                     filepath = testpath;
+                    foundCandidate = true;
                     break;
                 }
             }
-            return;
+            if (!foundCandidate) {
+                return;
+            }
         }
 
         let new_variants = this.loadVariantsFromSettings();

--- a/src/kits/variant.ts
+++ b/src/kits/variant.ts
@@ -252,8 +252,8 @@ export class VariantManager implements vscode.Disposable {
             path.join(workspaceFolder, '.vscode/cmake-variants.yaml')
         ];
 
+        let foundCandidate = false;
         if (!filepath || !await fs.exists(filepath) || !candidates.includes(filepath)) {
-            let foundCandidate = false;
             for (const testpath of candidates) {
                 if (await fs.exists(testpath)) {
                     filepath = testpath;
@@ -261,14 +261,11 @@ export class VariantManager implements vscode.Disposable {
                     break;
                 }
             }
-            if (!foundCandidate) {
-                return;
-            }
         }
 
         let new_variants = this.loadVariantsFromSettings();
         // Check once more that we have a file to read
-        if (filepath && await fs.exists(filepath)) {
+        if (foundCandidate && filepath && await fs.exists(filepath)) {
             this.customVariantsFileExists = true;
             const content = (await fs.readFile(filepath)).toString();
             try {

--- a/src/kits/variant.ts
+++ b/src/kits/variant.ts
@@ -259,6 +259,7 @@ export class VariantManager implements vscode.Disposable {
                     break;
                 }
             }
+            return;
         }
 
         let new_variants = this.loadVariantsFromSettings();

--- a/src/kits/variant.ts
+++ b/src/kits/variant.ts
@@ -261,8 +261,7 @@ export class VariantManager implements vscode.Disposable {
                     break;
                 }
             }
-        }
-        else {
+        } else {
             foundCandidate = true;
         }
 

--- a/src/kits/variant.ts
+++ b/src/kits/variant.ts
@@ -262,6 +262,9 @@ export class VariantManager implements vscode.Disposable {
                 }
             }
         }
+        else {
+            foundCandidate = true;
+        }
 
         let new_variants = this.loadVariantsFromSettings();
         // Check once more that we have a file to read


### PR DESCRIPTION
chokidar library has a bug where it shows unwatched symlinks, to prevent crashes dont further process files that is not in candidates.

Fixes #4304 
Fixes #2903 