### PR TITLE
make test run in order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Features:
 - Support string arrays in kit `cmakeSettings` to pass CMake lists without escaping semicolons (e.g., `"LLVM_ENABLE_PROJECTS": ["clang", "lld"]`). [#4503](https://github.com/microsoft/vscode-cmake-tools/issues/4503)
 
 Improvements:
+- Run tests sequentially in alphabetical order (matching the Test Explorer display order) when `cmake.ctest.allowParallelJobs` is disabled. [#4829](https://github.com/microsoft/vscode-cmake-tools/issues/4829)
 - Add `.github/copilot-instructions.md` to ground GitHub Copilot in the repo's architecture and coding conventions.
 - Clicking on a CTest in the Project Outline now navigates to the test source file, matching the existing Test Explorer behavior. [#4773](https://github.com/microsoft/vscode-cmake-tools/issues/4773)
 - Clicking on a CTest unit test in the Test Explorer now navigates to the test source file by matching the test executable to its CMake target's source files. [#4449](https://github.com/microsoft/vscode-cmake-tools/issues/4449)

--- a/docs/cmake-settings.md
+++ b/docs/cmake-settings.md
@@ -34,7 +34,7 @@ Options that support substitution, in the table below, allow variable references
 | `cmake.cpackArgs` | An array of additional arguments to pass to cpack. | `[]` | yes |
 | `cmake.cpackEnvironment` | An object containing `key:value` pairs of environment variables, which will be available when running cpack. | `{}` | yes |
 | `cmake.cpackPath` | Path to cpack executable. | `null` | no |
-| `cmake.ctest.allowParallelJobs` | If `true`, allow running test jobs in parallel. | `false` | no |
+| `cmake.ctest.allowParallelJobs` | If `true`, allow running test jobs in parallel. When `false`, tests run sequentially in alphabetical order, matching the Test Explorer display order. | `false` | no |
 | `cmake.ctest.debugLaunchTarget` | Target to debug during CTest execution. | `null` | no |
 | `cmake.ctest.parallelJobs` | Specify the number of jobs to run in parallel for ctest. Using the value `0` will detect and use the number of CPUs. Using the value `1` will disable test parallelism. | `0` | no |
 | `cmake.ctest.testExplorerIntegrationEnabled` | If `true`, configure CMake to generate information needed by the test explorer. | `true` | no |

--- a/package.nls.json
+++ b/package.nls.json
@@ -138,7 +138,7 @@
         "message": "The number of parallel test jobs. Use zero to use the value of `#cmake.parallelJobs#`. This only applies when `#cmake.ctest.allowParallelJobs#` is set to `true`.",
         "comment": "Markdown text between `` should not be translated or localized (they represent literal text) and the capitalization, spacing, and punctuation (including the ``) should not be altered."
     },
-    "cmake-tools.configuration.cmake.ctest.allowParallelJobs.description": "Allows ctests to be run in parallel, however the result output may be garbled as a result and the Test Explorer may not accurately reflect test progress.",
+    "cmake-tools.configuration.cmake.ctest.allowParallelJobs.description": "Allows ctests to be run in parallel, however the result output may be garbled as a result and the Test Explorer may not accurately reflect test progress. When disabled, tests run sequentially in alphabetical order, matching the Test Explorer display order.",
     "cmake-tools.configuration.cmake.ctest.testExplorerIntegrationEnabled.description": "Whether or not the integration with the test explorer is enabled. This is helpful to disable if you prefer using a different extension for test integration.",
     "cmake-tools.configuration.cmake.ctest.testSuiteDelimiter.markdownDescription": {
         "message": "Optional delimiter used to separate test suite names and group tests hierarchically in the Test Explorer. This string is used in a Regular Expression, so some delimiters may need escaping. Examples: `-` ( One delimiter: `-`), `\\.|::` (Two delimiters: `.` or `::`. Note that `.` needs to be escaped.)",

--- a/src/ctest.ts
+++ b/src/ctest.ts
@@ -696,6 +696,8 @@ export class CTestDriver implements vscode.Disposable {
 
         if (!this.ws.config.ctestAllowParallelJobs) {
             for (const driver of driverMap.values()) {
+                // Sort tests alphabetically by label to match the Test Explorer display order.
+                driver.tests.sort((a, b) => (a.label).localeCompare(b.label));
                 for (const test of driver.tests) {
                     if (cancellation && cancellation.isCancellationRequested) {
                         run.skipped(test);


### PR DESCRIPTION
This PR addresses issue #4802 

Previously when in sequential mode test run out of order as can be seen in this screenshot:
<img width="1324" height="506" alt="image" src="https://github.com/user-attachments/assets/b6f6ba45-380c-4925-95b4-9ad145f89ac4" />

This fix makes them run in alphabetical order as they are listed in the test explorer:
<img width="1123" height="551" alt="image" src="https://github.com/user-attachments/assets/db26269a-a828-4918-8f8f-d1d616966ff3" />



