### PR TITLE
feature: Don't expand presets when running configure or build

### DIFF
--- a/package.json
+++ b/package.json
@@ -3578,6 +3578,12 @@
           "description": "%cmake-tools.configuration.cmake.useCMakePresets.description%",
           "scope": "resource"
         },
+        "cmake.expandCMakePresets": {
+          "type": "boolean",
+          "default": true,
+          "description": "%cmake-tools.configuration.cmake.expandCMakePresets.description%",
+          "scope": "resource"
+        },
         "cmake.useVsDeveloperEnvironment": {
             "type": "string",
             "enum": [

--- a/src/config.ts
+++ b/src/config.ts
@@ -210,6 +210,7 @@ export interface ExtensionConfigurationSettings {
     touchbar: TouchBarConfig;
     options: OptionConfig;
     useCMakePresets: UseCMakePresets;
+    expandCMakePresets: boolean;
     useVsDeveloperEnvironment: UseVsDeveloperEnvironment;
     allowCommentsInPresetsFile: boolean;
     allowUnsupportedPresetsVersions: boolean;
@@ -473,6 +474,9 @@ export class ConfigurationReader implements vscode.Disposable {
     get useCMakePresets(): UseCMakePresets {
         return this.configData.useCMakePresets;
     }
+    get expandCMakePresets(): boolean {
+        return this.configData.expandCMakePresets;
+    }
     get useVsDeveloperEnvironment(): UseVsDeveloperEnvironment {
         return this.configData.useVsDeveloperEnvironment;
     }
@@ -659,6 +663,7 @@ export class ConfigurationReader implements vscode.Disposable {
         touchbar: new vscode.EventEmitter<TouchBarConfig>(),
         options: new vscode.EventEmitter<OptionConfig>(),
         useCMakePresets: new vscode.EventEmitter<UseCMakePresets>(),
+        expandCMakePresets: new vscode.EventEmitter<boolean>(),
         useVsDeveloperEnvironment: new vscode.EventEmitter<UseVsDeveloperEnvironment>(),
         allowCommentsInPresetsFile: new vscode.EventEmitter<boolean>(),
         allowUnsupportedPresetsVersions: new vscode.EventEmitter<boolean>(),

--- a/src/drivers/cmakeLegacyDriver.ts
+++ b/src/drivers/cmakeLegacyDriver.ts
@@ -162,6 +162,7 @@ export class CMakeLegacyDriver extends CMakeDriver {
         sourceDir: string,
         isMultiProject: boolean,
         useCMakePresets: boolean,
+        expandCMakePresets: boolean,
         kit: Kit | null,
         configurePreset: ConfigurePreset | null,
         buildPreset: BuildPreset | null,
@@ -174,6 +175,7 @@ export class CMakeLegacyDriver extends CMakeDriver {
         log.debug(localize('creating.instance.of', 'Creating instance of {0}', "LegacyCMakeDriver"));
         return this.createDerived(new CMakeLegacyDriver(cmake, config, sourceDir, isMultiProject, workspaceFolder, preconditionHandler),
             useCMakePresets,
+            expandCMakePresets,
             kit,
             configurePreset,
             buildPreset,

--- a/src/drivers/cmakeServerDriver.ts
+++ b/src/drivers/cmakeServerDriver.ts
@@ -441,6 +441,7 @@ export class CMakeServerDriver extends CMakeDriver {
         sourceDir: string,
         isMultiProject: boolean,
         useCMakePresets: boolean,
+        expandCMakePresets: boolean,
         kit: Kit | null,
         configurePreset: ConfigurePreset | null,
         buildPreset: BuildPreset | null,
@@ -452,6 +453,7 @@ export class CMakeServerDriver extends CMakeDriver {
         preferredGenerators: CMakeGenerator[]): Promise<CMakeServerDriver> {
         return this.createDerived(new CMakeServerDriver(cmake, config, sourceDir, isMultiProject, workspaceFolder, preconditionHandler),
             useCMakePresets,
+            expandCMakePresets,
             kit,
             configurePreset,
             buildPreset,

--- a/test/unit-tests/config.test.ts
+++ b/test/unit-tests/config.test.ts
@@ -73,6 +73,7 @@ function createConfig(conf: Partial<ExtensionConfigurationSettings>): Configurat
             statusBarVisibility: "visible"
         },
         useCMakePresets: 'never',
+        expandCMakePresets: true,
         useVsDeveloperEnvironment: 'auto',
         allowCommentsInPresetsFile: false,
         allowUnsupportedPresetsVersions: false,

--- a/test/unit-tests/driver/cmakeFileApiDriver.test.ts
+++ b/test/unit-tests/driver/cmakeFileApiDriver.test.ts
@@ -7,7 +7,7 @@ import { makeCodeModelDriverTestsuite } from '@test/unit-tests/driver/driver-cod
 import { makeDriverTestsuite } from '@test/unit-tests/driver/driver-test';
 
 async function cmakeFileApiDriverFactory(cmake: CMakeExecutable, config: ConfigurationReader, kit: Kit | null, workspaceFolder: string, preconditionHandler: CMakePreconditionProblemSolver, preferredGenerators: CMakeGenerator[]) {
-    const d: CMakeFileApiDriver = await CMakeFileApiDriver.create(cmake, config, workspaceFolder || "", false, false, kit, null, null, null, null, null, workspaceFolder, preconditionHandler, preferredGenerators);
+    const d: CMakeFileApiDriver = await CMakeFileApiDriver.create(cmake, config, workspaceFolder || "", false, false, true, kit, null, null, null, null, null, workspaceFolder, preconditionHandler, preferredGenerators);
     return d;
 }
 

--- a/test/unit-tests/driver/cmakeServerDriver.test.ts
+++ b/test/unit-tests/driver/cmakeServerDriver.test.ts
@@ -6,7 +6,7 @@ import { makeCodeModelDriverTestsuite } from '@test/unit-tests/driver/driver-cod
 import { makeDriverTestsuite } from '@test/unit-tests/driver/driver-test';
 
 async function cmakeServerDriverFactory(cmake: CMakeExecutable, config: ConfigurationReader, kit: Kit | null, workspaceFolder: string, preconditionHandler: CMakePreconditionProblemSolver, preferredGenerators: CMakeGenerator[]) {
-    const d: CMakeServerDriver = await CMakeServerDriver.create(cmake, config, workspaceFolder || "", false, false, kit, null, null, null, null, null, workspaceFolder, preconditionHandler, preferredGenerators);
+    const d: CMakeServerDriver = await CMakeServerDriver.create(cmake, config, workspaceFolder || "", false, false, true, kit, null, null, null, null, null, workspaceFolder, preconditionHandler, preferredGenerators);
     return d;
 }
 


### PR DESCRIPTION
# Summary of Changes
This pull request adds an enhancement to the CMake Tools extension by introducing a new configuration option, cmake.expandCMakePresets, which allows users to choose whether to expand CMake presets or use the preset name directly in the command line arguments. The default value for this new configuration is set to true.

Main objective is to gather feedback and ideas.

Although, this is against wishes of CMake documentation. This gives users clear choice and fixes many outstanding issues with the support of CMake Presets.

If this PR isn't accepted I will create a fork of CMake Tools with argument expansion entirely removed as it's the only reason I don't use this excellent extension.

# Key Changes

Updated package.json to include new configuration cmake.expandCMakePresets.

# Source Code Updates:

Updated CMakeProject and CMakeDriver classes to handle the new configuration option.

Modified methods within cmakeProject.ts, cmakeDriver.ts, cmakeFileApiDriver.ts, cmakeLegacyDriver.ts, and cmakeServerDriver.ts to conditionally expand or use preset names based on expandCMakePresets.
