### PR TITLE
capture VCPKG_ROOT from Visual Developer env

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ Bug Fixes:
 - Fix Compiler Warnings not shown in Problems Window [#4567]https://github.com/microsoft/vscode-cmake-tools/issues/4567
 - Fix bug in which clicking "Run Test" for filtered tests executed all tests instead [#4501](https://github.com/microsoft/vscode-cmake-tools/pull/4501) [@hippo91](https://github.com/hippo91)
 - Migrate macOS CI from deprecated macOS-13 to macOS-15 Image [#4633](https://github.com/microsoft/vscode-cmake-tools/pull/4633)
+- Ensure Visual Studio developer environment propagation preserves `VCPKG_ROOT`, enabling vcpkg-dependent configure runs after using the Set Visual Studio Developer Environment command. [microsoft/vscode-cpptools#14083](https://github.com/microsoft/vscode-cpptools/issues/14083)
 
 ## 1.20.53
 

--- a/src/installs/visualStudio.ts
+++ b/src/installs/visualStudio.ts
@@ -281,6 +281,7 @@ const msvcEnvVars = [
     'WindowsSDKVersion',
     'WindowsSDK_ExecutablePath_x64',
     'WindowsSDK_ExecutablePath_x86',
+    'VCPKG_ROOT',
 
     /* These are special also need to be cached */
     'CL',


### PR DESCRIPTION
## This change addresses item #4630 

### This changes visible behavior

The following changes are proposed:

- include VCPKG_ROOT when we capture a Visual Studio developer environment.
- document fix in CHANGELOG.md

## The purpose of this change
Ensure that any workflow in CMake Tools that uses a Visual Studio developer environment such as selecting a VS kit, configuring via a preset that sets cmake.useVsDeveloperEnvironment, or relying on the “Set Visual Studio Developer Environment” command now surfaces the same VCPKG_ROOT value that a VS Developer Command Prompt provides, so vcpkg-based configure runs behave consistently.

## Other Notes/Information
Manually verified by selecting a VS kit and running CMake: Configure, VCPKG_ROOT now prints the VS vcpkg path. Presets using the VS developer environment inherit the same behavior.
