### PR TITLE
Fix single test running all tests in multi-project workspace

### DIFF
--- a/src/ctest.ts
+++ b/src/ctest.ts
@@ -532,7 +532,7 @@ export class CTestDriver implements vscode.Disposable {
         const ctestArgs = await this.getCTestArgs(driver, customizedTask, testPreset) || [];
         if (testsToRun && testsToRun.length > 0) {
             ctestArgs.push("-R");
-            const superset = this.getTestNames() || [];
+            const superset = this.getTestNamesForSourceDir(driver.sourceDir) || [];
             const testsNamesRegex = getMinimalRegexFragments(superset, testsToRun).join('|');
             ctestArgs.push(testsNamesRegex);
         }
@@ -706,7 +706,7 @@ export class CTestDriver implements vscode.Disposable {
 
                     run.started(test);
 
-                    const superset = this.getTestNames() || [];
+                    const superset = this.getTestNamesForSourceDir(driver.driver.sourceDir) || [];
                     const _ctestArgs = driver.ctestArgs.concat('-R', getMinimalRegexFragments(superset, [test.id]).join('|'));
 
                     const testResults = await this.runCTestImpl(driver.driver, driver.ctestPath, _ctestArgs, cancellation, customizedTask, consumer);
@@ -746,7 +746,8 @@ export class CTestDriver implements vscode.Disposable {
                 // In this case, we should specifically use the -R flag to select the exact tests.
                 // Otherwise, we can leave it to the -T flag to run all tests.
                 let targetTests: vscode.TestItem[] | undefined;
-                if (entryPoint === RunCTestHelperEntryPoint.TestExplorer && testExplorer && this._tests && this._tests.tests.length !== driver.tests.length) {
+                const allTestNamesForDriver = this.getTestNamesForSourceDir(uniqueDriver.sourceDir);
+                if (entryPoint === RunCTestHelperEntryPoint.TestExplorer && testExplorer && allTestNamesForDriver && allTestNamesForDriver.length !== driver.tests.length) {
                     targetTests = driver.tests;
                 } else if (testsToRun && testsToRun.length > 0) {
                     targetTests = driver.tests.filter(t => testsToRun.includes(t.id));
@@ -754,7 +755,7 @@ export class CTestDriver implements vscode.Disposable {
 
                 if (targetTests) {
                     uniqueCtestArgs.push("-R");
-                    const superset = this.getTestNames() || [];
+                    const superset = allTestNamesForDriver || [];
                     const targets = targetTests.map(t => {
                         run.started(t);
                         return t.id;
@@ -1194,6 +1195,32 @@ export class CTestDriver implements vscode.Disposable {
         }
 
         return undefined;
+    }
+
+    /**
+     * Returns all leaf test names for a specific project (sourceDir) from the test explorer tree.
+     * In multi-project workspaces, this ensures the superset used for regex computation
+     * contains only tests belonging to the correct project, avoiding overly broad matches.
+     */
+    private getTestNamesForSourceDir(sourceDir: string): string[] | undefined {
+        if (!testExplorer) {
+            return this.getTestNames();
+        }
+        const normalizedSourceDir = util.platformNormalizePath(sourceDir);
+        const projectRoot = testExplorer.items.get(normalizedSourceDir);
+        if (!projectRoot) {
+            return this.getTestNames();
+        }
+        const names: string[] = [];
+        const collectLeafNames = (item: vscode.TestItem) => {
+            if (item.children.size === 0) {
+                names.push(item.id);
+            } else {
+                item.children.forEach(child => collectLeafNames(child));
+            }
+        };
+        projectRoot.children.forEach(child => collectLeafNames(child));
+        return names.length > 0 ? names : this.getTestNames();
     }
 
     /**


### PR DESCRIPTION
 ## Problem

  In multi-project workspaces, clicking "Run" on a single test in the Test Explorer runs all tests for that project
  instead of just the selected test.

  The CTest command shows -R ^project2 (matching all project2 tests) instead of -R ^project2_test_case_1$ (matching
  only the selected test).

  Fixes #4911

  ## Root Cause

  The CTestDriver class stores test information in a shared _tests field that gets overwritten by whichever project
  was last refreshed. When computing the regex filter for test selection, getTestNames() returns this shared field as
  the "superset" for getMinimalRegexFragments(superset, targets).

  In a multi-project workspace, the superset contains tests from the wrong project. Since none of the wrong project's
  tests share a prefix with the target test, the regex algorithm produces an overly broad match (e.g., ^project2)
  instead of an exact one (e.g., ^project2_test_case_1$).

  ##Fix

  Added getTestNamesForSourceDir(sourceDir) which retrieves test names directly from the Test Explorer tree for a
  specific project, ensuring the superset used for regex computation contains only tests belonging to the correct
  project.

  ##Updated all three affected call sites:

   - runCTestDirectly — direct CTest execution path
   - runCTestHelper (non-parallel) — sequential test execution
   - runCTestHelper (parallel) — parallel test execution, including fixing the subset detection comparison to use the
  correct per-project test count

  The method falls back to the existing getTestNames() behavior when the Test Explorer is unavailable (e.g.,
  single-project workspaces or direct command invocations), maintaining backward compatibility.

## Validation
**Before**
<img width="1057" height="851" alt="image" src="https://github.com/user-attachments/assets/80d53969-c43c-43ab-a2df-043f37b4732e" />

**After**
<img width="1106" height="987" alt="image" src="https://github.com/user-attachments/assets/96e8b117-c625-4a1f-9c02-eedfea7f929c" />
