### PR TITLE
Implement outlineViewType setting that changes the Project Outline View (#3799)

### DIFF
--- a/docs/cmake-settings.md
+++ b/docs/cmake-settings.md
@@ -66,6 +66,7 @@ Options that support substitution, in the table below, allow variable references
 | `cmake.options.advanced` | Advanced options for CMake Tools. | See package.json | no |
 | `cmake.options.statusBarVisibility` | Controls visibility of the status bar. | `hidden` | no |
 | `cmake.outputLogEncoding` | Encoding to use for tool output. | `auto` | no |
+| `cmake.outlineViewType` | Project Outline View`s type. | `["list", "tree"]` | no |
 | `cmake.parallelJobs` | Specify the number of jobs run in parallel during the build. Using the value `0` will detect and use the number of CPUs. Using the value `1` will disable build parallelism. | `0` | no |
 | `cmake.parseBuildDiagnostics` | If `true`, parse compiler output for diagnostics. | `true` | no |
 | `cmake.pinnedCommands` | List of commands pinned to the command palette. | `["workbench.action.tasks.configureTaskRunner", "workbench.action.tasks.runTask"]` | no |

--- a/package.json
+++ b/package.json
@@ -2833,6 +2833,16 @@
           ],
           "scope": "window"
         },
+        "cmake.outlineViewType": {
+          "type": "string",
+          "enum": [
+            "list",
+            "tree"
+          ],
+          "default": "list",
+          "description": "%cmake-tools.configuration.cmake.outlineViewType.description%",
+          "scope": "resource"
+        },
         "cmake.options.advanced": {
           "type": "object",
           "default": {

--- a/package.nls.json
+++ b/package.nls.json
@@ -349,6 +349,7 @@
     },
     "cmake-tools.configuration.cmake.launchBehavior.newTerminal.markdownDescriptions": "A new terminal instance is created and the target is launched in it. Existing terminals are not automatically cleaned up.",
     "cmake-tools.configuration.cmake.loadCompileCommands.description": "Controls whether the extension reads compile_commands.json to enable single file compilation.",
+    "cmake-tools.configuration.cmake.outlineViewType.description": "Project Outline View`s type. Available options are: \"list\" and \"tree\".",
     "cmake-tools.command.cmake.projectStatus.update.title": "Refresh the project status",
     "cmake-tools.command.cmake.pinnedCommands.add.title": "Add a CMake command to pin",
     "cmake-tools.command.cmake.pinnedCommands.remove.title": "Unpin Command",

--- a/src/config.ts
+++ b/src/config.ts
@@ -223,6 +223,7 @@ export interface ExtensionConfigurationSettings {
     postRunCoverageTarget: string | null;
     coverageInfoFiles: string[];
     useFolderPropertyInBuildTargetDropdown: boolean;
+    outlineViewType : string;
 }
 
 type EmittersOf<T> = {
@@ -601,6 +602,10 @@ export class ConfigurationReader implements vscode.Disposable {
         return this.configData.useFolderPropertyInBuildTargetDropdown;
     }
 
+    get outlineViewType(): string {
+        return this.configData.outlineViewType;
+    }
+
     private readonly emitters: EmittersOf<ExtensionConfigurationSettings> = {
         autoSelectActiveFolder: new vscode.EventEmitter<boolean>(),
         defaultActiveFolder: new vscode.EventEmitter<string | null>(),
@@ -671,7 +676,8 @@ export class ConfigurationReader implements vscode.Disposable {
         preRunCoverageTarget: new vscode.EventEmitter<string | null>(),
         postRunCoverageTarget: new vscode.EventEmitter<string | null>(),
         coverageInfoFiles: new vscode.EventEmitter<string[]>(),
-        useFolderPropertyInBuildTargetDropdown: new vscode.EventEmitter<boolean>()
+        useFolderPropertyInBuildTargetDropdown: new vscode.EventEmitter<boolean>(),
+        outlineViewType: new vscode.EventEmitter<string>()
     };
 
     /**

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -275,6 +275,9 @@ export class ExtensionManager implements vscode.Disposable {
         this.workspaceConfig.onChange('mingwSearchDirs', async _ => { // Deprecated in 1.14, replaced by additionalCompilerSearchDirs, but kept for backwards compatibility
             KitsController.additionalCompilerSearchDirs = await this.getAdditionalCompilerDirs();
         });
+        this.workspaceConfig.onChange('outlineViewType', async _ => {
+            this.updateCodeModel(getActiveProject());
+        });
         KitsController.additionalCompilerSearchDirs = await this.getAdditionalCompilerDirs();
 
         let isMultiProject = false;

--- a/src/ui/projectOutline/projectOutline.ts
+++ b/src/ui/projectOutline/projectOutline.ts
@@ -8,6 +8,7 @@ import CMakeProject from '@cmt/cmakeProject';
 import { populateViewCodeModel } from '@cmt/ui/projectOutline/targetsViewCodeModel';
 import { fs } from '@cmt/pr';
 import { CodeModelKind } from '@cmt/drivers/cmakeFileApi';
+import { ConfigurationReader } from '@cmt/config';
 
 nls.config({ messageFormat: nls.MessageFormat.bundle, bundleFormat: nls.BundleFormat.standalone })();
 const localize: nls.LocalizeFunc = nls.loadMessageBundle();
@@ -466,7 +467,8 @@ export class ProjectNode extends BaseNode {
     constructor(
         readonly name: string,
         readonly folder: vscode.WorkspaceFolder,
-        readonly sourceDirectory: string
+        readonly sourceDirectory: string,
+        readonly config: ConfigurationReader
     ) {
         // id: project_name:project_directory
         super(`${name}:${sourceDirectory}`);
@@ -550,12 +552,22 @@ export class ProjectNode extends BaseNode {
             if (target.isGeneratorProvided) {
                 continue;
             }
-
-            if (target.folder) {
-                addToTree(tree, target.folder.name, target);
+            
+            if(this.config.outlineViewType === "tree") {
+                const srcdir = target.sourceDirectory || '';
+                const relpath = path.relative(pr.sourceDirectory, srcdir);
+                addToTree(tree, relpath, target);
             } else {
-                addToTree(tree, '', target);
+                if (target.folder) {
+                    addToTree(tree, target.folder.name, target);
+                } else {
+                    addToTree(tree, '', target);
+                }
             }
+        }
+
+        if(this.config.outlineViewType  === "tree") {
+            collapseTreeInplace(tree);
         }
 
         this._rootDir.update({
@@ -639,7 +651,7 @@ export class WorkspaceFolderNode extends BaseNode {
         const rootProject = projectOutlineModel.project;
         let item = this.getNode(cmakeProject, rootProject.name);
         if (!item) {
-            item = new ProjectNode(rootProject.name, this.wsFolder, cmakeProject.folderPath);
+            item = new ProjectNode(rootProject.name, this.wsFolder, cmakeProject.folderPath, cmakeProject.workspaceContext.config);
             this.setNode(cmakeProject, rootProject.name, item);
         }
         item.update(rootProject, ctx);

--- a/test/unit-tests/config.test.ts
+++ b/test/unit-tests/config.test.ts
@@ -84,7 +84,8 @@ function createConfig(conf: Partial<ExtensionConfigurationSettings>): Configurat
         preRunCoverageTarget: null,
         postRunCoverageTarget: null,
         coverageInfoFiles: [],
-        useFolderPropertyInBuildTargetDropdown: true
+        useFolderPropertyInBuildTargetDropdown: true,
+        outlineViewType: "list"
     });
     ret.updatePartial(conf);
     return ret;


### PR DESCRIPTION
This change addresses item #[3799]

This changes visible behavior, documentation and configuration]

The following changes are proposed:

- New config option "**cmake.outlineViewType**" that accepts one of 2 values - **_list_** or **_tree_**
- If "**cmake.outlineViewType**" is set to "**_list_**", the Project Outline View will show all cmake targets in a "flat" view
- If "**cmake.outlineViewType**" is set to "**_tree_**", the Project Outline View will show all cmake targets in a hierarchical view

The purpose of this change is to enable users to choose witch type of view to use. In my case, I find the "**_tree_**" view much more useful 

Changes:

- A ConfigurationReader argument is added to ProjectNode`s constructor
- ProjectNodes::update uses the  "**cmake.outlineViewType**" to produce a different output
- An on change event handler is added to refresh the Outline View each time the value of the new config option is changed
