### PR TITLE
buildKitVendor etc.. expansion for clang-cl support

### DIFF
--- a/src/kits/kit.ts
+++ b/src/kits/kit.ts
@@ -61,7 +61,7 @@ export interface CMakeGenerator {
     platform?: string;
 }
 
-type CompilerVendorEnum = 'Clang' | 'GCC' | 'MSVC';
+type CompilerVendorEnum = 'Clang' | 'ClangCl' | 'GCC' | 'MSVC';
 
 export interface KitDetect {
     /**
@@ -176,7 +176,7 @@ export async function getCompilerVersion(vendor: CompilerVendorEnum, binPath: st
     }
     let version_re: RegExp;
     let version_match_index;
-    if (vendor === 'Clang') {
+    if (vendor === 'Clang' || vendor === 'ClangCl') {
         version_re = /^(?:Apple LLVM|.*clang) version ([^\s-]+)(?:[\s-]|$)/mgi;
         version_match_index = 1;
     } else {
@@ -268,6 +268,8 @@ export async function getKitDetect(kit: Kit): Promise<KitDetect> {
             vendor = 'GCC';
         } else if (kit.name.startsWith('Clang ')) {
             vendor = 'Clang';
+        } else if (kit.name.startsWith('Clang-cl')) {
+            vendor = 'ClangCl';
         }
         if (vendor === undefined) {
             return kit;


### PR DESCRIPTION
### This changes user-visible behavior

The following changes are proposed:

- Added `"ClangCl"` to the `CompilerVendorEnum` type
- Enhanced vendor detection to identify `Clang-cl` kits by name
- Updated version detection to treat `ClangCl` the same as `Clang` (reusing the same regex)
- Fixed variable expansion for `${buildKitVendor}`, `${buildKitVersionMajor}`, etc., when using clang-cl-based kits on Windows

## The purpose of this change

When using a `clang-cl` toolchain on Windows, variables like `${buildKitVendor}` and `${buildKitVersionMajor}` did not expand correctly in user-defined build directory paths. For example, with `Cmake: Build Directory` set to
```text
${workspaceFolder}/build-${buildKitHostOs}-${buildKitVendor}${buildKitVersionMajor}-${buildKitTargetArch}-${buildType}
```

**Before:**
```text
[cmake] -- Build files have been written to: C:/svn/myApp/build-win32-__unknown_vendor__0-unknown-Debug
```
**After this change:**
```text
[cmake] -- Build files have been written to: C:/svn/myApp/build-win32-ClangCl20-x64-Debug
```