### PR TITLE
support multiple natvis files in visualizerFile debugConfig

### DIFF
--- a/package.json
+++ b/package.json
@@ -2355,7 +2355,19 @@
               }
             },
             "visualizerFile": {
-              "type": "string",
+              "anyOf": [
+                {
+                  "type": "string",
+                  "default": ""
+                },
+                {
+                  "type": "array",
+                  "default": [],
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              ],
               "description": "%cmake-tools.configuration.cmake.debugConfig.visualizerFile.description%"
             },
             "args": {

--- a/src/debug/debugger.ts
+++ b/src/debug/debugger.ts
@@ -34,7 +34,7 @@ export interface CppDebugConfiguration {
     externalConsole?: boolean;
     console?: ConsoleTypes;
     logging?: DebuggerLogging;
-    visualizerFile?: string;
+    visualizerFile?: string | string[];
     args?: string[];
     cwd?: string;
     environment?: proc.DebuggerEnvironmentVariable[];


### PR DESCRIPTION
<!-- Thanks for your contribution! To make things easier, please fill out the template below. -->

<!-- Please delete any unused sections. -->

<!-- Delete the following heading if there is no corresponding issue -->
## This change addresses item #4410

vscode-cpptools extension now support multiple visualizerFiles in cppdbg launch configuration. See https://github.com/microsoft/vscode-cpptools/pull/10487

However, cmake.debugConfig accept a single string as visualizerFile currently.
