### PR TITLE
Fix token splitting for Windows backslashes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Improvements:
 - Improve responsiveness to CMake path changes made by vendor extensions during configure-on-open retry. [#4908](https://github.com/microsoft/vscode-cmake-tools/pull/4908) Contributed by STMicroelectronics
 
 Bug Fixes:
+- Fix Windows backslash handling in token splitting to preserve trailing backslashes before whitespace. This caused "Compile Active File" with MSVC + Ninja Multi-Config to merge adjacent flags (e.g., `/Fd<dir>\ /FS`) into a single malformed argument. [#4902](https://github.com/microsoft/vscode-cmake-tools/issues/4902)
 - Fix kit detection returning "unknown vendor" when using clang-cl compiler. [#4638](https://github.com/microsoft/vscode-cmake-tools/issues/4638)
 - Update testing framework to fix bugs when running tests of CMake Tools without a reliable internet connection. [#4891](https://github.com/microsoft/vscode-cmake-tools/pull/4891) [@cwalther](https://github.com/cwalther)
 

--- a/src/shlex.ts
+++ b/src/shlex.ts
@@ -52,6 +52,18 @@ export function* split(str: string, opt?: ShlexOptions): Iterable<string> {
                 // Windows mode: only backslash can be escaped
                 if (escapeChars.includes(char)) {
                     token.push(char);
+                } else if (!quoteChar && /[\t \r\f]/.test(char)) {
+                    // Backslash followed by whitespace outside quotes:
+                    // backslash is a literal character; whitespace must terminate the token.
+                    // Without this, e.g. "/Fd...\ /FS" would be merged into a single token
+                    // because the space would be consumed as part of the escape sequence,
+                    // causing cl.exe to receive a malformed PDB path and lose the next flag.
+                    // See https://github.com/microsoft/vscode-cmake-tools/issues/4902
+                    token.push(escapeChar);
+                    yield token.join('');
+                    token = [];
+                    escapeChar = undefined;
+                    continue;
                 } else {
                     token.push(escapeChar, char);
                 }

--- a/src/shlex.ts
+++ b/src/shlex.ts
@@ -53,12 +53,8 @@ export function* split(str: string, opt?: ShlexOptions): Iterable<string> {
                 if (escapeChars.includes(char)) {
                     token.push(char);
                 } else if (!quoteChar && /[\t \r\f]/.test(char)) {
-                    // Backslash followed by whitespace outside quotes:
-                    // backslash is a literal character; whitespace must terminate the token.
-                    // Without this, e.g. "/Fd...\ /FS" would be merged into a single token
-                    // because the space would be consumed as part of the escape sequence,
-                    // causing cl.exe to receive a malformed PDB path and lose the next flag.
-                    // See https://github.com/microsoft/vscode-cmake-tools/issues/4902
+                    // Backslash followed by whitespace outside quotes: backslash is literal,
+                    // whitespace terminates the token. See issue #4902.
                     token.push(escapeChar);
                     yield token.join('');
                     token = [];

--- a/test/unit-tests/backend/shlex.test.ts
+++ b/test/unit-tests/backend/shlex.test.ts
@@ -31,6 +31,40 @@ suite('shlex testing (backend)', () => {
             }
         });
 
+        test('Windows trailing backslash before space terminates token (issue #4902)', () => {
+            // Minimal case: backslash before space outside quotes is literal,
+            // and the space must still act as a delimiter.
+            expect(splitWin('foo\\ bar')).to.deep.equal(['foo\\', 'bar']);
+        });
+
+        test('Windows /Fd<dir>\\ /FS compile command (issue #4902)', () => {
+            // Reproduces the exact compile_commands.json shape that breaks
+            // "Compile Active File" with MSVC + Ninja Multi-Config when no
+            // COMPILE_PDB_NAME is set. CMake emits /Fd<dir>\ (trailing backslash)
+            // followed by /FS; cl.exe must receive these as two separate args.
+            const cmd = 'cl.exe /nologo /FdCMakeFiles\\INPUT_TESTS.dir\\RelWithDebInfo\\ /FS /c foo.cpp';
+            expect(splitWin(cmd)).to.deep.equal([
+                'cl.exe',
+                '/nologo',
+                '/FdCMakeFiles\\INPUT_TESTS.dir\\RelWithDebInfo\\',
+                '/FS',
+                '/c',
+                'foo.cpp'
+            ]);
+        });
+
+        test('Windows backslash runs before space (issue #4902 edge cases)', () => {
+            // Existing Windows-mode behavior collapses pairs of backslashes (\\ -> \),
+            // and a trailing odd backslash before whitespace is now preserved literally.
+            expect(splitWin('foo\\ bar')).to.deep.equal(['foo\\', 'bar']);   // 1 backslash
+            expect(splitWin('foo\\\\ bar')).to.deep.equal(['foo\\', 'bar']); // 2 -> collapses to 1, space delimits
+            expect(splitWin('foo\\\\\\ bar')).to.deep.equal(['foo\\\\', 'bar']); // 3 -> 1 (collapsed pair) + 1 literal trailing
+        });
+
+        test('Windows backslash before tab also terminates token', () => {
+            expect(splitWin('foo\\\tbar')).to.deep.equal(['foo\\', 'bar']);
+        });
+
         test('Windows mode: backslash only escapes backslash, not quotes', () => {
             // -DAWESOME=\"\\\"'fo o' bar\\\"\" should preserve all escapes
             const cmd = `-DAWESOME=\"\\\"'fo o' bar\\\"\"`;


### PR DESCRIPTION
This pull request addresses a bug in the Windows argument splitting logic that caused malformed compiler flags when a trailing backslash appeared before whitespace. The main fix ensures that such backslashes are treated as literal characters and that whitespace still acts as a token delimiter, preventing adjacent arguments from being merged incorrectly. The update also adds targeted unit tests to verify the new behavior. Fixes #4902 

**Bug Fixes and Parsing Improvements:**

* Updated the `split` function in `src/shlex.ts` to correctly handle a trailing backslash before whitespace on Windows, ensuring the backslash is preserved and the whitespace terminates the token. This resolves issues where arguments like `/Fd<dir>\ /FS` were incorrectly merged, causing build failures.

**Testing Enhancements:**

* Added unit tests in `test/unit-tests/backend/shlex.test.ts` to cover the fixed scenarios, including cases with a trailing backslash before space or tab, and several edge cases with multiple backslashes. These tests ensure robust handling of Windows argument splitting going forward.