### PR TITLE
Improve responsiveness to cmake changes made by vendors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ Features:
 - Add support for the FASTBuild generator (CMake 4.2+). [#4690](https://github.com/microsoft/vscode-cmake-tools/pull/4690)
 - Add support for `${workspaceFolder}`, `${workspaceFolder:name}` variables and relative paths in `cmake.exclude` setting for multi-root workspaces. [#4689](https://github.com/microsoft/vscode-cmake-tools/pull/4689)
 
+Improvements:
+- Improve responsiveness to CMake path changes made by vendor extensions during configure-on-open retry. [#4908](https://github.com/microsoft/vscode-cmake-tools/pull/4908) Contributed by STMicroelectronics
+
 Bug Fixes:
 - Fix kit detection returning "unknown vendor" when using clang-cl compiler. [#4638](https://github.com/microsoft/vscode-cmake-tools/issues/4638)
 - Update testing framework to fix bugs when running tests of CMake Tools without a reliable internet connection. [#4891](https://github.com/microsoft/vscode-cmake-tools/pull/4891) [@cwalther](https://github.com/cwalther)

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -843,7 +843,9 @@ export class ExtensionManager implements vscode.Disposable {
                     const delayMs = cmakeNotFoundRetryDelaysMs[
                         Math.min(attempt, cmakeNotFoundRetryDelaysMs.length - 1)
                     ];
-                    await new Promise<void>(resolve => setTimeout(resolve, delayMs));
+
+                    // Wait for delayMs or cmake.cmakePath change
+                    await this.waitForDelayOrCmakePathChange(delayMs);
 
                     // Lightweight probe: just check if cmake is available now.
                     // This does NOT enter the driverStrand, does NOT show popups,
@@ -871,6 +873,31 @@ export class ExtensionManager implements vscode.Disposable {
             log.warning(localize('cmake.retry.exhausted', 'CMake not found after {0} retries', cmakeNotFoundMaxRetries));
         }
         await this.configureExtensionInternal(ConfigureTrigger.configureOnOpen, project);
+    }
+
+    private async waitForDelayOrCmakePathChange(delay: number): Promise<void> {
+        return new Promise<void>(resolve => {
+            let settled = false;
+
+            const finish = () => {
+                if (settled) {
+                    return;
+                }
+                settled = true;
+                clearTimeout(timeout);
+                sub.dispose();
+                resolve();
+            };
+
+            const timeout = setTimeout(() => {
+                finish();
+            }, delay);
+
+            const sub = this.workspaceConfig.onChange('cmakePath', () => {
+                log.info(localize('cmake.configuration.change.detected', 'Detected change in CMake configuration while waiting for CMake to become available.'));
+                finish();
+            });
+        });
     }
 
     private async onDidChangeActiveTextEditor(editor: vscode.TextEditor | undefined): Promise<void> {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -67,12 +67,12 @@ export const hideBuildCommandKey = 'cmake:hideBuildCommand';
 
 /**
  * Friendly display names for known vendor extensions. Used to show a nicer
- * progress message (e.g., "Waiting for STM32 for VS Code..." instead of
+ * progress message (e.g., "Waiting for STM32Cube for VS Code..." instead of
  * "Waiting for stmicroelectronics.stm32-vscode-extension...").
  * Extensions not in this map fall back to their raw ID.
  */
 const vendorExtensionLabels: ReadonlyMap<string, string> = new Map([
-    ['stmicroelectronics.stm32-vscode-extension', 'STM32 for VS Code'],
+    ['stmicroelectronics.stm32-vscode-extension', 'STM32Cube for VS Code'],
     ['espressif.esp-idf-extension', 'ESP-IDF'],
     ['NXPSemiconductors.mcuxpresso', 'MCUXpresso'],
     ['nordic-semiconductor.nrf-connect', 'nRF Connect']


### PR DESCRIPTION
### This changes improve responsiveness to `cmake.cmakePath` configuration changes made by Vendors during the extension initialization phase

The following changes are proposed:

- subscribe to `onDidChangeConfiguration` in the wait loop in addition to `setTimeout`
- minor vendor friendly name update

