### PR TITLE
fix the error in the `Cache Editor` the `key` translation in simplified Chinese

### DIFF
--- a/i18n/chs/src/ui/cacheView.i18n.json
+++ b/i18n/chs/src/ui/cacheView.i18n.json
@@ -15,6 +15,6 @@
 	"unsaved.cache.edits": "是否要保存最新的缓存编辑?",
 	"search": "搜索",
 	"save": "保存",
-	"key": "密钥",
+	"key": "缓存键",
 	"value": "值"
 }


### PR DESCRIPTION
#4417

fix the error in the `key` translation in simplified Chinese: `密钥` change to `缓存键`.

### This changes 

The following changes are proposed:

- `key` translation: `密钥` change to `缓存键`

## The purpose of this change

fix translation error in simplified Chinese.
