### PR TITLE
Improve Test Reliability

### DIFF
--- a/test/end-to-end-tests/successful-build/test/debugger.test.ts
+++ b/test/end-to-end-tests/successful-build/test/debugger.test.ts
@@ -294,23 +294,28 @@ suite('Debug/Launch interface', () => {
 
         const terminal = await cmakeProject.launchTarget();
         expect(terminal).to.be.not.null;
-        expect(terminal!.name).to.eq(`CMake/Launch - ${executablesTargets[0].name}`);
 
-        const start = new Date();
-        // Needed to get launch target result
-        await new Promise(resolve => setTimeout(resolve, 3000));
+        try {
+            // Use creationOptions.name — terminal.name may be dynamically
+            // overridden by the shell process title in newer VS Code versions.
+            expect(terminal!.creationOptions.name).to.eq(`CMake/Launch - ${executablesTargets[0].name}`);
 
-        const elapsed = (new Date().getTime() - start.getTime()) / 1000;
-        console.log(`Waited ${elapsed} seconds for output file to appear`);
+            const start = new Date();
+            // Needed to get launch target result
+            await new Promise(resolve => setTimeout(resolve, 3000));
 
-        const exists = fs.existsSync(createdFileOnExecution);
-        // Check that it is compiled as a new file
-        expect(exists).to.be.true;
+            const elapsed = (new Date().getTime() - start.getTime()) / 1000;
+            console.log(`Waited ${elapsed} seconds for output file to appear`);
 
-        terminal?.dispose();
+            const exists = fs.existsSync(createdFileOnExecution);
+            // Check that it is compiled as a new file
+            expect(exists).to.be.true;
+        } finally {
+            terminal?.dispose();
 
-        // Needed to ensure things get disposed
-        await new Promise((resolve) => setTimeout(resolve, 3000));
+            // Needed to ensure things get disposed
+            await new Promise((resolve) => setTimeout(resolve, 3000));
+        }
     }).timeout(60000);
 
     test('Test launch same target multiple times when newTerminal run is enabled', async () => {
@@ -341,17 +346,23 @@ suite('Debug/Launch interface', () => {
 
         const term2 = await cmakeProject.launchTarget();
         expect(term2).to.be.not.null;
-        expect(term2!.name).to.eq(
-            `CMake/Launch - ${executablesTargets[0].name}`
-        );
 
-        const term2Pid = await term2?.processId;
-        expect(term1Pid).to.not.eq(term2Pid);
-        term1?.dispose();
-        term2?.dispose();
+        try {
+            // Use creationOptions.name — terminal.name may be dynamically
+            // overridden by the shell process title in newer VS Code versions.
+            expect(term2!.creationOptions.name).to.eq(
+                `CMake/Launch - ${executablesTargets[0].name}`
+            );
 
-        // Needed to ensure things get disposed
-        await new Promise((resolve) => setTimeout(resolve, 3000));
+            const term2Pid = await term2?.processId;
+            expect(term1Pid).to.not.eq(term2Pid);
+        } finally {
+            term1?.dispose();
+            term2?.dispose();
+
+            // Needed to ensure things get disposed
+            await new Promise((resolve) => setTimeout(resolve, 3000));
+        }
     }).timeout(60000);
 
     test('Test launch same target multiple times when newTerminal run is disabled', async () => {


### PR DESCRIPTION
This pull request updates the debugger end-to-end tests to improve reliability when checking terminal names, ensuring compatibility with newer versions of VS Code where the terminal's display name may be overridden by the shell process. It also improves resource cleanup in the tests.

**Test reliability improvements:**

* Updated tests in `debugger.test.ts` to check `terminal.creationOptions.name` instead of `terminal.name`, since the displayed terminal name can be dynamically overridden in newer VS Code versions. [[1]](diffhunk://#diff-880daf1b5f291d70d56c3777571ad47ab09be1254b4995a6f48e8453208b766bL297-R301) [[2]](diffhunk://#diff-880daf1b5f291d70d56c3777571ad47ab09be1254b4995a6f48e8453208b766bL344-R365)

**Resource management enhancements:**

* Wrapped terminal assertions and execution checks in `try/finally` blocks to ensure terminals are always disposed of, improving test cleanup and reliability. [[1]](diffhunk://#diff-880daf1b5f291d70d56c3777571ad47ab09be1254b4995a6f48e8453208b766bL309-R318) [[2]](diffhunk://#diff-880daf1b5f291d70d56c3777571ad47ab09be1254b4995a6f48e8453208b766bL344-R365)