### PR TITLE
Associate CTest tests with `add_test()` wrappers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Improvements:
 - Add name de-mangling for C++ symbols in the Test Explorer view when running tests with coverage. [#4340](https://github.com/microsoft/vscode-cmake-tools/pull/4340) [@rjaegers](https://github.com/rjaegers)
 - No longer convert paths on lowercase on MacOS to enable cpp tools to resolve them. [#4325](https://github.com/microsoft/vscode-cmake-tools/pull/4325) [@tringenbach](https://github.com/tringenbach)
 - Speedup & reduce heap allocations in shlex split module function. Significant gains for mid-large compile_commands.json - CompilationDatabase construction. [#4458](https://github.com/microsoft/vscode-cmake-tools/pull/4458) [@borjamunozf](https://github.com/borjamunozf)
+- In the Test Explorer, associate CTest tests with outermost function or macro invocation that calls `add_test()` instead of with the `add_test()` call itself. [#4490](https://github.com/microsoft/vscode-cmake-tools/issues/4490) [@malsyned]
 
 Bug Fixes:
 

--- a/src/ctest.ts
+++ b/src/ctest.ts
@@ -835,11 +835,16 @@ export class CTestDriver implements vscode.Disposable {
                         }
                     }
 
-                    if (!testDefFile && test.backtrace !== undefined && this.tests!.backtraceGraph.nodes[test.backtrace] !== undefined) {
+                    const nodes = this.tests!.backtraceGraph.nodes;
+                    if (!testDefFile && test.backtrace !== undefined && nodes[test.backtrace] !== undefined) {
                         // Use the backtrace graph to find the file and line number
                         // This finds the CMake module's file and line number and not the test file and line number
-                        testDefFile = this.tests!.backtraceGraph.files[this.tests!.backtraceGraph.nodes[test.backtrace].file];
-                        testDefLine = this.tests!.backtraceGraph.nodes[test.backtrace].line;
+                        let node = nodes[test.backtrace];
+                        while (nodes[node.parent!].command !== undefined) {
+                            node = nodes[node.parent!];
+                        }
+                        testDefFile = this.tests!.backtraceGraph.files[node.file];
+                        testDefLine = node.line;
                     }
 
                     const testAndParentSuite = this.createTestItemAndSuiteTree(test.name, testExplorerRoot, initializedTestExplorer, testDefFile ? vscode.Uri.file(testDefFile) : undefined);


### PR DESCRIPTION
When CTest tests are associated directly with `add_test()` calls in the Test Explorer, then using functions that wrap `add_test()` leads to having many tests linked to the exact same line of code. Instead, walk the CTest backtrace from the `add_test()` call and associate the test with the outermost stack frame.

<!-- Thanks for your contribution! To make things easier, please fill out the template below. -->

<!-- Please delete any unused sections. -->

<!-- Delete the following heading if there is no corresponding issue -->
## This change addresses item #4490

### This changes visible behavior

The following changes are proposed:

Clicking each test brings the cursor to the line of code where an `add_test()` wrapper function or macro is invoked, instead of that wrapper's call to `add_test()`. The testing gutter controls also appear next to the invocation lines of the wrapper instead of on the line with the `add_test()` call.

![Image](https://github.com/user-attachments/assets/ce0657ad-4749-4b36-ab68-beaddd972d8f)

## Other Notes/Information

The self-test suite for CMake itself makes frequent use of functions or macros that call `add_test()` to define test suites, so merging this PR would dramatically improve the user experience for the developers of CMake.

Without this PR, clicking any of over 300 tests leads to the same line of code in `add_RunCMake_test`, and over 100 tests are associated with the same line of code in `ADD_TEST_MACRO`. With it, the situation is much more tractable:

![image](https://github.com/user-attachments/assets/c0764aad-bf18-411b-be76-510b82ef848b)

![image](https://github.com/user-attachments/assets/a18f2b6e-e067-4b5b-b843-e4f43430a0ab)

