### PR TITLE
Initial commit for cmake:build cmake:configure cmake:get_errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "syntaxes"
   ],
   "engines": {
-    "vscode": "^1.88.0"
+    "vscode": "^1.109.0"
   },
   "categories": [
     "Other",
@@ -115,6 +115,63 @@
         }
       }
     },
+    "languageModelTools": [
+      {
+        "name": "cmake_build",
+        "displayName": "CMake: Build",
+        "canBeReferencedInPrompt": true,
+        "toolReferenceName": "cmake:build",
+        "icon": "$(cmake-tools-build)",
+        "userDescription": "Build the CMake project with the active build preset",
+        "modelDescription": "Builds the CMake project using the currently active build preset. Use this tool when the user asks to build, compile, or make the project. The tool, if asked, can optionally build a specific target and can clean before building. This tool requires an active CMake project with a configured preset. Returns the build result including exit code and status.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "target": {
+              "type": "string",
+              "description": "The specific build target to compile. If not provided, builds the default target. Examples: 'all', 'myapp', 'tests'"
+            },
+            "clean": {
+              "type": "boolean",
+              "description": "Whether to clean before building. Defaults to false.",
+              "default": false
+            }
+          }
+        }
+      },
+      {
+        "name": "cmake_configure",
+        "displayName": "CMake: Configure",
+        "canBeReferencedInPrompt": true,
+        "toolReferenceName": "cmake:configure",
+        "icon": "$(cmake-tools-configure)",
+        "userDescription": "Configure the CMake project with the active configure preset",
+        "modelDescription": "Configures the CMake project using the currently active configure preset. Use this tool when the user asks to configure, reconfigure, or set up the CMake project. Use this tool if you, the agent, add, remove, or rename source files. The tool, if asked,  can delete the CMake cache before configuring for a clean reconfigure. This tool requires an active CMake project and preset. Returns the configuration result including exit code and preset used.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "cleanFirst": {
+              "type": "boolean",
+              "description": "Whether to delete the CMake cache before configuring. Defaults to false. Set to true for a clean reconfigure.",
+              "default": false
+            }
+          }
+        }
+      },
+      {
+        "name": "cmake_get_errors",
+        "displayName": "CMake: Get Errors",
+        "canBeReferencedInPrompt": true,
+        "toolReferenceName": "cmake:get_errors",
+        "icon": "$(warning)",
+        "userDescription": "Get CMake-specific diagnostics (configure, build, and preset errors)",
+        "modelDescription": "Retrieves diagnostics from CMake-specific sources including configure errors, build/compilation errors, and preset errors. Use this tool when the user asks about CMake errors, build failures, or compilation issues. This tool specifically excludes IntelliSense and clangd diagnostics to focus only on CMake-related problems. Returns a formatted list of errors with file locations, line numbers, and messages grouped by type. Important: This is more focused than the general get_errors tool because it only shows CMake-specific diagnostics.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {}
+        }
+      }
+    ],
     "languages": [
         {
             "id": "cmake",
@@ -3980,7 +4037,7 @@
     "@types/rimraf": "^3.0.0",
     "@types/sinon": "~9.0.10",
     "@types/tmp": "^0.2.0",
-    "@types/vscode": "1.88.0",
+    "@types/vscode": "1.109.0",
     "@types/which": "~2.0.0",
     "@types/xml2js": "^0.4.8",
     "@types/uuid": "~8.3.3",

--- a/src/copilot/index.ts
+++ b/src/copilot/index.ts
@@ -1,0 +1,34 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as vscode from 'vscode';
+import { ExtensionManager } from '@cmt/extension';
+import { CMakeBuildTool, CMakeConfigureTool, CMakeGetErrorsTool } from './tools';
+
+/**
+ * Registers CMake Copilot tools for use with VS Code's Language Model API
+ *
+ * @param context Extension context for managing disposables
+ * @param extensionManager The CMake Tools extension manager instance
+ */
+export function registerCopilotTools(
+    context: vscode.ExtensionContext,
+    extensionManager: ExtensionManager
+): void {
+    // Register the build tool
+    context.subscriptions.push(
+        vscode.lm.registerTool('cmake_build', new CMakeBuildTool(extensionManager))
+    );
+
+    // Register the configure tool
+    context.subscriptions.push(
+        vscode.lm.registerTool('cmake_configure', new CMakeConfigureTool(extensionManager))
+    );
+
+    // Register the get errors tool
+    context.subscriptions.push(
+        vscode.lm.registerTool('cmake_get_errors', new CMakeGetErrorsTool())
+    );
+}

--- a/src/copilot/tools.ts
+++ b/src/copilot/tools.ts
@@ -1,0 +1,245 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as vscode from 'vscode';
+import { IBuildParameters, IConfigureParameters, IGetErrorsParameters } from './types';
+import { ExtensionManager } from '@cmt/extension';
+import { collections } from '@cmt/diagnostics/collections';
+
+/**
+ * Language Model Tool for building CMake projects
+ */
+export class CMakeBuildTool implements vscode.LanguageModelTool<IBuildParameters> {
+    constructor(private readonly extensionManager: ExtensionManager) {}
+
+    async prepareInvocation(
+        options: vscode.LanguageModelToolInvocationPrepareOptions<IBuildParameters>,
+        _token: vscode.CancellationToken
+    ): Promise<vscode.PreparedToolInvocation> {
+        const target = options.input.target;
+        const clean = options.input.clean ?? false;
+
+        let targetDesc = target ? `target '${target}'` : 'default target';
+        if (clean) {
+            targetDesc = `clean and build ${targetDesc}`;
+        } else {
+            targetDesc = `build ${targetDesc}`;
+        }
+
+        const confirmationMessages = {
+            title: 'Build CMake Project',
+            message: new vscode.MarkdownString(
+                `Build the CMake project: ${targetDesc}?`
+            )
+        };
+
+        return {
+            invocationMessage: clean ? 'Cleaning and building CMake project...' : 'Building CMake project...',
+            confirmationMessages
+        };
+    }
+
+    async invoke(
+        options: vscode.LanguageModelToolInvocationOptions<IBuildParameters>,
+        _token: vscode.CancellationToken
+    ): Promise<vscode.LanguageModelToolResult> {
+        const params = options.input;
+        const targets = params.target ? [params.target] : undefined;
+
+        try {
+            // If clean is requested, clean first
+            if (params.clean) {
+                await this.extensionManager.clean();
+            }
+
+            // Perform the build
+            const result = await this.extensionManager.build(undefined, undefined, undefined, undefined, undefined);
+
+            if (result === 0) {
+                const targetDesc = params.target ? `target '${params.target}'` : 'default target';
+                const message = `CMake build completed successfully for ${targetDesc}.`;
+                return new vscode.LanguageModelToolResult([
+                    new vscode.LanguageModelTextPart(message)
+                ]);
+            } else {
+                const errorMsg = `CMake build failed with exit code ${result}.`;
+                throw new Error(errorMsg + ' Use the cmake_get_errors tool to see the compilation errors, then help the user fix them.');
+            }
+        } catch (error) {
+            const errorMessage = error instanceof Error ? error.message : String(error);
+            throw new Error(`CMake build failed: ${errorMessage}. Use the cmake_get_errors tool to see detailed diagnostics.`);
+        }
+    }
+}
+
+/**
+ * Language Model Tool for configuring CMake projects
+ */
+export class CMakeConfigureTool implements vscode.LanguageModelTool<IConfigureParameters> {
+    constructor(private readonly extensionManager: ExtensionManager) {}
+
+    async prepareInvocation(
+        options: vscode.LanguageModelToolInvocationPrepareOptions<IConfigureParameters>,
+        _token: vscode.CancellationToken
+    ): Promise<vscode.PreparedToolInvocation> {
+        const cleanFirst = options.input.cleanFirst ?? false;
+        const presetName = this.extensionManager.activeConfigurePresetName() || 'default';
+
+        const action = cleanFirst ? 'Clean and reconfigure' : 'Configure';
+        const confirmationMessages = {
+            title: `${action} CMake Project`,
+            message: new vscode.MarkdownString(
+                `${action} the CMake project with preset '${presetName}'?`
+            )
+        };
+
+        return {
+            invocationMessage: cleanFirst ? 'Cleaning and reconfiguring CMake project...' : 'Configuring CMake project...',
+            confirmationMessages
+        };
+    }
+
+    async invoke(
+        options: vscode.LanguageModelToolInvocationOptions<IConfigureParameters>,
+        _token: vscode.CancellationToken
+    ): Promise<vscode.LanguageModelToolResult> {
+        const params = options.input;
+        const presetName = this.extensionManager.activeConfigurePresetName() || 'default';
+
+        try {
+            let result: number;
+            if (params.cleanFirst) {
+                result = await this.extensionManager.cleanConfigure();
+            } else {
+                result = await this.extensionManager.configure();
+            }
+
+            if (result === 0) {
+                const action = params.cleanFirst ? 'Clean reconfiguration' : 'Configuration';
+                const message = `${action} completed successfully using preset '${presetName}'.`;
+                return new vscode.LanguageModelToolResult([
+                    new vscode.LanguageModelTextPart(message)
+                ]);
+            } else {
+                const errorMsg = `CMake configuration failed with exit code ${result}.`;
+                throw new Error(errorMsg + ' Use the cmake_get_errors tool to see the configuration errors, then help the user fix the CMakeLists.txt or preset issues.');
+            }
+        } catch (error) {
+            const errorMessage = error instanceof Error ? error.message : String(error);
+            throw new Error(`CMake configuration failed: ${errorMessage}. Use the cmake_get_errors tool to see detailed diagnostics.`);
+        }
+    }
+}
+
+/**
+ * Language Model Tool for retrieving CMake-specific errors
+ */
+export class CMakeGetErrorsTool implements vscode.LanguageModelTool<IGetErrorsParameters> {
+    async prepareInvocation(
+        _options: vscode.LanguageModelToolInvocationPrepareOptions<IGetErrorsParameters>,
+        _token: vscode.CancellationToken
+    ): Promise<vscode.PreparedToolInvocation> {
+        return {
+            invocationMessage: 'Reading CMake diagnostics...',
+            confirmationMessages: {
+                title: 'Get CMake Errors',
+                message: new vscode.MarkdownString('Retrieve CMake-specific diagnostics (configure, build, and preset errors)?')
+            }
+        };
+    }
+
+    async invoke(
+        _options: vscode.LanguageModelToolInvocationOptions<IGetErrorsParameters>,
+        _token: vscode.CancellationToken
+    ): Promise<vscode.LanguageModelToolResult> {
+        const workspaceFolders = vscode.workspace.workspaceFolders;
+        const workspaceRoot = workspaceFolders?.[0]?.uri.fsPath || '';
+
+        // Collect diagnostics from all CMake-specific collections
+        const diagnosticGroups = [
+            { name: 'CMake Configure', collection: collections.cmake },
+            { name: 'CMake Build', collection: collections.build },
+            { name: 'CMake Presets', collection: collections.presets }
+        ];
+
+        let totalErrors = 0;
+        let totalWarnings = 0;
+        let totalInfo = 0;
+        const errorLines: string[] = [];
+
+        for (const group of diagnosticGroups) {
+            const diagnostics: [vscode.Uri, readonly vscode.Diagnostic[]][] = [];
+            group.collection.forEach((uri, diags) => {
+                diagnostics.push([uri, diags]);
+            });
+
+            if (diagnostics.length === 0) {
+                continue;
+            }
+
+            const groupErrors: string[] = [];
+            for (const [uri, diags] of diagnostics) {
+                for (const diag of diags) {
+                    // Count by severity
+                    switch (diag.severity) {
+                        case vscode.DiagnosticSeverity.Error:
+                            totalErrors++;
+                            break;
+                        case vscode.DiagnosticSeverity.Warning:
+                            totalWarnings++;
+                            break;
+                        case vscode.DiagnosticSeverity.Information:
+                        case vscode.DiagnosticSeverity.Hint:
+                            totalInfo++;
+                            break;
+                    }
+
+                    // Format the diagnostic
+                    const severityLabel = this.getSeverityLabel(diag.severity);
+                    const relativePath = workspaceRoot ? uri.fsPath.replace(workspaceRoot, '.') : uri.fsPath;
+                    const location = `${relativePath}:${diag.range.start.line + 1}:${diag.range.start.character + 1}`;
+                    const source = diag.source ? `[${diag.source}] ` : '';
+                    const code = diag.code ? `(${diag.code}) ` : '';
+
+                    groupErrors.push(`${severityLabel}: ${location}: ${source}${code}${diag.message}`);
+                }
+            }
+
+            if (groupErrors.length > 0) {
+                errorLines.push(`\n## ${group.name} Errors (${groupErrors.length})`);
+                errorLines.push(...groupErrors);
+            }
+        }
+
+        // Build summary
+        const summary = `Found ${totalErrors} error(s), ${totalWarnings} warning(s), ${totalInfo} info message(s) in CMake diagnostics.`;
+
+        if (errorLines.length === 0) {
+            return new vscode.LanguageModelToolResult([
+                new vscode.LanguageModelTextPart('No CMake errors found. The project is clean.')
+            ]);
+        }
+
+        const fullReport = [summary, ...errorLines].join('\n');
+        return new vscode.LanguageModelToolResult([
+            new vscode.LanguageModelTextPart(fullReport)
+        ]);
+    }
+
+    private getSeverityLabel(severity: vscode.DiagnosticSeverity): string {
+        switch (severity) {
+            case vscode.DiagnosticSeverity.Error:
+                return 'ERROR';
+            case vscode.DiagnosticSeverity.Warning:
+                return 'WARNING';
+            case vscode.DiagnosticSeverity.Information:
+                return 'INFO';
+            case vscode.DiagnosticSeverity.Hint:
+                return 'HINT';
+            default:
+                return 'UNKNOWN';
+        }
+    }
+}

--- a/src/copilot/types.ts
+++ b/src/copilot/types.ts
@@ -1,0 +1,38 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Input parameters for the cmake_build tool
+ */
+export interface IBuildParameters {
+    /**
+     * The specific build target to compile. If not provided, builds the default target.
+     * Examples: "all", "myapp", "tests"
+     */
+    target?: string;
+
+    /**
+     * Whether to clean before building. Defaults to false.
+     */
+    clean?: boolean;
+}
+
+/**
+ * Input parameters for the cmake_configure tool
+ */
+export interface IConfigureParameters {
+    /**
+     * Whether to delete the CMake cache before configuring. Defaults to false.
+     * Set to true for a clean reconfigure.
+     */
+    cleanFirst?: boolean;
+}
+
+/**
+ * Input parameters for the cmake_get_errors tool
+ */
+export interface IGetErrorsParameters {
+    // No parameters needed - returns all CMake-specific diagnostics
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2661,6 +2661,14 @@ export async function activate(context: vscode.ExtensionContext): Promise<api.CM
     extensionManager = await ExtensionManager.create(context);
     await extensionManager.init();
 
+    // Register Copilot language model tools (requires extensionManager to be initialized)
+    try {
+        const { registerCopilotTools } = await import('./copilot/index');
+        registerCopilotTools(context, extensionManager);
+    } catch (error) {
+        log.warning(localize('copilot.tools.registration.failed', 'Failed to register Copilot tools: {0}', String(error)));
+    }
+
     // need the extensionManager to be initialized for this.
     pinnedCommands = new PinnedCommands(extensionManager.getWorkspaceConfig(), extensionManager.extensionContext);
 

--- a/test/helpers/vscodefake/extensioncontext.ts
+++ b/test/helpers/vscodefake/extensioncontext.ts
@@ -38,6 +38,9 @@ export class DefaultExtensionContext implements vscode.ExtensionContext {
     get extensionMode(): vscode.ExtensionMode {
         throw new Error(notImplementedErr);
     }
+    get languageModelAccessInformation(): vscode.LanguageModelAccessInformation {
+        throw new Error(notImplementedErr);
+    }
     extension: vscode.Extension<any>;
 
     constructor() {
@@ -84,6 +87,9 @@ export class SmokeTestExtensionContext implements vscode.ExtensionContext {
         return path.join(this.extensionPath, '.smoke-logs');
     }
     get extensionMode(): vscode.ExtensionMode {
+        throw new Error(notImplementedErr);
+    }
+    get languageModelAccessInformation(): vscode.LanguageModelAccessInformation {
         throw new Error(notImplementedErr);
     }
     extension: vscode.Extension<any>;


### PR DESCRIPTION
This pull request introduces new CMake-specific tools for use with VS Code's Language Model API (Copilot), enabling build, configure, and error-reporting operations to be invoked programmatically or by AI agents. It also updates the extension's VS Code engine dependencies to the latest version and adds supporting type definitions. The most significant changes are the addition of the new Copilot tool implementations and their registration during extension activation.

**Copilot Tool Integration for CMake:**

- Added new CMake Copilot tools:
  - [`cmake_build`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R118-R174): Builds the CMake project, optionally for a specific target and with a clean step. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R118-R174) [[2]](diffhunk://#diff-1454223f15273a833d1541462afb0e4b54cf7cb3d1f18c691430afd2537256afR1-R245) [[3]](diffhunk://#diff-5c2a53b8c4cdb0ec8cee07d1d62a31c84899d9c61dbd0ce8a4a45782803cff7cR1-R38)
  - [`cmake_configure`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R118-R174): Configures (or reconfigures) the CMake project, with an option to clean the cache first. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R118-R174) [[2]](diffhunk://#diff-1454223f15273a833d1541462afb0e4b54cf7cb3d1f18c691430afd2537256afR1-R245) [[3]](diffhunk://#diff-5c2a53b8c4cdb0ec8cee07d1d62a31c84899d9c61dbd0ce8a4a45782803cff7cR1-R38)
  - [`cmake_get_errors`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R118-R174): Retrieves CMake-specific diagnostics, including configure, build, and preset errors. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R118-R174) [[2]](diffhunk://#diff-1454223f15273a833d1541462afb0e4b54cf7cb3d1f18c691430afd2537256afR1-R245) [[3]](diffhunk://#diff-5c2a53b8c4cdb0ec8cee07d1d62a31c84899d9c61dbd0ce8a4a45782803cff7cR1-R38)

- Implemented tool registration logic in `src/copilot/index.ts` and ensured registration occurs during extension activation in `src/extension.ts`. [[1]](diffhunk://#diff-aee0914e9d9ba62251dbd0c9f74566071c847f2406d7e45619a95ce91c21d199R1-R34) [[2]](diffhunk://#diff-04bba6a35cad1c794cbbe677678a51de13441b7a6ee8592b7b50be1f05c6f626R2664-R2671)

**Dependency and Compatibility Updates:**

- Updated the minimum required VS Code engine version and corresponding type definitions to `^1.109.0` to support the new Language Model API. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L25-R25) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3983-R4040)

**Testing Infrastructure:**

- Updated fake extension context classes in the test helpers to stub the new `languageModelAccessInformation` property, ensuring compatibility with the latest VS Code API. [[1]](diffhunk://#diff-3429eda8cbf93851ad6b2f78a5274f43ce8c022844294fafc446da16c5c6977eR41-R43) [[2]](diffhunk://#diff-3429eda8cbf93851ad6b2f78a5274f43ce8c022844294fafc446da16c5c6977eR92-R94)<!-- Thanks for your contribution! To make things easier, please fill out the template below. -->

<img width="1301" height="849" alt="image" src="https://github.com/user-attachments/assets/ec04a18d-d3a7-4296-b7e2-4f4fd578edc9" />

