### PR TITLE
Make more consistent tooltips

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Bug Fixes:
 - Fix displaying "Go to Test" in the Test Explorer when the DEF_SOURCE_LINE property is set, but there is no backtrace information present. [4321](https://github.com/microsoft/vscode-cmake-tools/pull/4321) [@rjaegers](https://github.com/rjaegers)
 - Fix gnuld error parsing false positive on make errors, false negative due to trailing \r, and false parsing of new "multiple definitions" error [#2864](https://github.com/microsoft/vscode-cmake-tools/issues/2864) [@0xemgy](https://github.com/0xemgy)
 - Fixes for small bug string bugs. [#4319](https://github.com/microsoft/vscode-cmake-tools/issues/4319), [#4317](https://github.com/microsoft/vscode-cmake-tools/issues/4317), [#4312](https://github.com/microsoft/vscode-cmake-tools/issues/4312)
+- Make tooltips for selecting Launch/Debug Target. [#4373](https://github.com/microsoft/vscode-cmake-tools/issues/4373)
 
 ## 1.20.53
 

--- a/package.nls.json
+++ b/package.nls.json
@@ -74,7 +74,7 @@
     "cmake-tools.command.cmake.outline.debugTarget.title": "Debug",
     "cmake-tools.command.cmake.outline.launchTarget.title": "Run in Terminal",
     "cmake-tools.command.cmake.outline.setDefaultTarget.title": "Set as Build Target",
-    "cmake-tools.command.cmake.outline.setLaunchTarget.title": "Set as Launch/Debug Target",
+    "cmake-tools.command.cmake.outline.setLaunchTarget.title": "Set Launch/Debug Target",
     "cmake-tools.command.cmake.outline.revealInCMakeLists.title": "Open CMakeLists.txt",
     "cmake-tools.command.cmake.folders.setActiveFolder.title": "Set Active Folder",
     "cmake-tools.configuration.title": "CMake Tools configuration",

--- a/package.nls.json
+++ b/package.nls.json
@@ -73,7 +73,7 @@
     "cmake-tools.command.cmake.outline.runUtilityTarget.title": "Run Utility",
     "cmake-tools.command.cmake.outline.debugTarget.title": "Debug",
     "cmake-tools.command.cmake.outline.launchTarget.title": "Run in Terminal",
-    "cmake-tools.command.cmake.outline.setDefaultTarget.title": "Set as Build Target",
+    "cmake-tools.command.cmake.outline.setDefaultTarget.title": "Set Build Target",
     "cmake-tools.command.cmake.outline.setLaunchTarget.title": "Set Launch/Debug Target",
     "cmake-tools.command.cmake.outline.revealInCMakeLists.title": "Open CMakeLists.txt",
     "cmake-tools.command.cmake.folders.setActiveFolder.title": "Set Active Folder",


### PR DESCRIPTION
Make sure the outline versus non-outline commands has the same format. 

Fixes #4373 