### PR TITLE
Fix macOS CI failures by ensuring correct CMake version is used

### DIFF
--- a/.github/workflows/ci-main-mac.yml
+++ b/.github/workflows/ci-main-mac.yml
@@ -42,9 +42,6 @@ jobs:
       - name: Remove conflicting system CMake installation 
         # The electron test runner modifies PATH priority, so we remove system CMake to ensure our installed version of CMake is used
         run: |
-          echo "CMake path:"
-          which cmake
-          cmake --version
           sudo rm -f /usr/local/bin/cmake
           sudo rm -f /usr/local/bin/cmake-gui
           sudo rm -f /usr/local/bin/ccmake


### PR DESCRIPTION
### Issue
The macOS CI workflow was consistently failing because tests were using the system CMake 4.x.x instead of our required CMake 3.18.3, causing compatibility errors.

### Investigation
We discovered that:

1. The workflow correctly installs CMake 3.18.3 via lukka/get-cmake action
2. Despite setting the PATH environment variable to prioritize our installed CMake, tests were still using the system version from /usr/local/bin.
3. Detailed logging revealed that the VSCode Electron test runner was modifying the PATH order during test execution, deprioritizing our custom paths.
4. The PATH was correct before launching tests, but changed during test execution.

### Solution
As a workaround and to unblock macOS CI tests, we're removing the system CMake binaries from /usr/local/bin, ensuring that only our installed CMake 3.18.3 is available.