### PR TITLE
Fix evaluates of presets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Bug Fixes:
 - Fixes localization for "workspace is" string. [#4374](https://github.com/microsoft/vscode-cmake-tools/issues/4374)
 - Make tooltips for selecting Launch/Debug Target. [#4373](https://github.com/microsoft/vscode-cmake-tools/issues/4373)
 - Fix bug where unrelated symlinks are read as variant files [#4304](https://github.com/microsoft/vscode-cmake-tools/issues/4304) [@vitorramos](https://github.com/vitorramos).
+- Fix evaluation of conditions in presets. [#4425](https://github.com/microsoft/vscode-cmake-tools/issues/4425)
 
 ## 1.20.53
 

--- a/src/presets/preset.ts
+++ b/src/presets/preset.ts
@@ -1297,7 +1297,7 @@ export async function expandConfigurePresetVariables(preset: ConfigurePreset, fo
     // Put the preset.environment on top of combined environment in the `__parentEnvironment` field.
     // If for some reason the preset.__parentEnvironment is undefined, default to process.env.
     // NOTE: Based on logic in `tryApplyVsDevEnv`, `preset.__parentEnvironment` should never be undefined at this point.
-    const env = EnvironmentUtils.mergePreserveNull([preset.__parentEnvironment ?? process.env, preset.environment]);
+    const env = EnvironmentUtils.mergePreserveNull([process.env, preset.__parentEnvironment, preset.environment]);
 
     // Expand strings under the context of current preset, also, pass preset.__parentEnvironment as a penvOverride so we include devenv if present.
     // `preset.__parentEnvironment` is allowed to be undefined here because in expansion, it will default to process.env.
@@ -1676,7 +1676,7 @@ async function getBuildPresetInheritsHelper(folder: string, preset: BuildPreset,
 }
 
 export async function expandBuildPresetVariables(preset: BuildPreset, name: string, workspaceFolder: string, sourceDir: string, errorHandler?: ExpansionErrorHandler): Promise<BuildPreset> {
-    const env = EnvironmentUtils.mergePreserveNull([preset.__parentEnvironment ?? process.env, preset.environment]);
+    const env = EnvironmentUtils.mergePreserveNull([process.env, preset.__parentEnvironment, preset.environment]);
 
     // Expand strings under the context of current preset
     const expandedPreset: BuildPreset = { name };
@@ -1852,7 +1852,7 @@ async function getTestPresetInheritsHelper(folder: string, preset: TestPreset, w
 }
 
 export async function expandTestPresetVariables(preset: TestPreset, name: string, workspaceFolder: string, sourceDir: string, errorHandler?: ExpansionErrorHandler): Promise<TestPreset> {
-    const env = EnvironmentUtils.mergePreserveNull([preset.__parentEnvironment ?? process.env, preset.environment]);
+    const env = EnvironmentUtils.mergePreserveNull([process.env, preset.__parentEnvironment, preset.environment]);
 
     const expandedPreset: TestPreset = { name };
     const expansionOpts: ExpansionOptions = await getExpansionOptions(workspaceFolder, sourceDir, preset, env, preset.__parentEnvironment);
@@ -2066,7 +2066,7 @@ async function getPackagePresetInheritsHelper(folder: string, preset: PackagePre
 }
 
 export async function expandPackagePresetVariables(preset: PackagePreset, name: string, workspaceFolder: string, sourceDir: string, errorHandler?: ExpansionErrorHandler): Promise<PackagePreset> {
-    const env = EnvironmentUtils.mergePreserveNull([preset.__parentEnvironment ?? process.env, preset.environment]);
+    const env = EnvironmentUtils.mergePreserveNull([process.env, preset.__parentEnvironment, preset.environment]);
 
     const expandedPreset: PackagePreset = { name };
     // Package presets cannot expand the macro ${generator} so this can't be included in opts


### PR DESCRIPTION
This ensures that the evaluation of variables expand based on the parent environment and the underlying process.env. 

It should be noted that this will have some unique behavior when developer environments are invoked, because we only invoke the developer environment when we select the build preset. 

Fixes #4425 