### PR TITLE
added REQUIRED to the list of cmake operators  and added a regex to capture integers

### DIFF
--- a/syntaxes/CMake.tmLanguage.json
+++ b/syntaxes/CMake.tmLanguage.json
@@ -32,6 +32,7 @@
     { "include": "#quoted" },
     { "include": "#string" },
     { "include": "#generatorExpression" },
+    { "include": "#integerString"},
     { "include": "#unquoted" }
   ],
   "repository": {
@@ -131,7 +132,7 @@
     },
     "operators": {
       "name": "keyword.operator.cmake",
-      "match": "\\b(?i:ABSOLUTE|AND|COMMAND|DEFINED|DIRECTORY|EQUAL|EXISTS|GREATER|GREATER_EQUAL|IN_LIST|IS_ABSOLUTE|IS_DIRECTORY|IS_NEWER_THAN|IS_SYMLINK|LAST_EXT|LESS|LESS_EQUAL|MATCHES|NAME|NAME_WE|NAME_WLE|NOT|NOTFOUND|OR|PATH|PATHS|POLICY|PROGRAM|REALPATH|STREQUAL|STRGREATER|STRGREATER_EQUAL|STRING|STRLESS|STRLESS_EQUAL|TARGET|TEST|VERSION_EQUAL|VERSION_GREATER|VERSION_GREATER_EQUAL|VERSION_LESS)\\b"
+      "match": "\\b(?i:ABSOLUTE|AND|COMMAND|DEFINED|DIRECTORY|EQUAL|EXISTS|GREATER|GREATER_EQUAL|IN_LIST|IS_ABSOLUTE|IS_DIRECTORY|IS_NEWER_THAN|IS_SYMLINK|LAST_EXT|LESS|LESS_EQUAL|MATCHES|NAME|NAME_WE|NAME_WLE|NOT|NOTFOUND|OR|PATH|PATHS|POLICY|PROGRAM|REALPATH|REQUIRED|STREQUAL|STRGREATER|STRGREATER_EQUAL|STRING|STRLESS|STRLESS_EQUAL|TARGET|TEST|VERSION_EQUAL|VERSION_GREATER|VERSION_GREATER_EQUAL|VERSION_LESS)\\b"
     },
     "boolean": {
       "name": "constant.language.boolean.cmake",
@@ -184,6 +185,12 @@
         { "include": "#envVariableReference" },
         { "include": "#cacheVariableReference" }
       ]
+    },
+    "integerString":{
+    "name": "constant.numeric.decimal.cmake",
+    "match": "\\bv?\\d+(?:\\.\\d+)*\\b"
     }
+
+
   }
 }


### PR DESCRIPTION
## The purpose of this change

To improve readability of CMake code by distinguishing numeric values from other. and adding REQUIRED to the list of parameters that should get some syntactic icing sugar.

I recently was running into issues with a large cmake project and had troubles reading it. After realising that most of my worries came from the fact that I had a deprecated cmake vscode extension that was ruining all syntax highlighting, I decided to try and improve it by submitting what i believe would be a good change to the repo.

Note: I was able to get this working on the main branch as well but since  this commit d217cacd507ca49bdc4e06620071949017842cba, effectively removed the advanced syntax highlighting that i was fond of in the latest update I decided to submit the pull request here where they could be combined together to make it very nice to look at. IDK if that was correct, if you want i can submit the pull request from this [change](9b0e68ff9709228a7cefe7b595775c894f9011f9) 



## Other Notes/Information
### Example:
This was just a sample `CMakeLists.txt` file, using the `Andromeda Italic Bordered` theme with the following pull request https://github.com/EliverLara/Andromeda/pull/40 which improves its syntax highlighting for cmake.
this pull request can be effectively replicated by adding the following code to the `settings.json` file
```json

"editor.tokenColorCustomizations": {
            "[Andromeda Italic Bordered]": {
                "textMateRules": [
                    {
                        "scope": "string.unquoted",
                        "settings": {
                            "foreground": "#D5CED9"
                        }
                    },
                    {
                    "scope": "support.type",
                        "settings": {
                            "foreground": "#c74ded"
                        }
                    }
                ]
            }
        }
```

<img width="720" height="1223" alt="image" src="https://github.com/user-attachments/assets/23b43e06-950b-4495-a6e9-7eb2608b5224" />

As you can see.
Very Mindful. Very Demure.
