### PR TITLE
Fix exportCompileCommands flag handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,13 @@ Features:
 - Add support for `${workspaceFolder}`, `${workspaceFolder:name}` variables and relative paths in `cmake.exclude` setting for multi-root workspaces. [#4689](https://github.com/microsoft/vscode-cmake-tools/pull/4689)
 
 Bug Fixes:
-- Fix `cmake.exportCompileCommandsFile` set to `false` still passing `-DCMAKE_EXPORT_COMPILE_COMMANDS:BOOL=FALSE` instead of omitting the flag entirely, which caused CMake warnings for projects with `LANGUAGES NONE`. [#4893](https://github.com/microsoft/vscode-cmake-tools/issues/4893)
 - Fix kit detection returning "unknown vendor" when using clang-cl compiler. [#4638](https://github.com/microsoft/vscode-cmake-tools/issues/4638)
 - Update testing framework to fix bugs when running tests of CMake Tools without a reliable internet connection. [#4891](https://github.com/microsoft/vscode-cmake-tools/pull/4891) [@cwalther](https://github.com/cwalther)
+
+## 1.23.52
+
+Bug Fixes:
+- Fix `cmake.exportCompileCommandsFile` set to `false` still passing `-DCMAKE_EXPORT_COMPILE_COMMANDS:BOOL=FALSE` instead of omitting the flag entirely, which caused CMake warnings for projects with `LANGUAGES NONE`. [#4893](https://github.com/microsoft/vscode-cmake-tools/issues/4893)
 
 ## 1.23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Features:
 - Add support for `${workspaceFolder}`, `${workspaceFolder:name}` variables and relative paths in `cmake.exclude` setting for multi-root workspaces. [#4689](https://github.com/microsoft/vscode-cmake-tools/pull/4689)
 
 Bug Fixes:
+- Fix `cmake.exportCompileCommandsFile` set to `false` still passing `-DCMAKE_EXPORT_COMPILE_COMMANDS:BOOL=FALSE` instead of omitting the flag entirely, which caused CMake warnings for projects with `LANGUAGES NONE`. [#4893](https://github.com/microsoft/vscode-cmake-tools/issues/4893)
 - Fix kit detection returning "unknown vendor" when using clang-cl compiler. [#4638](https://github.com/microsoft/vscode-cmake-tools/issues/4638)
 - Update testing framework to fix bugs when running tests of CMake Tools without a reliable internet connection. [#4891](https://github.com/microsoft/vscode-cmake-tools/pull/4891) [@cwalther](https://github.com/cwalther)
 

--- a/src/drivers/cmakeDriver.ts
+++ b/src/drivers/cmakeDriver.ts
@@ -1537,7 +1537,7 @@ export abstract class CMakeDriver implements vscode.Disposable {
         const presetCacheVariables = configPreset.cacheVariables ?? {};
         const hasExportCompileCommands = Object.prototype.hasOwnProperty.call(presetCacheVariables, 'CMAKE_EXPORT_COMPILE_COMMANDS')
             || expandedArgs.some(arg => arg.startsWith('-DCMAKE_EXPORT_COMPILE_COMMANDS'));
-        if (!hasExportCompileCommands) {
+        if (!hasExportCompileCommands && exportCompileCommandsFile) {
             const exportCompileCommandsValue = util.cmakeify(exportCompileCommandsFile);
             expandedArgs.push(`-DCMAKE_EXPORT_COMPILE_COMMANDS:${exportCompileCommandsValue.type}=${exportCompileCommandsValue.value}`);
         }
@@ -1847,7 +1847,9 @@ export abstract class CMakeDriver implements vscode.Disposable {
         // Export compile_commands.json
         const exportCompileCommandsSetting = config.get<boolean>("exportCompileCommandsFile");
         const exportCompileCommandsFile: boolean = exportCompileCommandsSetting === undefined ? true : (exportCompileCommandsSetting || false);
-        settingMap.CMAKE_EXPORT_COMPILE_COMMANDS = util.cmakeify(exportCompileCommandsFile);
+        if (exportCompileCommandsFile) {
+            settingMap.CMAKE_EXPORT_COMPILE_COMMANDS = util.cmakeify(exportCompileCommandsFile);
+        }
 
         console.assert(!!this._kit);
         if (!this._kit) {

--- a/test/unit-tests/backend/exportCompileCommands.test.ts
+++ b/test/unit-tests/backend/exportCompileCommands.test.ts
@@ -1,0 +1,123 @@
+import { expect } from 'chai';
+
+/**
+ * Tests for the export compile commands logic in cmakeDriver.ts
+ *
+ * This tests the LOGIC PATTERN used for deciding whether to inject
+ * -DCMAKE_EXPORT_COMPILE_COMMANDS into CMake configure arguments.
+ *
+ * The actual implementation lives in cmakeDriver.ts but depends on vscode,
+ * so we mirror the decision logic here to validate correctness.
+ *
+ * Issue #4893: When cmake.exportCompileCommandsFile is set to false,
+ * the flag should NOT be passed at all (not even as FALSE), to avoid
+ * CMake warnings for projects with LANGUAGES NONE.
+ */
+
+suite('[Export Compile Commands Logic]', () => {
+    /**
+     * Mirrors the logic from cmakeDriver.ts generateConfigArgsFromPreset()
+     * and generateCMakeSettingsFlags()
+     *
+     * @param exportCompileCommandsSetting The raw setting value (undefined, true, or false)
+     * @param hasExportCompileCommandsInPresetOrArgs Whether preset or args already specify the flag
+     * @returns Whether to inject the -DCMAKE_EXPORT_COMPILE_COMMANDS flag
+     */
+    function shouldInjectExportCompileCommandsFlag(
+        exportCompileCommandsSetting: boolean | undefined,
+        hasExportCompileCommandsInPresetOrArgs: boolean
+    ): boolean {
+        // Mirror the logic from cmakeDriver.ts:
+        // const exportCompileCommandsFile: boolean = exportCompileCommandsSetting === undefined ? true : (exportCompileCommandsSetting || false);
+        const exportCompileCommandsFile: boolean = exportCompileCommandsSetting === undefined ? true : (exportCompileCommandsSetting || false);
+
+        // For presets mode (generateConfigArgsFromPreset):
+        // if (!hasExportCompileCommands && exportCompileCommandsFile)
+        //
+        // For kits mode (generateCMakeSettingsFlags):
+        // if (exportCompileCommandsFile)
+        //
+        // Both modes now check exportCompileCommandsFile is truthy before injecting
+        return !hasExportCompileCommandsInPresetOrArgs && exportCompileCommandsFile;
+    }
+
+    suite('Setting is undefined (default)', () => {
+        test('Should inject flag when preset/args do not specify it', () => {
+            const result = shouldInjectExportCompileCommandsFlag(undefined, false);
+            expect(result).to.equal(true, 'Default behavior should inject TRUE to enable compile_commands.json');
+        });
+
+        test('Should NOT inject flag when preset/args already specify it', () => {
+            const result = shouldInjectExportCompileCommandsFlag(undefined, true);
+            expect(result).to.equal(false, 'Should respect preset/args override');
+        });
+    });
+
+    suite('Setting is explicitly true', () => {
+        test('Should inject flag when preset/args do not specify it', () => {
+            const result = shouldInjectExportCompileCommandsFlag(true, false);
+            expect(result).to.equal(true, 'Explicit true should inject the flag');
+        });
+
+        test('Should NOT inject flag when preset/args already specify it', () => {
+            const result = shouldInjectExportCompileCommandsFlag(true, true);
+            expect(result).to.equal(false, 'Should respect preset/args override');
+        });
+    });
+
+    suite('Setting is explicitly false (Issue #4893 fix)', () => {
+        test('Should NOT inject flag when preset/args do not specify it', () => {
+            const result = shouldInjectExportCompileCommandsFlag(false, false);
+            expect(result).to.equal(false, 'Explicit false should NOT inject the flag at all');
+        });
+
+        test('Should NOT inject flag when preset/args already specify it', () => {
+            const result = shouldInjectExportCompileCommandsFlag(false, true);
+            expect(result).to.equal(false, 'Should respect preset/args override');
+        });
+    });
+
+    suite('exportCompileCommandsFile computation', () => {
+        /**
+         * Mirrors the computation: exportCompileCommandsSetting === undefined ? true : (exportCompileCommandsSetting || false)
+         */
+        function computeExportCompileCommandsFile(setting: boolean | undefined): boolean {
+            return setting === undefined ? true : (setting || false);
+        }
+
+        test('undefined setting defaults to true', () => {
+            expect(computeExportCompileCommandsFile(undefined)).to.equal(true);
+        });
+
+        test('explicit true remains true', () => {
+            expect(computeExportCompileCommandsFile(true)).to.equal(true);
+        });
+
+        test('explicit false becomes false', () => {
+            expect(computeExportCompileCommandsFile(false)).to.equal(false);
+        });
+    });
+
+    suite('Kits mode logic (generateCMakeSettingsFlags)', () => {
+        /**
+         * In kits mode, the logic is simpler: just check if exportCompileCommandsFile is truthy
+         * (no hasExportCompileCommands check needed as configureSettings handles that)
+         */
+        function shouldAddToSettingMapInKitsMode(exportCompileCommandsSetting: boolean | undefined): boolean {
+            const exportCompileCommandsFile: boolean = exportCompileCommandsSetting === undefined ? true : (exportCompileCommandsSetting || false);
+            return exportCompileCommandsFile;
+        }
+
+        test('undefined setting should add to settingMap', () => {
+            expect(shouldAddToSettingMapInKitsMode(undefined)).to.equal(true);
+        });
+
+        test('explicit true should add to settingMap', () => {
+            expect(shouldAddToSettingMapInKitsMode(true)).to.equal(true);
+        });
+
+        test('explicit false should NOT add to settingMap (Issue #4893 fix)', () => {
+            expect(shouldAddToSettingMapInKitsMode(false)).to.equal(false);
+        });
+    });
+});


### PR DESCRIPTION
This pull request addresses a bug related to the handling of the `cmake.exportCompileCommandsFile` setting, ensuring that when it is set to `false`, the `-DCMAKE_EXPORT_COMPILE_COMMANDS` flag is omitted entirely rather than being passed as `FALSE`. This prevents CMake warnings for projects configured with `LANGUAGES NONE`. The changes also add targeted unit tests to validate the new logic. Resolves #4893 and tied to #4681 

**Bug Fixes and Logic Improvements:**

* Updated the logic in `CMakeDriver` (`cmakeDriver.ts`) so that the `-DCMAKE_EXPORT_COMPILE_COMMANDS` flag is only injected if `cmake.exportCompileCommandsFile` is `true` or unset, and omitted entirely if `false`, both for presets and kits modes. This resolves warnings in certain CMake projects. [[1]](diffhunk://#diff-6645acdc0be3bcb29a2643c100233e69f82c7285cd04e83a0290eb2d9df96f4fL1540-R1540) [[2]](diffhunk://#diff-6645acdc0be3bcb29a2643c100233e69f82c7285cd04e83a0290eb2d9df96f4fR1850-R1852)
* Added a new unit test suite (`exportCompileCommands.test.ts`) to verify the correct behavior for all combinations of the setting and argument overrides, ensuring the bug is fixed and future regressions are caught.