### PR TITLE
Reuse cmake.environment at init to avoid ENOENT errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Bug Fixes:
 - Make tooltips for selecting Launch/Debug Target. [#4373](https://github.com/microsoft/vscode-cmake-tools/issues/4373)
 - Fix bug where unrelated symlinks are read as variant files [#4304](https://github.com/microsoft/vscode-cmake-tools/issues/4304) [@vitorramos](https://github.com/vitorramos).
 - Fix evaluation of conditions in presets. [#4425](https://github.com/microsoft/vscode-cmake-tools/issues/4425)
+- Fix ENOENT error at vscode startup on some circumstances [#2855](https://github.com/microsoft/vscode-cmake-tools/issues/2855) Contributed by STMicroelectronics
 
 ## 1.20.53
 

--- a/src/cmakeExecutable.ts
+++ b/src/cmakeExecutable.ts
@@ -3,6 +3,7 @@ import * as util from '@cmt/util';
 import {setContextAndStore} from '@cmt/extension';
 import * as logging from '@cmt/logging';
 import * as nls from 'vscode-nls';
+import { ConfigurationReader } from './config';
 
 nls.config({ messageFormat: nls.MessageFormat.bundle, bundleFormat: nls.BundleFormat.standalone })();
 const localize: nls.LocalizeFunc = nls.loadMessageBundle();
@@ -24,7 +25,7 @@ export interface CMakeExecutable {
 
 const cmakeInfo = new Map<string, CMakeExecutable>();
 
-export async function getCMakeExecutableInformation(path: string): Promise<CMakeExecutable> {
+export async function getCMakeExecutableInformation(path: string, config?: ConfigurationReader): Promise<CMakeExecutable> {
     const cmake: CMakeExecutable = {
         path,
         isPresent: false,
@@ -50,7 +51,7 @@ export async function getCMakeExecutableInformation(path: string): Promise<CMake
         }
 
         try {
-            const execOpt: proc.ExecutionOptions = { showOutputOnError: true };
+            const execOpt: proc.ExecutionOptions = { showOutputOnError: true, environment: config?.environment };
             const execVersion = await proc.execute(path, ['--version'], null, execOpt).result;
             if (execVersion.retc === 0 && execVersion.stdout) {
                 console.assert(execVersion.stdout);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -146,7 +146,7 @@ export class ExtensionManager implements vscode.Disposable {
             cmakePath = await workspaceContext.getCMakePath() || '';
         }
         // initialize the state of the cmake exe
-        await getCMakeExecutableInformation(cmakePath);
+        await getCMakeExecutableInformation(cmakePath, this.workspaceConfig);
 
         await util.setContextValue("cmake:testExplorerIntegrationEnabled", this.workspaceConfig.testExplorerIntegrationEnabled);
         this.workspaceConfig.onChange("ctest", async (value) => {


### PR DESCRIPTION
## This change addresses item #2855

### This fixes ENOENT errors at vscode startup on some circumstances.
Especially when cmake is not in system `PATH`, and if cmake installation location defined with `PATH` in `cmake.environment`

The following changes are proposed:
- Ensure to reuse `cmake.environment` setting when launching `${cmake.cmakePath} --version` and `${cmake.cmakePath} -E capabilities` during CMakeTools extension init.

## Other Notes/Information
Contributed by STMicroelectronics
Signed-off-by: Julien DEHAUDT [julien.dehaudt@st.com](mailto:julien.dehaudt@st.com)
