### PR TITLE
Construct minimal regex when running unit tests in parallel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,7 @@ Bug Fixes:
 - Fix diagnostics to handle when there isn't a command in the error output. [PR #4765](https://github.com/microsoft/vscode-cmake-tools/pull/4765)
 - Fix bug in which running "CMake: Build" would always run "CMake: Clean Rebuild" when `cmake.buildTask` is enabled [#4421](https://github.com/microsoft/vscode-cmake-tools/issues/4421) [@RedSkittleFox](https://github.com/RedSkittleFox)
 - Fix issue with hover provider not checking for undefined. [#4812](https://github.com/microsoft/vscode-cmake-tools/issues/4812)
+- Fix bug in which CTest is unable to run large amount of tests in parallel due to regex exceeding command line length limits [#4829](https://github.com/microsoft/vscode-cmake-tools/issues/4829) [@theuke](https://github.com/theuke)
 
 ## 1.22.28
 

--- a/src/ctest.ts
+++ b/src/ctest.ts
@@ -166,6 +166,96 @@ export function searchOutputForFailures(patterns: FailurePatternsConfig, output:
     return messages;
 }
 
+/**
+ * Finds the minimal regex fragments to match targets from the superset.
+ * If a target is a prefix of a forbidden string, it returns an exact match.
+ * Otherwise, it returns a minimal prefix.
+ *
+ * @param superset : the list of all individual test names (individual and or group names)
+ * @param targets : the list of test names (individual and or group names) we want to match.
+ * @returns : the list of regex fragments to match the targets without matching any other test from the superset
+ */
+export function getMinimalRegexFragments(superset: string[], targets: string[]): string[] {
+    interface TrieNode {
+        children: Map<string, TrieNode>;
+        forbiddenCount: number;
+    }
+
+    const targetSet = new Set(targets);
+    const forbidden = superset.filter(s => !targetSet.has(s));
+
+    if (targets.length === 0) {
+        return [];
+    }
+    if (forbidden.length === 0) {
+        return ["^."];
+    }
+
+    const root: TrieNode = { children: new Map(), forbiddenCount: 0 };
+
+    // 1. Build Trie with forbidden strings
+    for (const s of forbidden) {
+        let current = root;
+        for (const char of s) {
+            if (!current.children.has(char)) {
+                current.children.set(char, { children: new Map(), forbiddenCount: 0 });
+            }
+            current = current.children.get(char)!;
+            current.forbiddenCount++;
+        }
+    }
+
+    const fragmentSet = new Set<string>();
+
+    // 2. Identify the optimal regex fragment for each target
+    for (const target of targets) {
+        let current = root;
+        let prefix = "";
+        let foundUnique = false;
+
+        for (const char of target) {
+            prefix += char;
+            const next = current.children.get(char);
+
+            if (!next || next.forbiddenCount === 0) {
+                // Safe unique prefix found
+                fragmentSet.add(`^${util.escapeStringForRegex(prefix)}`);
+                foundUnique = true;
+                break;
+            }
+            current = next;
+        }
+
+        // 3. The "Swallowed" Target Case
+        // Target is a prefix of a forbidden string (e.g., "Test" vs "Test.1")
+        if (!foundUnique) {
+            fragmentSet.add(`^${util.escapeStringForRegex(target)}$`);
+        }
+    }
+
+    // 4. Remove redundant fragments
+    // Sort by length: "Test\." (length 6) comes before "Test\.x\.1" (length 10)
+    const sorted = Array.from(fragmentSet).sort((a, b) => a.length - b.length);
+    const minimalFragments: string[] = [];
+
+    for (const fragment of sorted) {
+        // If we already have a prefix that covers this fragment, skip it.
+        // Note: 'existing' only matches 'fragment' if it's a true prefix (no $ anchor)
+        const isRedundant = minimalFragments.some(existing => {
+            if (existing.endsWith('$')) {
+                return false; // Exact matches can't cover other things
+            }
+            return fragment.startsWith(existing);
+        });
+
+        if (!isRedundant) {
+            minimalFragments.push(fragment);
+        }
+    }
+
+    return minimalFragments;
+}
+
 function matchToTestMessage(pat: FailurePattern, match: RegExpMatchArray): vscode.TestMessage {
     const file = match[pat.file as number];
     const line = pat.line ? parseLineMatch(match[pat.line]) : 0;
@@ -442,7 +532,8 @@ export class CTestDriver implements vscode.Disposable {
         const ctestArgs = await this.getCTestArgs(driver, customizedTask, testPreset) || [];
         if (testsToRun && testsToRun.length > 0) {
             ctestArgs.push("-R");
-            const testsNamesRegex = testsToRun.map(t => `^${util.escapeStringForRegex(t)}\$`).join('|');
+            const superset = this.getTestNames() || [];
+            const testsNamesRegex = getMinimalRegexFragments(superset, testsToRun).join('|');
             ctestArgs.push(testsNamesRegex);
         }
 
@@ -613,7 +704,8 @@ export class CTestDriver implements vscode.Disposable {
 
                     run.started(test);
 
-                    const _ctestArgs = driver.ctestArgs.concat('-R', `^${util.escapeStringForRegex(test.id)}\$`);
+                    const superset = this.getTestNames() || [];
+                    const _ctestArgs = driver.ctestArgs.concat('-R', getMinimalRegexFragments(superset, [test.id]).join('|'));
 
                     const testResults = await this.runCTestImpl(driver.driver, driver.ctestPath, _ctestArgs, cancellation, customizedTask, consumer);
 
@@ -651,21 +743,21 @@ export class CTestDriver implements vscode.Disposable {
                 // then there may be a scenario when the user requested only a subset of tests to be ran.
                 // In this case, we should specifically use the -R flag to select the exact tests.
                 // Otherwise, we can leave it to the -T flag to run all tests.
+                let targetTests: vscode.TestItem[] | undefined;
                 if (entryPoint === RunCTestHelperEntryPoint.TestExplorer && testExplorer && this._tests && this._tests.tests.length !== driver.tests.length) {
-                    uniqueCtestArgs.push("-R");
-                    const testsNamesRegex = driver.tests.map(t => {
-                        run.started(t);
-                        return `^${util.escapeStringForRegex(t.id)}\$`;
-                    }).join('|');
-                    uniqueCtestArgs.push(testsNamesRegex);
+                    targetTests = driver.tests;
                 } else if (testsToRun && testsToRun.length > 0) {
+                    targetTests = driver.tests.filter(t => testsToRun.includes(t.id));
+                }
+
+                if (targetTests) {
                     uniqueCtestArgs.push("-R");
-                    const tests = driver.tests.filter(t => testsToRun.includes(t.id));
-                    const testsNamesRegex = tests.map(t => {
+                    const superset = this.getTestNames() || [];
+                    const targets = targetTests.map(t => {
                         run.started(t);
-                        return `^${util.escapeStringForRegex(t.id)}\$`;
-                    }).join('|');
-                    uniqueCtestArgs.push(testsNamesRegex);
+                        return t.id;
+                    });
+                    uniqueCtestArgs.push(getMinimalRegexFragments(superset, targets).join('|'));
                 }
 
                 const testResults = await this.runCTestImpl(uniqueDriver, uniqueCtestPath, uniqueCtestArgs, cancellation, customizedTask, consumer);

--- a/test/unit-tests/ctest.test.ts
+++ b/test/unit-tests/ctest.test.ts
@@ -1,4 +1,4 @@
-import { readTestResultsFile, searchOutputForFailures } from "@cmt/ctest";
+import { readTestResultsFile, searchOutputForFailures, getMinimalRegexFragments } from "@cmt/ctest";
 import { expect, getTestResourceFilePath } from "@test/util";
 import { TestMessage } from "vscode";
 
@@ -111,4 +111,94 @@ suite('CTest test', () => {
         expect(tm.expectedOutput).to.eq(expected);
         expect(tm.actualOutput).to.eq(actual);
     }
+
+    suite('getMinimalRegexFragments', () => {
+        test('no targets', () => {
+            const result = getMinimalRegexFragments(['A', 'B', 'C'], []);
+            expect(result).to.deep.eq([]);
+        });
+
+        test('no forbidden strings', () => {
+            const result = getMinimalRegexFragments(['A', 'B', 'C'], ['A', 'B', 'C']);
+            expect(result).to.deep.eq(['^.']);
+        });
+
+        test('unique prefixes map correctly', () => {
+            const superset = ['Test1', 'Test2', 'OtherTest'];
+            // Target is a unique subset
+            const result = getMinimalRegexFragments(superset, ['Test1', 'OtherTest']);
+            // Test1 -> T e s t 1 (at '1', no other forbidden string shares this prefix since Test2 diverges at 1)
+            // OtherTest -> O (matches nothing forbidden immediately)
+            // wait, forbidden is ['Test2']
+            // For 'Test1': prefix 'Test1' -> forbidden count 0. Wait, 'T' matches 'Test2', 'e', 's', 't', '1'. 'Test1' is the prefix!
+            expect(result.length).to.eq(2);
+            expect(result).to.include('^Test1');
+            expect(result).to.include('^O');
+        });
+
+        test('swallowed target case (prefix of forbidden string)', () => {
+            const superset = ['Test', 'Test.1', 'Test.2'];
+            const targets = ['Test'];
+            // Since 'Test' is a prefix of 'Test.1', it never finds a prefix that has forbiddenCount 0.
+            // It parses all characters of 'Test' and then uses an end anchor.
+            const result = getMinimalRegexFragments(superset, targets);
+            expect(result).to.deep.eq(['^Test$']);
+        });
+
+        test('handles regex special characters properly', () => {
+            const superset = ['Test[A]', 'Test[B]'];
+            const targets = ['Test[A]'];
+            // Forbidden is ['Test[B]']
+            // 'Test[' is shared. 'Test[A' is unique.
+            const result = getMinimalRegexFragments(superset, targets);
+            expect(result).to.deep.eq(['^Test\\[A']);
+        });
+
+        test('removes redundant fragments', () => {
+            // Targets: ['A', 'AB']
+            // Forbidden: ['B']
+            // 'A' -> 'A', AB -> 'A'
+            // "A" covers "AB", so "AB" is redundant.
+            const result = getMinimalRegexFragments(['A', 'AB', 'B'], ['A', 'AB']);
+            // forbidden: 'B'. root has 'B'.
+            // 'A' char 'A' -> forbidden 0 -> 'A'
+            // 'AB' char 'A' -> forbidden 0 -> 'A'
+            // result ['^A']
+            expect(result).to.deep.eq(['^A']);
+        });
+
+        test('complex edge cases: nested suites, swallowed prefixes, special characters', () => {
+            const superset = [
+                'Suite',            // Target: gets swallowed by prefix sharing with forbidden
+                'Suite.Test1',      // Target: logically nested
+                'Suite.Test2',      // Target: logically nested
+                'Suite.Test3',      // Forbidden
+                'OtherSuite.Test1', // Target
+                'OtherSuite.Test2', // Target
+                'O[ther]',          // Forbidden: share 'O' prefix
+                'A+B.Test',         // Target: gets swallowed + special chars
+                'A+B.Test2'         // Forbidden
+            ];
+
+            const targets = [
+                'Suite',
+                'Suite.Test1',
+                'Suite.Test2',
+                'OtherSuite.Test1',
+                'OtherSuite.Test2',
+                'A+B.Test'
+            ];
+
+            const result = getMinimalRegexFragments(superset, targets);
+
+            expect(result).to.have.members([
+                '^Suite$',
+                '^Suite\\.Test1',
+                '^Suite\\.Test2',
+                '^Ot',
+                '^A\\+B\\.Test$'
+            ]);
+            expect(result.length).to.eq(5);
+        });
+    });
 });


### PR DESCRIPTION
## This change addresses item #4829

### This changes behavior of how CTest generates regex for running parallel unit tests

The following changes are proposed:

- Minimize the regex used to indicate which unit tests are to be run when many unit tests are selected.
- Current behavior is to have a single "strict match" regex for every single unit test case which results in ctest crashing out due to the size of the aggregate regex.