### PR TITLE
Remove C/C++ DevTools from extensionPack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Improvements:
 - Display info tooltip when hovering over CMake policy identifiers (e.g., `CMP0177`), showing the CMake version that introduced the policy, a short description, and a link to the official documentation. [#4544](https://github.com/microsoft/vscode-cmake-tools/issues/4544)
 - Append `cmake` to diagnostics that this extension contributes to the Problems Pane. [PR #4766](https://github.com/microsoft/vscode-cmake-tools/pull/4766)
 - Honor `debugger.workingDirectory` from the CMake File API when debugging a target, so that the `DEBUGGER_WORKING_DIRECTORY` target property is used as the debugger working directory. [#4595](https://github.com/microsoft/vscode-cmake-tools/issues/4595)
+- Removed extension pack dependency on `ms-vscode.cpp-devtools`
 
 Bug Fixes:
 - Fix `cmake.buildTask` build failures not aborting debug launches. When `${command:cmake.launchTargetPath}` is used in `launch.json`, a failed build now correctly prevents the stale executable from being launched. [#3389](https://github.com/microsoft/vscode-cmake-tools/issues/3389)

--- a/package.json
+++ b/package.json
@@ -69,9 +69,6 @@
     "onLanguage:cmake",
     "onLanguage:cmake-cache"
   ],
-  "extensionPack": [
-    "ms-vscode.cpp-devtools"
-  ],
   "main": "./dist/main",
   "contributes": {
     "icons": {


### PR DESCRIPTION
### This changes visible behavior

The following changes are proposed:

- Remove `ms-vscode.cpp-devtools` from `extensionPack`

## The purpose of this change

`ms-vscode.cpp-devtools` is a Copilot integration extension that is already included in the C/C++ Extension Pack. Adding it as an extension pack dependency of CMake Tools causes it to be silently installed on users who chose CMake Tools standalone. Users who don't use Copilot end up with a closed-source extension that has no effect on their workflow.