### PR TITLE
Fix wrong path created for artifacts when parsing code model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Improvements:
 - Allow preset modification commands to target CMakeUserPresets.json. The target file is determined by the focused editor, or by prompting the user when both files exist. [#4564](https://github.com/microsoft/vscode-cmake-tools/issues/4564)
 
 Bug Fixes:
+- Fix wrong path created for artifact when parsing code model using CMake File API. [#3015](https://github.com/microsoft/vscode-cmake-tools/issues/3015)
 - Fix garbled characters (Mojibake) in the Output panel when MSVC outputs UTF-8 (e.g., with `/utf-8`) on non-UTF-8 Windows systems. When `cmake.outputLogEncoding` is `auto`, the build output is now validated as UTF-8 before falling back to the system code page. [#4520](https://github.com/microsoft/vscode-cmake-tools/issues/4520)
 - Fix CMakePresets.json discovery failing in multi-folder workspaces when the presets file is in a subdirectory specified by `cmake.sourceDirectory`. [#4727](https://github.com/microsoft/vscode-cmake-tools/issues/4727)
 - Fix initial kit scan ignoring `cmake.enableAutomaticKitScan: false` on first workspace open, and prevent redundant concurrent scans in multi-project workspaces. [#4726](https://github.com/microsoft/vscode-cmake-tools/issues/4726)

--- a/src/drivers/cmakeFileApi.ts
+++ b/src/drivers/cmakeFileApi.ts
@@ -532,7 +532,7 @@ async function loadCodeModelTarget(rootPaths: CodeModelKind.PathInfo, jsonFile: 
         sourceDirectory: convertToAbsolutePath(targetObject.paths.source, rootPaths.source),
         fullName: targetObject.nameOnDisk,
         artifacts: targetObject.artifacts ? targetObject.artifacts.map(
-            a => convertToAbsolutePath(path.join(targetObject.paths.build, a.path), rootPaths.build))
+            a => convertToAbsolutePath(a.path, rootPaths.build))
             : [],
         fileGroups,
         sysroot,


### PR DESCRIPTION
## This change addresses item #[[3015]]

### Problem

When parsing code model fetched using CMake File API, the path to the artifact was created using `path.join` with `build` directory specified inside `target-buildpath-*.json`. The result was then converted to absolute path using `convertToAbsolutePath` function, which in turn also prepended the path with top-level build directory. This resulted in an incorrect path with duplicated segments in the middle, e.g. given example from the issue [#3015](https://github.com/microsoft/vscode-cmake-tools/issues/3015):

`target-buildpath-*.json`:

```
{
	"artifacts" : 
	[
		{
			"path" : "src/buildpath"
		}
	],
    /* ... */
	"paths" : 
	{
		"build" : "src",
		"source" : "src"
	},
    /* ... */
}
```

`codemodel-v2-*.json`:

```
{
    /* ... */
	"paths" : 
	{
		"build" : "<workspace>/build",
		"source" : "<workspace>"
	},
    /* ... */
}
```

Path to artifact was created as `<workspace>/build/src/src/buildpath`, while the correct path should be `<workspace>/build/src/buildpath`.

### Correction

Changed the logic to append top-level build directory from `codemodel-v2-*.json` when creating the artifact path if the path from `target-buildpath-*.json` is relative, and to use it as-is if it's already absolute. This approach is in line with [CMake File API specification](https://cmake.org/cmake/help/v3.14/manual/cmake-file-api.7.html#codemodel-version-2-target-object) for `artifacts.path`, which states that:

> If the file is inside the top-level build directory then the path is specified relative to that directory. Otherwise the path is absolute.
