### PR TITLE
Fix Issue #4567 - change diagnostic regex to match compiler errors/wa…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Bug Fixes:
 - Fix bug that makes some build hang [#4424](https://github.com/microsoft/vscode-cmake-tools/issues/4424) and [#4465](https://github.com/microsoft/vscode-cmake-tools/issues/4465)
 - Fix issue with switching to presets during Quick Start. [#4409](https://github.com/microsoft/vscode-cmake-tools/issues/4409)
 - Fix bug that shows empty lines in Pinned Commands view. [#4406](https://github.com/microsoft/vscode-cmake-tools/issues/4406)
+- Fix Compiler Warnings not shown in Problems Window [#4567]https://github.com/microsoft/vscode-cmake-tools/issues/4567
 
 ## 1.20.53
 

--- a/src/diagnostics/diab.ts
+++ b/src/diagnostics/diab.ts
@@ -6,7 +6,7 @@ import * as vscode from 'vscode';
 
 import { oneLess, RawDiagnosticParser, FeedLineResult } from '@cmt/diagnostics/util';
 
-export const REGEX = /^\"(.*)\",\s+(?:line\s+(\d+):\s+)?(info|warning|(?:|fatal |catastrophic )error)\s+\((.*)\):\s+(.*)$/;
+export const REGEX = /\"(.*)\",\s+(?:line\s+(\d+):\s+)?(info|warning|(?:|fatal |catastrophic )error)\s+\((.*)\):\s+(.*)$/;
 
 export class Parser extends RawDiagnosticParser {
     doHandleLine(line: string) {

--- a/src/diagnostics/ghs.ts
+++ b/src/diagnostics/ghs.ts
@@ -6,7 +6,7 @@ import * as vscode from 'vscode';
 
 import { oneLess, RawDiagnosticParser, FeedLineResult } from '@cmt/diagnostics/util';
 
-export const REGEX = /^\"(.*)\",\s+(?:(?:line\s+(\d+)\s+\(col\.\s+(\d+)\))|(?:At end of source)):\s+(?:fatal )?(remark|warning|error)\s+(.*)/;
+export const REGEX = /\"(.*)\",\s+(?:(?:line\s+(\d+)\s+\(col\.\s+(\d+)\))|(?:At end of source)):\s+(?:fatal )?(remark|warning|error)\s+(.*)/;
 
 export class Parser extends RawDiagnosticParser {
     doHandleLine(line: string) {

--- a/src/diagnostics/iar.ts
+++ b/src/diagnostics/iar.ts
@@ -6,7 +6,7 @@ import * as vscode from 'vscode';
 
 import { oneLess, RawDiagnosticParser, FeedLineResult, RawDiagnostic } from '@cmt/diagnostics/util';
 
-const CODE_REGEX = /^\"(?<file>.*)\",(?<line>\d+)\s+(?<severity>[A-Za-z ]+)\[(?<code>[A-Za-z]+[0-9]+)\]:(?<message_start>.*)$/;
+const CODE_REGEX = /\"(?<file>.*)\",(?<line>\d+)\s+(?<severity>[A-Za-z ]+)\[(?<code>[A-Za-z]+[0-9]+)\]:(?<message_start>.*)$/;
 
 const POINTER_REGEX = /^( +)\^$/;
 


### PR DESCRIPTION
Change diagnostic regex to match compiler errors/warnings from output window


## This change addresses item #[[4567]]

The following changes are proposed:

- Remove "^" from problme matches diagnostic regex for diab, ghs and iar compilers, to show compiler errors/warnings in the problems window. 

