### PR TITLE
Fix RegExp 'd' flag compatibility issue in createTestItemAndSuiteTree

### DIFF
--- a/src/ctest.ts
+++ b/src/ctest.ts
@@ -698,17 +698,17 @@ export class CTestDriver implements vscode.Disposable {
             if (maxCount === 0) {
                 maxCount = Number.MAX_SAFE_INTEGER;
             }
-            const delimiterRegExp = new RegExp(regexString, 'dg');
+            const delimiterRegExp = new RegExp(regexString, 'g');
             const parts = [];
             let lastStart = 0;
             while (parts.length < maxCount) {
-                const match: any = delimiterRegExp.exec(subject);
-                if (match === null || match.indices === null) {
+                const match = delimiterRegExp.exec(subject);
+                if (match === null) { // Remove match.indices check
                     break;
                 }
 
-                parts.push(subject.substring(lastStart, match.indices[0][0]));
-                lastStart = match.indices[0][1];
+                parts.push(subject.substring(lastStart, match.index!));
+                lastStart = match.index! + match[0].length;
             }
 
             parts.push(subject.substring(lastStart));


### PR DESCRIPTION
### This changes performance/compatibility

The following changes are proposed:

- Remove unsupported 'd' flag from RegExp constructor in `limited_split` function
- Replace `match.indices[0][0]` and `match.indices[0][1]` with `match.index!` and `match.index! + match[0].length`
- Maintain identical functionality while improving compatibility across different JavaScript environments
- Fix "Invalid flags: dg" error when test suite delimiters are used with gtest-style test names

## The purpose of this change

The `'d'` flag (which provides `match.indices`) is not supported in all JavaScript engines that VS Code extension host might run on. When test suite delimiters like `"\\."` or `"_"` are used and match characters in test names, the `limited_split` function in `createTestItemAndSuiteTree` fails with "Invalid flags: dg" error.

This change improves compatibility by using the standard `match.index` property (supported since ES3) instead of the newer `match.indices` property that requires the `'d'` flag. The functionality remains identical - string splitting works the same way with better cross-environment support.

## Other Notes/Information

The issue started when I tried to parse test names with the delimiter in an environment which used GoogleTest (gtest) for testing.
I'm not 100% certain but I think the issue might have been that gtest will append the test case during discovery with a dot, like this: `myTest.myTestCase`. I could fix this locally and make the delimiters working as expected by removing the d flag.

- No behavioral changes - only improved compatibility
- Uses well-established `match.index` property available in all JavaScript environments
- Particularly beneficial for users experiencing the "Invalid flags: dg" error during test discovery