### PR TITLE
Enable Quick Debugging in Test Explorer like in Project Outline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ Features:
 - Add support for the FASTBuild generator (CMake 4.2+). [#4690](https://github.com/microsoft/vscode-cmake-tools/pull/4690)
 - Add support for `${workspaceFolder}`, `${workspaceFolder:name}` variables and relative paths in `cmake.exclude` setting for multi-root workspaces. [#4689](https://github.com/microsoft/vscode-cmake-tools/pull/4689)
 
+Improvements:
+- Harmonize test debugging with executable debugging: debugging a test from the Test Explorer now uses the same quick debug approach as the Project Outline by default, with no `launch.json` required. The `cmake.ctest.neverDebugTestsWithLaunchConfiguration` setting now defaults to `true`. To use launch configurations for test debugging, set it to `false`. [#3345](https://github.com/microsoft/vscode-cmake-tools/issues/3345) [#3451](https://github.com/microsoft/vscode-cmake-tools/pull/3451)
+
 Bug Fixes:
 - Fix kit detection returning "unknown vendor" when using clang-cl compiler. [#4638](https://github.com/microsoft/vscode-cmake-tools/issues/4638)
 - Update testing framework to fix bugs when running tests of CMake Tools without a reliable internet connection. [#4891](https://github.com/microsoft/vscode-cmake-tools/pull/4891) [@cwalther](https://github.com/cwalther)

--- a/docs/debug-launch.md
+++ b/docs/debug-launch.md
@@ -309,17 +309,19 @@ You can substitute the value of any variable in the CMake cache by adding a `com
 
 ## Debugging tests
 
-You can also construct launch.json configurations that allow you to debug tests in the Test Explorer.
+By default, debugging a test from the Test Explorer works the same way as debugging an executable from the Project Outline — CMake Tools automatically generates a debug configuration from the CMake cache without requiring a `launch.json` file.
 
-> **Note:**
-> These launch.json configurations are to be used specifically from the UI of the Test Explorer. 
+The auto-generated debug configuration respects `cmake.debugConfig` settings (such as custom `type`, `MIMode`, or `miDebuggerPath`). Test arguments, working directory, and environment variables are automatically resolved from CTest test properties.
 
-The easiest way to do this is to construct the debug configuration using `cmake.testProgram` for the `program` field, `cmake.testArgs` for 
-the `args` field, `cmake.testWorkingDirectory` for the `cwd` field, and `cmake.testEnvironment` for the `environment` field.
+### Using a launch.json for test debugging
 
-`cmake.testEnvironment` resolves to the environment variables set via the CTest `ENVIRONMENT` test property (e.g., from `set_tests_properties(... PROPERTIES ENVIRONMENT "A=B;C=D")`). It is replaced with an array of `{ "name": "...", "value": "..." }` objects suitable for launch.json.
+If you prefer to debug tests using a custom `launch.json` configuration, set `cmake.ctest.neverDebugTestsWithLaunchConfiguration` to `false` in your workspace settings. When disabled, CMake Tools shows a picker that lets you choose between quick debugging (without launch configuration) and any available `launch.json` configurations.
 
-A couple of examples:
+You can construct launch configurations using the following CMake Tools variables:
+- `${cmake.testProgram}` — the test executable path
+- `${cmake.testArgs}` — the test command-line arguments
+- `${cmake.testWorkingDirectory}` — the test working directory
+- `${cmake.testEnvironment}` — the test environment variables (from CTest `ENVIRONMENT` property)
 
 ### gdb
 ```jsonc

--- a/package.json
+++ b/package.json
@@ -2663,7 +2663,7 @@
         },
         "cmake.ctest.neverDebugTestsWithLaunchConfiguration": {
           "type": "boolean",
-          "default": false,
+          "default": true,
           "description": "%cmake-tools.configuration.cmake.ctest.neverDebugTestsWithLaunchConfiguration.description%",
           "scope": "resource"
         },

--- a/src/cmakeProject.ts
+++ b/src/cmakeProject.ts
@@ -2,6 +2,7 @@ import { CMakeCache } from '@cmt/cache';
 import { CMakeExecutable, getCMakeExecutableInformation } from '@cmt/cmakeExecutable';
 import { CompilationDatabase } from '@cmt/compilationDatabase';
 import * as debuggerModule from '@cmt/debug/debugger';
+import { VSCodeDebugConfiguration } from '@cmt/debug/debugger';
 import collections from '@cmt/diagnostics/collections';
 import * as shlex from '@cmt/shlex';
 import { Strand } from '@cmt/strand';
@@ -2697,12 +2698,6 @@ export class CMakeProject {
     }
 
     async debugCTest(testName: string): Promise<vscode.DebugSession | null> {
-        const drv = await this.getCMakeDriverInstance();
-        if (!drv) {
-            void vscode.window.showErrorMessage(localize('set.up.and.build.project.before.debugging', 'Set up and build your CMake project before debugging.'));
-            return null;
-        }
-
         const testInfo = this.cTestController.getTestInfo(testName);
         if (!testInfo) {
             log.error(localize('test.not.found', 'Test not found: {0}', testName));
@@ -2714,62 +2709,24 @@ export class CMakeProject {
             path: testInfo.program
         };
 
-        let debugConfig;
-        const userConfig = this.workspaceContext.config.debugConfig;
-        if (userConfig?.type) {
-            // User specified a custom debug adapter type — skip auto-detection
-            // and build a minimal base config from the target. Properties from
-            // userConfig are merged on top, so any base property can be overridden.
-            debugConfig = {
-                type: userConfig.type,
-                name: `Debug ${testName}`,
-                request: 'launch',
-                program: testInfo.program,
-                cwd: path.dirname(testInfo.program),
-                args: [] as string[]
-            };
-            Object.assign(debugConfig, userConfig);
-        } else {
-            try {
-                const cache = await CMakeCache.fromPath(drv.cachePath);
-                debugConfig = await debuggerModule.getDebugConfigurationFromCache(cache, target, process.platform,
-                    userConfig?.MIMode,
-                    userConfig?.miDebuggerPath);
-            } catch (error: any) {
-                void vscode.window
-                    .showErrorMessage(error.message, {
-                        title: localize('debugging.documentation.button', 'Debugging documentation'),
-                        isLearnMore: true
-                    })
-                    .then(item => {
-                        if (item && item.isLearnMore) {
-                            open('https://vector-of-bool.github.io/docs/vscode-cmake-tools/debugging.html');
-                        }
-                    });
-                return null;
-            }
-
-            if (debugConfig === null) {
-                log.error(localize('failed.to.generate.debugger.configuration', 'Failed to generate debugger configuration'));
-                void vscode.window.showErrorMessage(localize('unable.to.generate.debugging.configuration', 'Unable to generate a debugging configuration.'));
-                return null;
-            }
-
-            // Add debug configuration from settings
-            Object.assign(debugConfig, userConfig);
+        const debugConfig = await this.getDebugConfiguration(target);
+        if (!debugConfig) {
+            return null;
         }
 
-        // Add test arguments and working directory
+        // Override with test-specific args and working directory
         debugConfig.args = testInfo.args;
         if (testInfo.workingDirectory) {
             debugConfig.cwd = testInfo.workingDirectory;
         }
 
-        // Merge CTest ENVIRONMENT properties into the debug environment
-        const testEnvVars = util.makeDebuggerEnvironmentVars(testInfo.environment);
-        const combinedEnvVars = [...testEnvVars, ...(debugConfig.environment ?? [])];
-        const launchEnv = await this.getTargetLaunchEnvironment(drv, combinedEnvVars);
-        debugConfig.environment = util.makeDebuggerEnvironmentVars(launchEnv);
+        // Merge CTest ENVIRONMENT properties INTO the debug environment.
+        // CTest ENVIRONMENT should win over base debug env, so overlay test env on top.
+        if (Object.keys(testInfo.environment).length > 0) {
+            const currentEnv = util.fromDebuggerEnvironmentVars(debugConfig.environment);
+            const mergedEnv = EnvironmentUtils.merge([currentEnv, testInfo.environment]);
+            debugConfig.environment = util.makeDebuggerEnvironmentVars(mergedEnv);
+        }
 
         await vscode.debug.startDebugging(this.workspaceFolder, debugConfig);
         return vscode.debug.activeDebugSession!;
@@ -3197,7 +3154,16 @@ export class CMakeProject {
         }
 
         if (name) {
-            const found = (await this.executableTargets).find(e => e.name === name);
+            let found = (await this.executableTargets).find(e => e.name === name);
+            if (!found) {
+                // Fallback: match by executable basename (handles test programs where
+                // the executable name differs from the CMake target name)
+                const targets = await this.executableTargets;
+                const byBasename = targets.filter(e => path.parse(e.path).name === name);
+                if (byBasename.length === 1) {
+                    found = byBasename[0];
+                }
+            }
             if (!found) {
                 return null;
             }
@@ -3299,6 +3265,73 @@ export class CMakeProject {
     }
 
     /**
+     * Build a debug configuration for the given executable target.
+     * Shared by `debugTarget()` and `debugCTest()`.
+     */
+    async getDebugConfiguration(targetExecutable: ExecutableTarget): Promise<VSCodeDebugConfiguration | null> {
+        const drv = await this.getCMakeDriverInstance();
+        if (!drv) {
+            void vscode.window.showErrorMessage(localize('set.up.and.build.project.before.debugging', 'Set up and build your CMake project before debugging.'));
+            return null;
+        }
+
+        let debugConfig: VSCodeDebugConfiguration;
+        const userConfig = this.workspaceContext.config.debugConfig;
+        if (userConfig?.type) {
+            // User specified custom debug adapter type — skip auto-detection
+            debugConfig = {
+                type: userConfig.type,
+                name: `Debug ${targetExecutable.name}`,
+                request: 'launch',
+                program: targetExecutable.path,
+                cwd: targetExecutable.debuggerWorkingDirectory || path.dirname(targetExecutable.path),
+                args: [] as string[]
+            } as VSCodeDebugConfiguration;
+            Object.assign(debugConfig, userConfig);
+            log.debug(localize('debug.configuration.from.settings', 'Debug configuration from user settings: {0}', JSON.stringify(debugConfig)));
+        } else {
+            try {
+                const cache = await CMakeCache.fromPath(drv.cachePath);
+                const config = await debuggerModule.getDebugConfigurationFromCache(cache, targetExecutable, process.platform,
+                    userConfig?.MIMode,
+                    userConfig?.miDebuggerPath);
+                if (config === null) {
+                    log.error(localize('failed.to.generate.debugger.configuration', 'Failed to generate debugger configuration'));
+                    void vscode.window.showErrorMessage(localize('unable.to.generate.debugging.configuration', 'Unable to generate a debugging configuration.'));
+                    return null;
+                }
+                debugConfig = config;
+                log.debug(localize('debug.configuration.from.cache', 'Debug configuration from cache: {0}', JSON.stringify(debugConfig)));
+            } catch (error: any) {
+                void vscode.window
+                    .showErrorMessage(error.message, {
+                        title: localize('debugging.documentation.button', 'Debugging documentation'),
+                        isLearnMore: true
+                    })
+                    .then(item => {
+                        if (item && item.isLearnMore) {
+                            open('https://vector-of-bool.github.io/docs/vscode-cmake-tools/debugging.html');
+                        }
+                    });
+                log.debug(localize('problem.getting.debug', 'Problem getting debug configuration from cache.'), error);
+                return null;
+            }
+
+            // Add debug configuration from settings
+            Object.assign(debugConfig, userConfig);
+        }
+
+        const launchEnv = await this.getTargetLaunchEnvironment(drv, debugConfig.environment);
+        debugConfig.environment = util.makeDebuggerEnvironmentVars(launchEnv);
+        log.debug(localize('starting.debugger.with', 'Starting debugger with following configuration.'), JSON.stringify({
+            workspace: this.workspaceFolder.uri.toString(),
+            config: debugConfig
+        }));
+
+        return debugConfig;
+    }
+
+    /**
      * Implementation of `cmake.debugTarget`
      */
     async debugTarget(name?: string): Promise<vscode.DebugSession | null> {
@@ -3327,60 +3360,10 @@ export class CMakeProject {
             return null;
         }
 
-        let debugConfig;
-        const userConfig = this.workspaceContext.config.debugConfig;
-        if (userConfig?.type) {
-            // User specified a custom debug adapter type — skip auto-detection
-            // and build a minimal base config from the target. Properties from
-            // userConfig are merged on top, so any base property can be overridden.
-            debugConfig = {
-                type: userConfig.type,
-                name: `Debug ${targetExecutable.name}`,
-                request: 'launch',
-                program: targetExecutable.path,
-                cwd: targetExecutable.debuggerWorkingDirectory || path.dirname(targetExecutable.path),
-                args: [] as string[]
-            };
-            Object.assign(debugConfig, userConfig);
-            log.debug(localize('debug.configuration.from.settings', 'Debug configuration from user settings: {0}', JSON.stringify(debugConfig)));
-        } else {
-            try {
-                const cache = await CMakeCache.fromPath(drv.cachePath);
-                debugConfig = await debuggerModule.getDebugConfigurationFromCache(cache, targetExecutable, process.platform,
-                    userConfig?.MIMode,
-                    userConfig?.miDebuggerPath);
-                log.debug(localize('debug.configuration.from.cache', 'Debug configuration from cache: {0}', JSON.stringify(debugConfig)));
-            } catch (error: any) {
-                void vscode.window
-                    .showErrorMessage(error.message, {
-                        title: localize('debugging.documentation.button', 'Debugging documentation'),
-                        isLearnMore: true
-                    })
-                    .then(item => {
-                        if (item && item.isLearnMore) {
-                            open('https://vector-of-bool.github.io/docs/vscode-cmake-tools/debugging.html');
-                        }
-                    });
-                log.debug(localize('problem.getting.debug', 'Problem getting debug configuration from cache.'), error);
-                return null;
-            }
-
-            if (debugConfig === null) {
-                log.error(localize('failed.to.generate.debugger.configuration', 'Failed to generate debugger configuration'));
-                void vscode.window.showErrorMessage(localize('unable.to.generate.debugging.configuration', 'Unable to generate a debugging configuration.'));
-                return null;
-            }
-
-            // Add debug configuration from settings.
-            Object.assign(debugConfig, userConfig);
+        const debugConfig = await this.getDebugConfiguration(targetExecutable);
+        if (!debugConfig) {
+            return null;
         }
-
-        const launchEnv = await this.getTargetLaunchEnvironment(drv, debugConfig.environment);
-        debugConfig.environment = util.makeDebuggerEnvironmentVars(launchEnv);
-        log.debug(localize('starting.debugger.with', 'Starting debugger with following configuration.'), JSON.stringify({
-            workspace: this.workspaceFolder.uri.toString(),
-            config: debugConfig
-        }));
 
         const cfg = vscode.workspace.getConfiguration('cmake', this.workspaceFolder.uri).inspect<object>('debugConfig');
         const customSetting = (cfg?.globalValue !== undefined || cfg?.workspaceValue !== undefined || cfg?.workspaceFolderValue !== undefined);
@@ -3394,7 +3377,6 @@ export class CMakeProject {
             customSetting: customSetting.toString(),
             debugger: dbg
         };
-
         telemetry.logEvent('debug', telemetryProperties);
 
         await vscode.debug.startDebugging(this.workspaceFolder, debugConfig);


### PR DESCRIPTION
## This change addresses items #3345, #3280 and #3153

Supersedes #3451 as it is rebased and updated for the current codebase.

The following changes are proposed:

When the user debugs a test via `TestExplorer/some-test/Debug-Icon` now the method to create a debug configuration behind the scenes is used as when the user right-clicks an executable and uses "Debug" in the `PROJECT OUTLINE` of cmake.

## The purpose of this change

Harmonize Quick Debugging of executables and tests.

Simplify debugging of tests.

## Changes in current behavior

- **Extracted `getDebugConfiguration()`** from `debugTarget()` into a shared public method on `CMakeProject`, eliminating duplicated debug config generation logic between `debugTarget()` and `debugCTest()`.
- **Refactored `debugCTest()`** to use the shared `getDebugConfiguration()`, fixing CTest `ENVIRONMENT` merge order so test env wins over base debug env.
- **Added basename fallback** in `prepareLaunchTargetExecutable()` for matching test executables whose names differ from CMake target names (only accepts unambiguous single matches).
- **Changed `neverDebugTestsWithLaunchConfiguration` default to `true`** so tests debug like executables by default — no `launch.json` required.
- **Updated `docs/debug-launch.md`** to reflect the simplified default workflow. Launch.json-based test debugging remains available by setting `cmake.ctest.neverDebugTestsWithLaunchConfiguration` to `false`.

The legacy driver check is kept only in `debugTarget()` and not in the shared helper, preserving existing behavior for test debugging paths.

Credit to @basejumpa for the original concept in #3451.