### PR TITLE
Fix some ctest issues

### DIFF
--- a/src/ctest.ts
+++ b/src/ctest.ts
@@ -1017,7 +1017,7 @@ export class CTestDriver implements vscode.Disposable {
                 parentSuiteItem = suiteItem;
             }
         }
-        const testItem = initializedTestExplorer.createTestItem(testName, testLabel, uri);
+        const testItem = parentSuiteItem.children.get(testName) || initializedTestExplorer.createTestItem(testName, testLabel, uri);
         return { test: testItem, parentSuite: parentSuiteItem };
     }
 

--- a/src/ctest.ts
+++ b/src/ctest.ts
@@ -1030,13 +1030,15 @@ export class CTestDriver implements vscode.Disposable {
             log.error(localize('folder.not.found.in.test.explorer', 'Folder is not found in Test Explorer: {0}', sourceDir));
             return;
         }
-        // Clear all children and re-add later
-        testExplorerRoot.children.replace([]);
+
+        // Keep track of all currently active test ids to remove the invalid ones afterwards
+        const activeTestIDs = new Set<string>();
 
         if (!ctestArgs) {
             // Happens when testPreset is not selected
             const testItem = initializedTestExplorer.createTestItem(testPresetRequired, localize('test.preset.required', 'Select a test preset to discover tests'));
             testExplorerRoot.children.add(testItem);
+            activeTestIDs.add(testItem.id);
             return;
         }
 
@@ -1044,6 +1046,7 @@ export class CTestDriver implements vscode.Disposable {
             // Legacy CTest tests
             for (const test of this.legacyTests) {
                 testExplorerRoot.children.add(initializedTestExplorer.createTestItem(test.name, test.name));
+                activeTestIDs.add(test.name);
             }
         } else if (testType === "CTestInfo" && this.tests !== undefined) {
             if (this.tests && this.tests.kind === 'ctestInfo') {
@@ -1077,12 +1080,25 @@ export class CTestDriver implements vscode.Disposable {
                     if (testTags.length !== 0) {
                         testItem.tags = [...testItem.tags, ...testTags];
                     }
-
                     parentSuiteItem.children.add(testItem);
+                    activeTestIDs.add(testItem.id);
                 });
             };
         }
 
+        const removeDeletedTests = (collection: vscode.TestItemCollection) => {
+            collection.forEach((item: vscode.TestItem, collection: vscode.TestItemCollection) => {
+                if (item.children.size === 0) {
+                    if (!activeTestIDs.has(item.id)) {
+                        collection.delete(item.id);
+                    }
+                } else {
+                    removeDeletedTests(item.children);
+                }
+            });
+        };
+
+        removeDeletedTests(initializedTestExplorer.items);
     }
 
     /**


### PR DESCRIPTION
## This change addresses item #4408 

### This changes the behaviour of the test explorer tree view

The following changes are proposed:

- If tests are added in cmake via `add_test` and at the same time via `gtest_discover_tests` it can happen that the tree view doesn't work properly, because test descriptions from `gtest_discover_tests` are overwritten by those generated by `add_test`. I think the correct approach would be to only use one of these commands in cmake - but still I thought it would be a good idea to make it work. The fix works by reusing existing test items.

- Another thing that annoyed me was that the tree structure was changing when a test is run - I tried to capture the behaviour here: 
[test_visibility_changes.webm](https://github.com/user-attachments/assets/ecb53a93-d1a0-4b72-add9-7002aa99cf7f)

- I found out that cmake build is executed when tests are run - and afterwards the tests are refreshed. This refreshing works by removing all test items and re-building the tree structure. This caused all the items in the tree to be initialized in a certain state. I fixed this by keeping track of all the currently active test ids and removing the deleted ones at the end of the refresh-function.

## Other Notes/Information

For the second issue I tried to figure out a way to avoid refreshing the tree if nothing has changed.
However, it seems as if this is not trivial. It could be possible to compute and store a hash (or something in this direction) of the json that is produced by cmake and use it as an indicator  - let me know if you think it would be worthwhile to explore this direction.

Thanks and best regards
oz
