### PR TITLE
Build tests prior to executing them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # What's New?
 
+Improvements:
+
+- When CMake is invoked prior to running tests, build targets required for the test rather than everything. [#4515](https://github.com/microsoft/vscode-cmake-tools/issues/4515)
+
 ## 1.21
 
 Features:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,5 @@
 # What's New?
 
-Improvements:
-
-- When CMake is invoked prior to running tests, build targets required for the test rather than everything. [#4515](https://github.com/microsoft/vscode-cmake-tools/issues/4515)
-
 ## 1.21
 
 Features:
@@ -21,6 +17,7 @@ Improvements:
 - No longer convert paths on lowercase on MacOS to enable cpp tools to resolve them. [#4325](https://github.com/microsoft/vscode-cmake-tools/pull/4325) [@tringenbach](https://github.com/tringenbach)
 - Speedup & reduce heap allocations in shlex split module function. Significant gains for mid-large compile_commands.json - CompilationDatabase construction. [#4458](https://github.com/microsoft/vscode-cmake-tools/pull/4458) [@borjamunozf](https://github.com/borjamunozf)
 - In the Test Explorer, associate CTest tests with outermost function or macro invocation that calls `add_test()` instead of with the `add_test()` call itself. [#4490](https://github.com/microsoft/vscode-cmake-tools/issues/4490) [@malsyned](https://github.com/malsyned)
+- When CMake is invoked prior to running tests, build targets required for the test rather than everything. [#4515](https://github.com/microsoft/vscode-cmake-tools/issues/4515) [@epistax](https://github.com/epistax)
 
 Bug Fixes:
 

--- a/src/ctest.ts
+++ b/src/ctest.ts
@@ -134,7 +134,7 @@ interface ProjectCoverageConfig {
 
 function parseXmlString<T>(xml: string): Promise<T> {
     return new Promise((resolve, reject) => {
-        xml2js.parseString(xml, (err: any, result: T | PromiseLike<T>) => {
+        xml2js.parseString(xml, (err, result) => {
             if (err) {
                 reject(err);
             } else {
@@ -1314,12 +1314,15 @@ export class CTestDriver implements vscode.Disposable {
                 this.ctestErrored(test, run, { message: localize('no.project.found', 'No project found for folder {0}', folder) });
                 return false;
             }
-            if (!foundTarget.has(project!)) {
-                foundTarget.set(project!, new Map<string, vscode.TestItem[]>([[testProgram, [test]]]));
-            } else if (!foundTarget.get(project!)?.has(testProgram)) {
-                foundTarget.get(project!)?.set(testProgram, [test]);
+            if (!foundTarget.has(project)) {
+                foundTarget.set(project, new Map<string, vscode.TestItem[]>([[testProgram, [test]]]));
             } else {
-                foundTarget.get(project!)?.get(testProgram)?.push(test);
+                const prj = foundTarget.get(project)!;
+                if (!prj.has(testProgram)) {
+                    prj.set(testProgram, [test]);
+                } else {
+                    prj.get(testProgram)!.push(test);
+                }
             }
         }
         return true;

--- a/src/ctest.ts
+++ b/src/ctest.ts
@@ -1304,10 +1304,16 @@ export class CTestDriver implements vscode.Disposable {
         if (test.children.size > 0) {
             const children = this.testItemCollectionToArray(test.children);
             for (const child of children) {
-                await this.getTestTargets(child, foundTarget, run);
+                if (!await this.getTestTargets(child, foundTarget, run)) {
+                    return false;
+                }
             }
         } else {
             const testProgram = this.testProgram(test.id);
+            if (!testProgram) {
+                this.ctestErrored(test, run, { message: localize('test.program.not.found', 'Test program not found for {0}', test.id) });
+                return false;
+            }
             const folder = this.getTestRootFolder(test);
             const project = await this.projectController?.getProjectForFolder(folder);
             if (!project) {
@@ -1335,13 +1341,24 @@ export class CTestDriver implements vscode.Disposable {
     private async buildTestTargets(foundTarget: Map<CMakeProject, Map<string, vscode.TestItem[]>>, run: vscode.TestRun): Promise<boolean> {
         let overallSuccess = true;
         for (const [project, targets] of foundTarget) {
-            const binaryDir = (await project.binaryDir).toString();
-            const accmulatedTestList: vscode.TestItem[] = [];
+            const execTargets = await project.executableTargets;
+            const exePathToTargetName = new Map<string, string>();
+            for (const t of execTargets) {
+                exePathToTargetName.set(path.normalize(t.path), t.name);
+            }
+            const accumulatedTestList: vscode.TestItem[] = [];
             const accumulatedTargets: string[] = [];
             let success: boolean = true;
-            for  (const [targetName, testList] of targets) {
-                accumulatedTargets.push(path.relative(binaryDir, targetName));
-                accmulatedTestList.concat(testList);
+            for (const [testProgramPath, testList] of targets) {
+                const normalizedPath = path.normalize(testProgramPath);
+                const targetName = exePathToTargetName.get(normalizedPath);
+                if (targetName) {
+                    accumulatedTargets.push(targetName);
+                } else {
+                    // Fallback: use the file name without extension as the target name
+                    accumulatedTargets.push(path.basename(testProgramPath, path.extname(testProgramPath)));
+                }
+                accumulatedTestList.push(...testList);
             }
             try {
                 if (extensionManager !== undefined && extensionManager !== null) {
@@ -1356,11 +1373,11 @@ export class CTestDriver implements vscode.Disposable {
             }
             if (!success) {
                 overallSuccess = false;
-                accmulatedTestList.forEach(test => {
+                accumulatedTestList.forEach(test => {
                     this.ctestErrored(test, run, { message: localize('build.failed', 'Build failed') });
                 });
             }
-        };
+        }
         return overallSuccess;
     }
 

--- a/src/ctest.ts
+++ b/src/ctest.ts
@@ -1304,16 +1304,10 @@ export class CTestDriver implements vscode.Disposable {
         if (test.children.size > 0) {
             const children = this.testItemCollectionToArray(test.children);
             for (const child of children) {
-                if (!await this.getTestTargets(child, foundTarget, run)) {
-                    return false;
-                }
+                await this.getTestTargets(child, foundTarget, run);
             }
         } else {
             const testProgram = this.testProgram(test.id);
-            if (!testProgram) {
-                this.ctestErrored(test, run, { message: localize('test.program.not.found', 'Test program not found for {0}', test.id) });
-                return false;
-            }
             const folder = this.getTestRootFolder(test);
             const project = await this.projectController?.getProjectForFolder(folder);
             if (!project) {
@@ -1341,24 +1335,13 @@ export class CTestDriver implements vscode.Disposable {
     private async buildTestTargets(foundTarget: Map<CMakeProject, Map<string, vscode.TestItem[]>>, run: vscode.TestRun): Promise<boolean> {
         let overallSuccess = true;
         for (const [project, targets] of foundTarget) {
-            const execTargets = await project.executableTargets;
-            const exePathToTargetName = new Map<string, string>();
-            for (const t of execTargets) {
-                exePathToTargetName.set(path.normalize(t.path), t.name);
-            }
-            const accumulatedTestList: vscode.TestItem[] = [];
+            const binaryDir = (await project.binaryDir).toString();
+            const accmulatedTestList: vscode.TestItem[] = [];
             const accumulatedTargets: string[] = [];
             let success: boolean = true;
-            for (const [testProgramPath, testList] of targets) {
-                const normalizedPath = path.normalize(testProgramPath);
-                const targetName = exePathToTargetName.get(normalizedPath);
-                if (targetName) {
-                    accumulatedTargets.push(targetName);
-                } else {
-                    // Fallback: use the file name without extension as the target name
-                    accumulatedTargets.push(path.basename(testProgramPath, path.extname(testProgramPath)));
-                }
-                accumulatedTestList.push(...testList);
+            for  (const [targetName, testList] of targets) {
+                accumulatedTargets.push(path.relative(binaryDir, targetName));
+                accmulatedTestList.concat(testList);
             }
             try {
                 if (extensionManager !== undefined && extensionManager !== null) {
@@ -1373,11 +1356,11 @@ export class CTestDriver implements vscode.Disposable {
             }
             if (!success) {
                 overallSuccess = false;
-                accumulatedTestList.forEach(test => {
+                accmulatedTestList.forEach(test => {
                     this.ctestErrored(test, run, { message: localize('build.failed', 'Build failed') });
                 });
             }
-        }
+        };
         return overallSuccess;
     }
 


### PR DESCRIPTION
## This change addresses item #4515

### This changes the build-before-test behavior

The following changes are proposed:

- When build before test is enabled, the extension will review the list of selected tests, which projects they are in, and request a minimum build from CMake.
- This is done by explicitly asking CMake to build the test executables. 

## The purpose of this change

- When building before test, the current behavior is to pass no build target to CMake, resulting in the ALL target.
- This will require that everything built by ALL works in order to run _any_ test. The only alternative is for the user to disable build before testing entirely, which is also not ideal.
- It's also possible that the particular target needed to built the test is excluded from _all_ in which case the current build isn't sufficient to prepare the selected test(s) to run.

## Other Notes/Information

I have never contributed to this project before and I ran into difficulties running the tests. I was not able to find any testss related to the change and I'd be willing to expand the test base with a little bit of instruction. I was not able to find a proper venue for getting started with the testing. There appears to be some required machine setup prior to running the tests. Thank you for any assistance!
This change opens up the possibility for very long command lines when invoking CMake. I am not aware if munging is taken care of automatically or if I need to introduce something myself. 
