### PR TITLE
Set Build Target Same As Launch Target feature

### DIFF
--- a/package.json
+++ b/package.json
@@ -3684,6 +3684,12 @@
             "default": false,
             "description": "%cmake-tools.configuration.cmake.useFolderPropertyInBuildTargetDropdown.description%",
             "scope": "resource"
+        },
+        "cmake.setBuildTargetSameAsLaunchTarget": {
+          "type": "boolean",
+          "default": false,
+          "description": "%cmake-tools.configuration.cmake.setBuildTargetSameAsLaunchTarget.description%",
+          "scope": "resource"
         }
       }
     },

--- a/package.nls.json
+++ b/package.nls.json
@@ -308,6 +308,7 @@
     "cmake-tools.configuration.cmake.postRunCoverageTarget.description": "Target to build after running tests with coverage using the test explorer",
     "cmake-tools.configuration.cmake.coverageInfoFiles.description": "LCOV coverage info files to be processed after running tests with coverage using the test explorer.",
     "cmake-tools.configuration.cmake.useFolderPropertyInBuildTargetDropdown.description": "Controls if the default build target dropdown is grouped by the CMake folder groups.",
+    "cmake-tools.configuration.cmake.setBuildTargetSameAsLaunchTarget.description": "When the launch target is set, the build target is set to match it.",
     "cmake-tools.debugger.pipeName.description": "Name of the pipe (on Windows) or domain socket (on Unix) to use for debugger communication.",
     "cmake-tools.debugger.clean.description": "Clean prior to configuring.",
     "cmake-tools.debugger.configureAll.description": "Configure for all projects.",

--- a/src/cmakeProject.ts
+++ b/src/cmakeProject.ts
@@ -2565,8 +2565,7 @@ export class CMakeProject {
             return null;
         } if (executableTargets.length === 1) {
             const target = executableTargets[0];
-            await this.workspaceContext.state.setLaunchTargetName(this.folderName, target.name, this.isMultiProjectFolder);
-            this._launchTargetName.set(target.name);
+            await this.setLaunchTargetName(target.name);
             return target.path;
         }
 
@@ -2584,9 +2583,16 @@ export class CMakeProject {
         if (!chosen) {
             return null;
         }
-        await this.workspaceContext.state.setLaunchTargetName(this.folderName, chosen.label, this.isMultiProjectFolder);
-        this._launchTargetName.set(chosen.label);
+        await this.setLaunchTargetName(chosen.label);
         return chosen.detail;
+    }
+
+    private async setLaunchTargetName(name: string) {
+        await this.workspaceContext.state.setLaunchTargetName(this.folderName, name, this.isMultiProjectFolder);
+        if (this.workspaceContext.config.setBuildTargetSameAsLaunchTarget) {
+            await this.setDefaultBuildTarget(name);
+        }
+        this._launchTargetName.set(name);
     }
 
     async getCurrentLaunchTarget(): Promise<ExecutableTarget | null> {

--- a/src/config.ts
+++ b/src/config.ts
@@ -223,6 +223,7 @@ export interface ExtensionConfigurationSettings {
     postRunCoverageTarget: string | null;
     coverageInfoFiles: string[];
     useFolderPropertyInBuildTargetDropdown: boolean;
+    setBuildTargetSameAsLaunchTarget: boolean;
 }
 
 type EmittersOf<T> = {
@@ -601,6 +602,10 @@ export class ConfigurationReader implements vscode.Disposable {
         return this.configData.useFolderPropertyInBuildTargetDropdown;
     }
 
+    get setBuildTargetSameAsLaunchTarget(): boolean {
+        return this.configData.setBuildTargetSameAsLaunchTarget;
+    }
+
     private readonly emitters: EmittersOf<ExtensionConfigurationSettings> = {
         autoSelectActiveFolder: new vscode.EventEmitter<boolean>(),
         defaultActiveFolder: new vscode.EventEmitter<string | null>(),
@@ -671,7 +676,8 @@ export class ConfigurationReader implements vscode.Disposable {
         preRunCoverageTarget: new vscode.EventEmitter<string | null>(),
         postRunCoverageTarget: new vscode.EventEmitter<string | null>(),
         coverageInfoFiles: new vscode.EventEmitter<string[]>(),
-        useFolderPropertyInBuildTargetDropdown: new vscode.EventEmitter<boolean>()
+        useFolderPropertyInBuildTargetDropdown: new vscode.EventEmitter<boolean>(),
+        setBuildTargetSameAsLaunchTarget: new vscode.EventEmitter<boolean>(),
     };
 
     /**

--- a/test/unit-tests/config.test.ts
+++ b/test/unit-tests/config.test.ts
@@ -84,7 +84,8 @@ function createConfig(conf: Partial<ExtensionConfigurationSettings>): Configurat
         preRunCoverageTarget: null,
         postRunCoverageTarget: null,
         coverageInfoFiles: [],
-        useFolderPropertyInBuildTargetDropdown: true
+        useFolderPropertyInBuildTargetDropdown: true,
+        setBuildTargetSameAsLaunchTarget: false,
     });
     ret.updatePartial(conf);
     return ret;


### PR DESCRIPTION
<!-- Thanks for your contribution! To make things easier, please fill out the template below. -->

<!-- Please delete any unused sections. -->

<!-- Delete the following heading if there is no corresponding issue -->
## This change addresses item #4466

### This changes visible behavior

The following changes are proposed:

- 'Set Build Target Same As Launch Target' setting is added.
- When enabled: when the launch target is set, the build target is set to match it.
