### PR TITLE
Remove `handlebars` dependency to fix dependabot issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -4315,7 +4315,6 @@
     "@friedemannsommer/lcov-parser": "^5.0.0",
     "@types/string.prototype.matchall": "^4.0.4",
     "ajv": "^8.18.0",
-    "handlebars": "^4.7.7",
     "iconv-lite": "^0.6.2",
     "js-yaml": "^4.1.1",
     "json5": "^2.2.2",

--- a/src/contextKeyExpr.ts
+++ b/src/contextKeyExpr.ts
@@ -5,7 +5,6 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 import * as nls from 'vscode-nls';
-import { Exception } from 'handlebars';
 
 const localize: nls.LocalizeFunc = nls.loadMessageBundle();
 const CONSTANT_VALUES = new Map<string, boolean>();
@@ -166,7 +165,7 @@ export class Scanner {
             case TokenType.EOF:
                 return 'EOF';
             default:
-                throw new Exception(`unhandled token type: ${JSON.stringify(token)}; have you forgotten to add a case?`);
+                throw new Error(`unhandled token type: ${JSON.stringify(token)}; have you forgotten to add a case?`);
         }
     }
 
@@ -840,8 +839,6 @@ export const enum CharCode {
 
 /** allow register constant context keys that are known only after startup; requires running `substituteConstants` on the context key - https://github.com/microsoft/vscode/issues/174218#issuecomment-1437972127 */
 export function setConstant(key: string, value: boolean) {
-    // if (CONSTANT_VALUES.get(key) !== undefined) { throw Exception('contextkey.setConstant(k, v) invoked with already set constant `k`'); }
-
     CONSTANT_VALUES.set(key, value);
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3952,18 +3952,6 @@ gulplog@^1.0.0:
   dependencies:
     glogg "^1.0.0"
 
-handlebars@^4.7.7:
-  version "4.7.7"
-  resolved "https://pkgs.dev.azure.com/azure-public/VisualCpp/_packaging/cpp_PublicPackages/npm/registry/handlebars/-/handlebars-4.7.7.tgz"
-  integrity sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==
-  dependencies:
-    minimist "^1.2.5"
-    neo-async "^2.6.0"
-    source-map "^0.6.1"
-    wordwrap "^1.0.0"
-  optionalDependencies:
-    uglify-js "^3.1.4"
-
 has-bigints@^1.0.1, has-bigints@^1.0.2:
   version "1.0.2"
   resolved "https://pkgs.dev.azure.com/azure-public/VisualCpp/_packaging/cpp_PublicPackages/npm/registry/has-bigints/-/has-bigints-1.0.2.tgz"
@@ -5434,7 +5422,7 @@ natural-compare@^1.4.0:
   resolved "https://pkgs.dev.azure.com/azure-public/VisualCpp/_packaging/cpp_PublicPackages/npm/registry/natural-compare/-/natural-compare-1.4.0.tgz"
   integrity sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=
 
-neo-async@^2.6.0, neo-async@^2.6.2:
+neo-async@^2.6.2:
   version "2.6.2"
   resolved "https://pkgs.dev.azure.com/azure-public/VisualCpp/_packaging/cpp_PublicPackages/npm/registry/neo-async/-/neo-async-2.6.2.tgz"
   integrity sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==
@@ -7600,11 +7588,6 @@ uc.micro@^2.0.0, uc.micro@^2.1.0:
   resolved "https://pkgs.dev.azure.com/azure-public/VisualCpp/_packaging/cpp_PublicPackages/npm/registry/uc.micro/-/uc.micro-2.1.0.tgz#f8d3f7d0ec4c3dea35a7e3c8efa4cb8b45c9e7ee"
   integrity sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==
 
-uglify-js@^3.1.4:
-  version "3.15.5"
-  resolved "https://pkgs.dev.azure.com/azure-public/VisualCpp/_packaging/cpp_PublicPackages/npm/registry/uglify-js/-/uglify-js-3.15.5.tgz"
-  integrity sha512-hNM5q5GbBRB5xB+PMqVRcgYe4c8jbyZ1pzZhS6jbq54/4F2gFK869ZheiE5A8/t+W5jtTNpWef/5Q9zk639FNQ==
-
 unbox-primitive@^1.0.2:
   version "1.0.2"
   resolved "https://pkgs.dev.azure.com/azure-public/VisualCpp/_packaging/cpp_PublicPackages/npm/registry/unbox-primitive/-/unbox-primitive-1.0.2.tgz"
@@ -8062,11 +8045,6 @@ word-wrap@^1.2.5:
   version "1.2.5"
   resolved "https://pkgs.dev.azure.com/azure-public/VisualCpp/_packaging/cpp_PublicPackages/npm/registry/word-wrap/-/word-wrap-1.2.5.tgz#d2c45c6dd4fbce621a66f136cbe328afd0410b34"
   integrity sha1-0sRcbdT7zmIaZvE2y+Mor9BBCzQ=
-
-wordwrap@^1.0.0:
-  version "1.0.0"
-  resolved "https://pkgs.dev.azure.com/azure-public/VisualCpp/_packaging/cpp_PublicPackages/npm/registry/wordwrap/-/wordwrap-1.0.0.tgz"
-  integrity sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=
 
 workerpool@^6.5.1:
   version "6.5.1"


### PR DESCRIPTION
Fixes `handlebars` by removing it, we can simply use the default node `Error`. 

This resolves the dependabot issue here: https://github.com/microsoft/vscode-cmake-tools/security/dependabot/133