### PR TITLE
Fix hover undefined check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ Bug Fixes:
 - Fix how `jobs` is handled in build presets. Also update how `cmake.parallelJobs` is handled as a fallback when a build preset does not define `jobs`. [#4176](https://github.com/microsoft/vscode-cmake-tools/issues/4176)
 - Fix diagnostics to handle when there isn't a command in the error output. [PR #4765](https://github.com/microsoft/vscode-cmake-tools/pull/4765)
 - Fix bug in which running "CMake: Build" would always run "CMake: Clean Rebuild" when `cmake.buildTask` is enabled [#4421](https://github.com/microsoft/vscode-cmake-tools/issues/4421) [@RedSkittleFox](https://github.com/RedSkittleFox)
+- Fix issue with hover provider not checking for undefined. [#4812](https://github.com/microsoft/vscode-cmake-tools/issues/4812)
 
 ## 1.22.28
 

--- a/src/languageServices/languageServiceData.ts
+++ b/src/languageServices/languageServiceData.ts
@@ -180,14 +180,12 @@ export class LanguageServiceData implements vscode.HoverProvider, vscode.Complet
         }
 
         const hoverSuggestions = this.commands[value] || this.variables[value] || this.modules[value] || this.modules[`Find${value}`];
-
-        const markdown: vscode.MarkdownString = new vscode.MarkdownString();
-        markdown.appendMarkdown(hoverSuggestions.description);
-        hoverSuggestions.syntax_examples?.forEach((example) => {
-            markdown.appendCodeblock(`\t${example}`, "cmake");
-        });
-
         if (hoverSuggestions) {
+            const markdown: vscode.MarkdownString = new vscode.MarkdownString();
+            markdown.appendMarkdown(hoverSuggestions.description);
+            hoverSuggestions.syntax_examples?.forEach((example) => {
+                markdown.appendCodeblock(`\t${example}`, "cmake");
+            });
             return new vscode.Hover(markdown);
         }
 


### PR DESCRIPTION
Fixes #4812. We weren't properly checking for the existence of `hoverSuggestions` before using it. 