### PR TITLE
Search CTest output for failure locations (#4418)

### DIFF
--- a/package.json
+++ b/package.json
@@ -2255,6 +2255,51 @@
           "markdownDescription": "%cmake-tools.configuration.cmake.ctest.testSuiteDelimiter.markdownDescription%",
           "scope": "machine-overridable"
         },
+        "cmake.ctest.failurePatterns": {
+          "type": ["string", "array"],
+          "items": {
+            "type": ["string", "object"],
+            "properties": {
+              "regexp": {
+                "type": "string",
+                "description": "%cmake-tools.configuration.cmake.ctest.failurePatterns.regexp%"
+              },
+              "file": {
+                "type": "integer",
+                "description": "%cmake-tools.configuration.cmake.ctest.failurePatterns.file%",
+                "default": 1
+              },
+              "line": {
+                "type": "integer",
+                "description": "%cmake-tools.configuration.cmake.ctest.failurePatterns.line%",
+                "default": 2
+              },
+              "message": {
+                "type": "integer",
+                "description": "%cmake-tools.configuration.cmake.ctest.failurePatterns.message%",
+                "default": 3
+              },
+              "actual": {
+                "type": ["integer" ],
+                "description": "%cmake-tools.configuration.cmake.ctest.failurePatterns.actual%"
+              },
+              "expected": {
+                "type": "integer",
+                "description": "%cmake-tools.configuration.cmake.ctest.failurePatterns.expected%"
+              }
+            }
+          },
+          "default": [
+            {
+              "regexp": "(.*?):(\\d+): *(?:error: *)(.*)"
+            },
+            {
+                "regexp": "(.*?)\\((\\d+)\\): *(?:error: *)(.*)"
+            }
+          ],
+          "markdownDescription": "%cmake-tools.configuration.cmake.ctest.failurePatterns.markdownDescription%",
+          "scope": "machine-overridable"
+        },
         "cmake.ctest.debugLaunchTarget": {
           "type": "string",
           "default": null,

--- a/package.nls.json
+++ b/package.nls.json
@@ -126,7 +126,31 @@
         "comment": [
             "Markdown text between `` should not be translated or localized (they represent literal text) and the capitalization, spacing, and punctuation (including the ``) should not be altered."
         ]
-    }, 
+    },
+    "cmake-tools.configuration.cmake.ctest.failurePatterns.markdownDescription": {
+        "message": "Regular expressions for searching CTest output for additional details about failures. All patterns are tried and test failure details from each are collected.\n\nPatterns must have at minimum one capture group to match the name of the `file` where the failure occurred. They can optionally also capture `line`, `message`, `expected`, and `actual`.\n\nFor example, to match a failure line like `path/to/file:47: text of error message`, this pattern matcher could be used:\n```json\n{\n  \"regexp\": \"(.+):(\\\\d+): ?(.*)\",\n  \"file\": 1,\n  \"line\": 2,\n  \"message\": 3\n}\n```\n",
+        "comment": [
+            "Markdown text between `` should not be translated or localized (they represent literal text) and the capitalization, spacing, and punctuation (including the ``) should not be altered."
+        ]
+    },
+    "cmake-tools.configuration.cmake.ctest.failurePatterns.regexp": {
+        "message": "The regular expression to find a failure in the output."
+    },
+    "cmake-tools.configuration.cmake.ctest.failurePatterns.file": {
+        "message": "The match group index of the filename. If omitted 1 is used."
+    },
+    "cmake-tools.configuration.cmake.ctest.failurePatterns.line": {
+        "message": "The match group index of the failure's line. Defaults to 2."
+    },
+    "cmake-tools.configuration.cmake.ctest.failurePatterns.message": {
+        "message": "The match group index of the message. Defaults to 3."
+    },
+    "cmake-tools.configuration.cmake.ctest.failurePatterns.actual": {
+        "message": "The match group index of the actual test output. Defaults to undefined."
+    },
+    "cmake-tools.configuration.cmake.ctest.failurePatterns.expected": {
+        "message": "The match group index of the expected test output. Defaults to undefined."
+    },
 	"cmake-tools.configuration.cmake.ctest.debugLaunchTarget.description": "Target name from launch.json to start when debugging a test with CTest. By default and in case of a non-existing target, this will show a picker with all available targets.",
     "cmake-tools.configuration.cmake.parseBuildDiagnostics.description": "Parse compiler output for warnings and errors.",
     "cmake-tools.configuration.cmake.enabledOutputParsers.description": {

--- a/src/config.ts
+++ b/src/config.ts
@@ -173,7 +173,7 @@ export interface ExtensionConfigurationSettings {
     buildToolArgs: string[];
     parallelJobs: number;
     ctestPath: string;
-    ctest: { parallelJobs: number; allowParallelJobs: boolean; testExplorerIntegrationEnabled: boolean; testSuiteDelimiter: string; debugLaunchTarget: string | null };
+    ctest: { parallelJobs: number; allowParallelJobs: boolean; testExplorerIntegrationEnabled: boolean; testSuiteDelimiter: string; failurePatterns: Object; debugLaunchTarget: string | null };
     parseBuildDiagnostics: boolean;
     enabledOutputParsers: string[];
     debugConfig: CppDebugConfiguration;
@@ -387,6 +387,9 @@ export class ConfigurationReader implements vscode.Disposable {
     }
     get testSuiteDelimiter(): string {
         return this.configData.ctest.testSuiteDelimiter;
+    }
+    get ctestFailurePatterns(): Object {
+        return this.configData.ctest.failurePatterns;
     }
     get ctestDebugLaunchTarget(): string | null {
         return this.configData.ctest.debugLaunchTarget;
@@ -610,7 +613,7 @@ export class ConfigurationReader implements vscode.Disposable {
         parallelJobs: new vscode.EventEmitter<number>(),
         ctestPath: new vscode.EventEmitter<string>(),
         cpackPath: new vscode.EventEmitter<string>(),
-        ctest: new vscode.EventEmitter<{ parallelJobs: number; allowParallelJobs: boolean; testExplorerIntegrationEnabled: boolean; testSuiteDelimiter: string; debugLaunchTarget: string | null }>(),
+        ctest: new vscode.EventEmitter<{ parallelJobs: number; allowParallelJobs: boolean; testExplorerIntegrationEnabled: boolean; testSuiteDelimiter: string; failurePatterns: Object; debugLaunchTarget: string | null }>(),
         parseBuildDiagnostics: new vscode.EventEmitter<boolean>(),
         enabledOutputParsers: new vscode.EventEmitter<string[]>(),
         debugConfig: new vscode.EventEmitter<CppDebugConfiguration>(),

--- a/src/ctest.ts
+++ b/src/ctest.ts
@@ -132,6 +132,68 @@ interface ProjectCoverageConfig {
     coverageInfoFiles: string[];
 }
 
+interface FailurePattern {
+    regexp: string;
+    file?: number;
+    line?: number;
+    message?: number;
+    actual?: number;
+    expected?: number;
+}
+
+type FailurePatternsConfig = string | string[] | FailurePattern[];
+
+export function searchOutputForFailures(patterns: FailurePatternsConfig, output: string): vscode.TestMessage[] {
+    output = stripCarriageReturns(output);
+    const messages = [];
+    patterns = Array.isArray(patterns) ? patterns : [patterns];
+    for (let pattern of patterns) {
+        pattern = typeof pattern === 'string' ? pattern = { regexp: pattern } : pattern;
+        pattern.file ??= 1;
+        pattern.line ??= 2;
+        pattern.message ??= 3;
+
+        try {
+            for (const match of output.matchAll(RegExp(pattern.regexp, "g"))) {
+                if (pattern.file && match[pattern.file]) {
+                    messages.push(matchToTestMessage(pattern, match));
+                }
+            }
+        } catch (e) {
+            console.error(e);
+        }
+    }
+    return messages;
+}
+
+function matchToTestMessage(pat: FailurePattern, match: RegExpMatchArray): vscode.TestMessage {
+    const file = match[pat.file as number];
+    const line = pat.line ? parseLineMatch(match[pat.line]) : 0;
+    const message = pat.message && match[pat.message]?.trim() || 'Test Failed';
+    const actual = pat.actual ? match[pat.actual] : undefined;
+    const expected = pat.expected ? match[pat.expected] : undefined;
+
+    const testMessage = new vscode.TestMessage(message);
+    testMessage.location = new vscode.Location(
+        vscode.Uri.file(file), new vscode.Position(line, 0)
+    );
+    testMessage.expectedOutput = expected;
+    testMessage.actualOutput = actual;
+    return testMessage;
+}
+
+function stripCarriageReturns(s: string) {
+    return s.replace(RegExp(/\r\n?/, 'g'), '\n');
+}
+
+function parseLineMatch(line: string | null) {
+    const i = parseInt(line || '');
+    if (i) {
+        return i - 1;
+    }
+    return 0;
+}
+
 function parseXmlString<T>(xml: string): Promise<T> {
     return new Promise((resolve, reject) => {
         xml2js.parseString(xml, (err, result) => {
@@ -410,7 +472,13 @@ export class CTestDriver implements vscode.Disposable {
         } else {
             log.info(message.message);
         }
-        run.failed(test, message, duration);
+        const outputMessages = searchOutputForFailures(
+            this.ws.config.ctestFailurePatterns as FailurePatternsConfig,
+            // string cast OK; never passed TestMessage with MarkdownString message
+            message.message as string
+        );
+        const messages = outputMessages.length ? outputMessages : message;
+        run.failed(test, messages, duration);
     }
 
     /**

--- a/test/unit-tests/config.test.ts
+++ b/test/unit-tests/config.test.ts
@@ -29,6 +29,7 @@ function createConfig(conf: Partial<ExtensionConfigurationSettings>): Configurat
             allowParallelJobs: false,
             testExplorerIntegrationEnabled: true,
             testSuiteDelimiter: '',
+            failurePatterns: [],
             debugLaunchTarget: null
         },
         parseBuildDiagnostics: true,

--- a/test/unit-tests/ctest.test.ts
+++ b/test/unit-tests/ctest.test.ts
@@ -1,5 +1,6 @@
-import { readTestResultsFile } from "@cmt/ctest";
+import { readTestResultsFile, searchOutputForFailures } from "@cmt/ctest";
 import { expect, getTestResourceFilePath } from "@test/util";
+import { TestMessage } from "vscode";
 
 suite('CTest test', () => {
     test('Parse XML test results', async () => {
@@ -21,4 +22,61 @@ suite('CTest test', () => {
         const result = await readTestResultsFile(getTestResourceFilePath('TestCMakeCache.txt'));
         expect(result).to.eq(undefined);
     });
+
+    test('Find failure patterns in output', () => {
+        const DEFAULT_MESSAGE = 'Test Failed';
+        const output =
+            '/path/to/file:47: the message\r\n'
+            + 'expected wanted this\r\n'
+            + 'actual got this\r\n'
+            + '/only/required/field::\r\n'
+            + '(42) other message: /path/to/other/file\r\n'
+            + 'actually got one thing\r\n'
+            + 'but wanted another\r\n';
+        const results = searchOutputForFailures([
+            {
+                regexp: /(.*):(\d*): ?(.*)(?:\nexpected (.*))?(?:\nactual (.*))?/.source,
+                expected: 4,
+                actual: 5
+            },
+            {
+                regexp: /\((\d*)\) ([^:]*):\s(.*)\nactually got (.*)\nbut wanted (.*)/.source,
+                file: 3,
+                message: 2,
+                line: 1,
+                actual: 4,
+                expected: 5
+            }
+        ], output);
+        expect(results.length).to.eq(3);
+        const [result1, result2, result3] = results;
+        assertMessageFields(result1, '/path/to/file', 46, 0, 'the message', 'wanted this', 'got this');
+        assertMessageFields(result2, '/only/required/field', 0, 0, DEFAULT_MESSAGE, undefined, undefined);
+        assertMessageFields(result3, '/path/to/other/file', 41, 0, 'other message', 'another', 'one thing');
+
+        const result4 = searchOutputForFailures(/(.*):(\d+):/.source, output)[0];
+        assertMessageFields(result4, '/path/to/file', 46, 0, DEFAULT_MESSAGE, undefined, undefined);
+
+        const results2 = searchOutputForFailures([
+            /\/only(.*)::/.source,
+            /(.*):(\d+): (.*)/.source
+        ], output);
+        expect(results2.length).to.eq(2);
+        const [result5, result6] = results2;
+        assertMessageFields(result5, '/required/field', 0, 0, DEFAULT_MESSAGE, undefined, undefined);
+        assertMessageFields(result6, '/path/to/file', 46, 0, 'the message', undefined, undefined);
+    });
+
+    function assertMessageFields(
+        tm: TestMessage,
+        file: string, line: number, column: number, message: string,
+        expected: string | undefined, actual: string | undefined
+    ): void {
+        expect(tm.message).to.eq(message);
+        expect(tm.location?.uri.path).to.eq(file);
+        expect(tm.location?.range.start.line).to.eq(line);
+        expect(tm.location?.range.start.character).to.eq(column);
+        expect(tm.expectedOutput).to.eq(expected);
+        expect(tm.actualOutput).to.eq(actual);
+    }
 });


### PR DESCRIPTION
## This change addresses item #4418

### This changes visible behavior

The following changes are proposed:

Adds configuration setting `cmake.ctest.failurePatterns`, a list of regular expressions and capture group indices for matching file, line, message, expected output, and actual output from failing tests.

## The purpose of this change

Populate `TestMessage` objects with more specific information about test failures than is available through the `DEF_SOURCE_LINE` property.

## Other Notes/Information

I based the design of this feature around the design of Task Problem Matchers. It lacks some of the advanced features of Problem Matchers, like named patterns, pattern inheritance, multi-regexp patterns, and loops. I'm happy to add those to the implementation if needed, but I thought it better to start with the simplest thing that could work and grow it in response to feedback.

## Screenshots

![image](https://github.com/user-attachments/assets/579ae4d3-80ca-416e-8c18-d926f2108486)

![image](https://github.com/user-attachments/assets/e8e8165b-31c4-4793-b1ba-cc492e75f095)

![image](https://github.com/user-attachments/assets/edfd97e0-ff73-4a06-b7a7-c9dae36f78af)
