### PR TITLE
Fix Issue #4421 - always clean rebuild

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ Bug Fixes:
 - Fix kits from `cmake.additionalKits` not being shown when `cmake.showSystemKits` is `false`. [#4651](https://github.com/microsoft/vscode-cmake-tools/issues/4651)
 - Fix how `jobs` is handled in build presets. Also update how `cmake.parallelJobs` is handled as a fallback when a build preset does not define `jobs`. [#4176](https://github.com/microsoft/vscode-cmake-tools/issues/4176)
 - Fix diagnostics to handle when there isn't a command in the error output. [PR #4765](https://github.com/microsoft/vscode-cmake-tools/pull/4765)
+- Fix bug in which running "CMake: Build" would always run "CMake: Clean Rebuild" when `cmake.buildTask` is enabled [#4421](https://github.com/microsoft/vscode-cmake-tools/issues/4421) [@RedSkittleFox](https://github.com/RedSkittleFox)
 
 ## 1.22.28
 

--- a/src/cmakeTaskProvider.ts
+++ b/src/cmakeTaskProvider.ts
@@ -330,11 +330,15 @@ export class CMakeTaskProvider implements vscode.TaskProvider {
                 if (defaultTask.length >= 1) {
                     return defaultTask[0];
                 } else {
+                    // If there are two tasks, both of them are templates, either build or clean rebuild, select the build one - the first one
+                    if (matchingTargetTasks.length === 2) {
+                        return matchingTargetTasks[0];
+                    }
                     // If there is no default task, matchingTargetTasks is a mixture of template and defined tasks.
                     // If there is only one task, that task is a template, so return the template.
-                    // If there are only two tasks, the first one is always a template, and the second one is the defined task that we are searching for.
-                    // But if there are more than two tasks, it means that there are multiple defiend tasks and none are set as default. So ask the user to choose one later.
-                    if (matchingTargetTasks.length === 1 || matchingTargetTasks.length === 2) {
+                    // If there are three tasks, the first two are always templates, and the third one is the defined task that we are searching for.
+                    // But if there are more than three tasks, it means that there are multiple defiend tasks and none are set as default. So ask the user to choose one later.
+                    if (matchingTargetTasks.length === 1 || matchingTargetTasks.length === 3) {
                         return matchingTargetTasks[matchingTargetTasks.length - 1];
                     }
                 }


### PR DESCRIPTION
<!-- Delete the following heading if there is no corresponding issue -->
## This change addresses item #4421

### This fixes a bug which would always run clean rebuild instead of build

The following changes are proposed:

- Update the `findBuildTask` function to properly account for the two existing templates.
- Properly select the `build` task instead of `clean rebuild` task. The cleaning in the `CMake: Clean Rebuild` command is handled separately and currently is being done twice. 

## Other Notes/Information

The debugging process with code snippets and screenshots has been documented in the respective issue. 
