### PR TITLE
improv: shlex.split() function heap allocs & perf for large compile commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Features:
 Improvements:
 
 - No longer convert paths on lowercase on MacOS to enable cpp tools to resolve them. [#4325](https://github.com/microsoft/vscode-cmake-tools/pull/4325) [@tringenbach](https://github.com/tringenbach)
+- Speedup & reduce heap allocations in shlex split module function. Significant gains for mid-large compile_commands.json - CompilationDatabase construction. [#4458](https://github.com/microsoft/vscode-cmake-tools/pull/4458) [@borjamunozf](https://github.com/borjamunozf)
 
 Bug Fixes:
 

--- a/src/shlex.ts
+++ b/src/shlex.ts
@@ -76,7 +76,6 @@ export function* split(str: string, opt?: ShlexOptions): Iterable<string> {
     }
 }
 
-
 /**
  * Quotes a string for safe use in a shell command.
  * If the string contains special characters, it will be wrapped in double quotes and any existing double quotes will be escaped.

--- a/src/shlex.ts
+++ b/src/shlex.ts
@@ -13,21 +13,23 @@ export function* split(str: string, opt?: ShlexOptions): Iterable<string> {
     opt = opt || {
         mode: process.platform === 'win32' ? 'windows' : 'posix'
     };
+
     const quoteChars = opt.mode === 'posix' ? '\'"' : '"';
     const escapeChars = '\\';
     let escapeChar: string | undefined;
-    let token: string | undefined;
+    let token: string[] = [];
     let isSubQuote: boolean = false;
 
     for (let i = 0; i < str.length; ++i) {
         const char = str.charAt(i);
+
         if (escapeChar) {
             if (char === '\n') {
                 // Do nothing
             } else if (escapeChars.includes(char)) {
-                token = (token || '') + char;
+                token.push(char);
             } else {
-                token = (token || '') + escapeChar + char;
+                token.push(escapeChar, char);  // Append escape sequence
             }
             // We parsed an escape seq. Reset to no escape
             escapeChar = undefined;
@@ -35,47 +37,45 @@ export function* split(str: string, opt?: ShlexOptions): Iterable<string> {
         }
 
         if (escapeChars.includes(char)) {
-            // We're parsing an escape sequence.
+            // Start escape sequence
             escapeChar = char;
             continue;
         }
 
         if (isSubQuote) {
             if (quoteChars.includes(char)) {
-                // Reached the end of a sub-quoted token.
+                // End of sub-quoted token
                 isSubQuote = false;
-                token = (token || '') + char;
+                token.push(char);
                 continue;
             }
-            // Another quoted char
-            token = (token || '') + char;
+            token.push(char);
             continue;
         }
 
         if (quoteChars.includes(char)) {
-            // Beginning of a sub-quoted token
+            // Beginning of a subquoted token
             isSubQuote = true;
-            // Accumulate
-            token = (token || '') + char;
+            token.push(char);
             continue;
         }
 
         if (!isSubQuote && /[\t \n\r\f]/.test(char)) {
-            if (token !== undefined) {
-                yield token;
+            if (token.length > 0) {
+                yield token.join('');
             }
-            token = undefined;
+            token = [];
             continue;
         }
 
-        // Accumulate
-        token = (token || '') + char;
+        token.push(char);
     }
 
-    if (token !== undefined) {
-        yield token;
+    if (token.length > 0) {
+        yield token.join('');
     }
 }
+
 
 /**
  * Quotes a string for safe use in a shell command.


### PR DESCRIPTION
<!-- Thanks for your contribution! To make things easier, please fill out the template below. -->

<!-- Please delete any unused sections. -->

<!-- Delete the following heading if there is no corresponding issue -->
## This change addresses item #4283 

The following changes are proposed:

- Coming from a discussion regarding #4283 and also related to #4279 I appreciated a huge heap usage when working with our large compile_commands.json generated by the build system.

The shlex (and CompileDatabase infoByFilePath) is only responsible for an average usage in the heap of ~4GB across our different projects. It also takes an avg of 35-40sg to parse.

- After digging a bit in the code and benchmarking it, it looks like an almost direct improvement to the **split** function is to avoid the naive string concatenation and extra heap allocations with a token array and joining at the end.

## The purpose of this change

- Reduce heap usage at least 50-60% in mid to large CompileDatabase
- Improve response times after the configuring step and processing of the Compile Database.
- Function signature and functionality respected avoiding possible side effects.

## Other Notes/Information

Probably there could be room to improve or optimize further, but I think this is a almost direct and easy change to apply.

<!-- Write whatever you feel is relevant -->

Tests seems to pass ok.

Some dummy file to bench:
```

import { CompilationDatabase, CompileCommand } from './compilationDatabase';
import { fs } from './pr';
import * as v8 from 'v8';
import * as shlex from './shlex';
import { time } from 'console';
import * as util from './util';

const databasePaths = [
    '/home/borjamf/workspace/vscode-cmake-tools/src/compile_commands.json',
];

function logHeapUsage() {
    const heapStats = v8.getHeapStatistics();
    console.log('Heap Statistics:');
    console.log(`Total heap size: ${heapStats.total_heap_size / 1024 / 1024} MB`);
    console.log(`Used heap size: ${heapStats.used_heap_size / 1024 / 1024} MB`);
    console.log(`Heap size limit: ${heapStats.heap_size_limit / 1024 / 1024} MB`);
}

async function buildCompileCommands(databasePaths: string[]): Promise<CompileCommand[]> {
    const database: CompileCommand[] = [];
    for (const path of databasePaths) {
        if (!await fs.exists(path)) {
            continue;
        }

        const fileContent = await fs.readFile(path);
        try {
            const content = JSON.parse(fileContent.toString()) as CompileCommand[];
            database.push(...content);
        } catch (e) {
            return database
        }
    }
    return database;
}

async function main() {
    const cmd_commands: CompileCommand[] = await buildCompileCommands(databasePaths);
    logHeapUsage();

    console.log("Before building the map")
    console.time('Total time spent building infoByFilePath: current-shlex');
    const infoByFilePath = cmd_commands.reduce(
                (acc, cur) => acc.set(cur.file, {
                    directory: cur.directory,
                    file: cur.file,
                    output: cur.output,
                    command: cur.command,
                    arguments: cur.arguments ? cur.arguments : [...shlex.split(cur.command)]
                }),
                new Map<string, CompileCommand>()
    );

    console.timeEnd('Total time spent building infoByFilePath: shlexSplit');

    console.log("After building the map")
    logHeapUsage();
}

main();
```

Heap stats with current split: **4GB** + time 48.452s
![imagen](https://github.com/user-attachments/assets/13c74107-cc0a-4898-9dfd-b71e6d3b54d6)

Heap stats after optimized split: **600Mb** + time ~16s
![imagen](https://github.com/user-attachments/assets/018bcc37-e1ef-4f0c-b8af-6e4f03cdf701)

