### PR TITLE
Use setImmediate for combined token disposal

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -1413,7 +1413,12 @@ export function createCombinedCancellationToken(...tokens: (vscode.CancellationT
     disposables.push(combinedSource);
 
     combinedSource.token.onCancellationRequested(() => {
-        disposables.forEach(d => d.dispose());
+        // Defer disposal to allow all listeners to be notified first
+        setImmediate(() => {
+            disposables.forEach(d => {
+                d.dispose();
+            });
+        });
     });
 
     return combinedSource.token;


### PR DESCRIPTION
use setImmediate to let all cancellation listeners happen. This works because setImmediate will run on the next event loop, while the cancellation listeners are on the current loop