### PR TITLE
Fix support of cmake 4.1.0 and new cmake-file-api error files

### DIFF
--- a/src/drivers/cmakeFileApi.ts
+++ b/src/drivers/cmakeFileApi.ts
@@ -284,7 +284,13 @@ export async function loadIndexFile(replyPath: string): Promise<Index.IndexFile 
 
     const indexFiles = files.filter(filename => filename.startsWith('index-')).sort();
     if (indexFiles.length === 0) {
-        throw Error('No index file found.');
+        const errorFiles = files.filter(filename => filename.startsWith('error-')).sort();
+        if (errorFiles.length > 0) {
+            log.error('Error during cmake configure, no index file found.');
+        } else {
+            log.error('No index file found.');
+        }
+        return null;
     }
     const indexFilePath = path.join(replyPath, indexFiles[indexFiles.length - 1]);
     const fileContent = await tryReadFile(indexFilePath);


### PR DESCRIPTION
## This change addresses item #[[4575]]

### This changes improve support of CMake 4.1.0

The following changes are proposed:

- Do not throw exception of no index files are found, return null and let callee deal with that. Which is currently already well done.