### PR TITLE
Update macOS CI runner to use macos-26

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,6 @@ Improvements:
 - Add MSVC linker error problem matching to the Problems pane. [#4675](https://github.com/microsoft/vscode-cmake-tools/pull/4675) [@bradphelan](https://github.com/bradphelan)
 - Use environment variables from `cmake.environment` and `cmake.configureEnvironment` when expanding `$penv{}` macros in CMake Presets `include` paths. [#3578](https://github.com/microsoft/vscode-cmake-tools/issues/3578)
 - Allow preset modification commands to target CMakeUserPresets.json. The target file is determined by the focused editor, or by prompting the user when both files exist. [#4564](https://github.com/microsoft/vscode-cmake-tools/issues/4564)
-- Migrate macOS CI runner from `macos-15` to `macos-26` (Apple Silicon M2 Pro ARM64, GitHub Actions public preview).
 
 Bug Fixes:
 - Fix CMakePresets.json discovery failing in multi-folder workspaces when the presets file is in a subdirectory specified by `cmake.sourceDirectory`. [#4727](https://github.com/microsoft/vscode-cmake-tools/issues/4727)


### PR DESCRIPTION
This pull request updates the macOS Continuous Integration (CI) workflow to use a newer runner and improves the cleanup of CMake-related binaries. It also documents these changes in the changelog.

**CI Infrastructure Updates:**

* The GitHub Actions workflow in `.github/workflows/ci-main-mac.yml` now uses the `macos-26` runner (Apple Silicon M2 Pro ARM64, GitHub Actions public preview) instead of the older `macos-15`.
* Additional cleanup steps have been added to remove CMake-related binaries from `/opt/homebrew/bin/` before building, ensuring a clean environment for CI runs.

**Documentation:**

* The changelog (`CHANGELOG.md`) has been updated to mention the migration of the macOS CI runner to `macos-26`
