### PR TITLE
fixing bracket comment issue in which colorization was not consistent

### DIFF
--- a/syntaxes/CMake.tmLanguage.json
+++ b/syntaxes/CMake.tmLanguage.json
@@ -79,10 +79,10 @@
       ]
     },
     "bracketComment": {
-      "name": "comment.line.number-sign.bracket.cmake",
+      "name": "comment.block.bracket.cmake",
       "begin": "#\\[(=*)\\[",
       "beginCaptures": { "0": { "name": "punctuation.definition.comment.begin.cmake" } },
-      "end": "\\](=*)\\]",
+      "end": "\\]\\1\\]",
       "endCaptures": { "0": { "name": "punctuation.definition.comment.end.cmake" } }
     },
     "lineComment": {
@@ -94,7 +94,7 @@
       "name": "variable.parameter.cmake",
       "begin": "\\[(=*)\\[",
       "beginCaptures": { "0": { "name": "punctuation.definition.string.begin.cmake" } },
-      "end": "\\](=*)\\]",
+      "end": "\\]\\1\\]",
       "endCaptures": { "0": { "name": "punctuation.definition.string.end.cmake" } }
     },
     "generatorExpression": {


### PR DESCRIPTION
## This change addresses item #4737

### This changes visible behavior

This pull request makes minor improvements to the CMake syntax highlighting rules, specifically for bracket comments and bracketed parameter variables. The changes improve the accuracy of matching the end of bracketed sections by using a more precise regular expression.

Syntax highlighting improvements:

* Updated the `bracketComment` rule in `CMake.tmLanguage.json` to use a more accurate regular expression for detecting the end of bracket comments, ensuring that the same number of equal signs is matched at the end as at the start.
* Updated the rule for bracketed parameter variables in `CMake.tmLanguage.json` to use the same improved regular expression for matching the end of bracketed strings.

Here are some images that shows the improvement:
<img width="2518" height="1663" alt="Screenshot 2026-02-20 125547" src="https://github.com/user-attachments/assets/38ad6f3e-693f-4d0f-9619-bfc3393c6216" />
<img width="3354" height="1644" alt="Screenshot 2026-02-20 125534" src="https://github.com/user-attachments/assets/275b4983-2e34-42da-9c61-f9a86d82b1f5" />
<img width="2397" height="1589" alt="Screenshot 2026-02-20 125522" src="https://github.com/user-attachments/assets/b3285377-7a13-40a6-824f-a88a5149a629" />