### PR TITLE
Fix stale CMAKE_MAKE_PROGRAM when reloading CMake driver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Improvements:
 - Improve ergonomics of the test explorer UI by removing the project source directory, improving horizontal scrolling experience. [#4562](https://github.com/microsoft/vscode-cmake-tools/issues/4562) [@miss-programgamer](https://github.com/miss-programgamer)
 
 Bug Fixes:
+- Fix `CMAKE_MAKE_PROGRAM` and other cache variables using stale values when presets are edited without restarting VS Code. The `onCodeModelChanged` subscription is now established in `startNewCMakeDriver` so it applies to both initial creation and driver reloads. [#4864](https://github.com/microsoft/vscode-cmake-tools/issues/4864)
 - Fix Windows backslash handling in token splitting to preserve trailing backslashes before whitespace. This caused "Compile Active File" with MSVC + Ninja Multi-Config to merge adjacent flags (e.g., `/Fd<dir>\ /FS`) into a single malformed argument. [#4902](https://github.com/microsoft/vscode-cmake-tools/issues/4902)
 - Fix kit detection returning "unknown vendor" when using clang-cl compiler. [#4638](https://github.com/microsoft/vscode-cmake-tools/issues/4638)
 - Update testing framework to fix bugs when running tests of CMake Tools without a reliable internet connection. [#4891](https://github.com/microsoft/vscode-cmake-tools/pull/4891) [@cwalther](https://github.com/cwalther)

--- a/src/cmakeProject.ts
+++ b/src/cmakeProject.ts
@@ -1212,6 +1212,17 @@ export class CMakeProject {
         }
         this.cTestController.clearTests(drv);
 
+        // Subscribe to code model changes so that updated presets
+        // (e.g. a new CMAKE_MAKE_PROGRAM) are picked up immediately,
+        // regardless of whether the driver was created via
+        // getCMakeDriverInstance or reloadCMakeDriver.
+        if (this.codeModelDriverSub) {
+            this.codeModelDriverSub.dispose();
+        }
+        if (!(drv instanceof CMakeLegacyDriver)) {
+            this.codeModelDriverSub = drv.onCodeModelChanged(cm => this._codeModelContent.set(cm));
+        }
+
         // All set up. Fulfill the driver promise.
         return drv;
     }
@@ -1568,14 +1579,6 @@ export class CMakeProject {
                     return null;
                 }
 
-                if (this.codeModelDriverSub) {
-                    this.codeModelDriverSub.dispose();
-                }
-                const drv = await this.cmakeDriver;
-                console.assert(drv !== null, 'Null driver immediately after creation?');
-                if (drv && !(drv instanceof CMakeLegacyDriver)) {
-                    this.codeModelDriverSub = drv.onCodeModelChanged(cm => this._codeModelContent.set(cm));
-                }
             }
 
             return this.cmakeDriver;


### PR DESCRIPTION
 Problem
 
 When switching the CMake generator (e.g. to Ninja) and updating CMAKE_MAKE_PROGRAM in presets, CMake Tools still
 invokes CMake with the stale make program value. This causes configuration to fail because the wrong build tool is
 used (e.g. -DCMAKE_MAKE_PROGRAM=make -G Ninja). A VS Code restart was required as a workaround.
 
 Root Cause
 
 getCMakeDriverInstance subscribes to drv.onCodeModelChanged, but reloadCMakeDriver — which is called when presets
 change — also creates a new driver via startNewCMakeDriver without re-subscribing to onCodeModelChanged. This means
 code model updates (including preset changes) are silently dropped.
 
 Fix
 
 Move the onCodeModelChanged event subscription from getCMakeDriverInstance into startNewCMakeDriver, so the
 subscription is always established regardless of which code path creates the driver.
 
 Fixes #4864 Problem
 
 When switching the CMake generator (e.g. to Ninja) and updating CMAKE_MAKE_PROGRAM in presets, CMake Tools still
 invokes CMake with the stale make program value. This causes configuration to fail because the wrong build tool is
 used (e.g. -DCMAKE_MAKE_PROGRAM=make -G Ninja). A VS Code restart was required as a workaround.
 
 Root Cause
 
 getCMakeDriverInstance subscribes to drv.onCodeModelChanged, but reloadCMakeDriver — which is called when presets
 change — also creates a new driver via startNewCMakeDriver without re-subscribing to onCodeModelChanged. This means
 code model updates (including preset changes) are silently dropped.
 
 Fix
 
 Move the onCodeModelChanged event subscription from getCMakeDriverInstance into startNewCMakeDriver, so the
 subscription is always established regardless of which code path creates the driver.
 
 Fixes #4864