### PR TITLE
revert encoding to fix configure bug

### DIFF
--- a/src/drivers/cmakeFileApiDriver.ts
+++ b/src/drivers/cmakeFileApiDriver.ts
@@ -221,8 +221,8 @@ export class CMakeFileApiDriver extends CMakeDriver {
             }
         }
         // -S and -B were introduced in CMake 3.13 and this driver assumes CMake >= 3.15
-        args.push("-S", `${encodeURI(util.lightNormalizePath(this.sourceDir))}`);
-        args.push("-B", `${encodeURI(util.lightNormalizePath(binaryDir))}`);
+        args.push("-S", `${util.lightNormalizePath(this.sourceDir)}`);
+        args.push("-B", `${util.lightNormalizePath(binaryDir)}`);
 
         if (!has_gen) {
             const generator = (configurePreset) ? {

--- a/src/presets/preset.ts
+++ b/src/presets/preset.ts
@@ -2255,10 +2255,10 @@ export function configureArgs(preset: ConfigurePreset): string[] {
     }
 
     if (preset.toolchainFile) {
-        result.push(`-DCMAKE_TOOLCHAIN_FILE=${encodeURI(preset.toolchainFile)}`);
+        result.push(`-DCMAKE_TOOLCHAIN_FILE=${preset.toolchainFile}`);
     }
     if (preset.installDir) {
-        result.push(`-DCMAKE_INSTALL_PREFIX=${encodeURI(preset.installDir)}`);
+        result.push(`-DCMAKE_INSTALL_PREFIX=${preset.installDir}`);
     }
 
     // Warnings


### PR DESCRIPTION
See title. Fixes #4407. 

Reverts a fix for path links with spaces in the output window. It's higher pri to have configure working compared to linking from the output window. 