### PR TITLE
Removed project source dir from test explorer.

### DIFF
--- a/src/ctest.ts
+++ b/src/ctest.ts
@@ -1865,7 +1865,7 @@ export class CTestDriver implements vscode.Disposable {
                     const folderPath = util.platformNormalizePath(project.sourceDir);
                     const folderName = path.basename(project.sourceDir);
                     const testItem = testExplorer.createTestItem(folderPath, folderName);
-                    testItem.description = folderPath;
+                    // testItem.description = folderPath;
                     testExplorer.items.add(testItem);
                 }
             }


### PR DESCRIPTION
## This change addresses item #4562

### This removes the project source directory from the test explorer UI.

As mentioned in the issue, the project source directory's inclusion was largely unhelpful and in fact cluttered the UI in an in-ergonomic way for users with horizontal scrolling enabled.