### PR TITLE
Fix pretest-buildfakebin on Windows

### DIFF
--- a/.github/workflows/ci-main-linux.yml
+++ b/.github/workflows/ci-main-linux.yml
@@ -40,11 +40,7 @@ jobs:
             ninjaVersion: 1.10.1
 
       - name: Build fake compilers for tests
-        uses: urkle/action-cmake-build@v1.0.0
-        with:
-          source-dir: ${{ github.workspace }}/test/fakeOutputGenerator
-          configure-options: -DCMAKE_INSTALL_PREFIX:STRING=${{ github.workspace }}/test/fakebin
-          install-build: true
+        run: yarn pretest-buildfakebin
 
       - name: Run backend tests
         run: yarn backendTests

--- a/.github/workflows/ci-main-mac.yml
+++ b/.github/workflows/ci-main-mac.yml
@@ -56,11 +56,7 @@ jobs:
           sudo rm -f /opt/homebrew/bin/ctest
 
       - name: Build fake compilers for tests
-        uses: urkle/action-cmake-build@v1.0.0
-        with:
-          source-dir: ${{ github.workspace }}/test/fakeOutputGenerator
-          configure-options: -DCMAKE_INSTALL_PREFIX:STRING=${{ github.workspace }}/test/fakebin
-          install-build: true
+        run: yarn pretest-buildfakebin
 
       - name: Run successful-build test
         run: yarn endToEndTestsSuccessfulBuild

--- a/.github/workflows/ci-main.win.yml
+++ b/.github/workflows/ci-main.win.yml
@@ -42,11 +42,7 @@ jobs:
             ninjaVersion: 1.10.1
 
       - name: Build fake compilers for tests
-        uses: urkle/action-cmake-build@v1.0.0
-        with:
-          source-dir: ${{ github.workspace }}/test/fakeOutputGenerator
-          configure-options: -DCMAKE_INSTALL_PREFIX:STRING=${{ github.workspace }}/test/fakebin
-          install-build: true
+        run: yarn pretest-buildfakebin
 
       - name: Run backend tests
         run: yarn backendTests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Bug Fixes:
 - Fix Windows backslash handling in token splitting to preserve trailing backslashes before whitespace. This caused "Compile Active File" with MSVC + Ninja Multi-Config to merge adjacent flags (e.g., `/Fd<dir>\ /FS`) into a single malformed argument. [#4902](https://github.com/microsoft/vscode-cmake-tools/issues/4902)
 - Fix kit detection returning "unknown vendor" when using clang-cl compiler. [#4638](https://github.com/microsoft/vscode-cmake-tools/issues/4638)
 - Update testing framework to fix bugs when running tests of CMake Tools without a reliable internet connection. [#4891](https://github.com/microsoft/vscode-cmake-tools/pull/4891) [@cwalther](https://github.com/cwalther)
+- Fix “Make it easier for a new developer of CMake Tools to run tests” on Windows. [#4932](https://github.com/microsoft/vscode-cmake-tools/pull/4932) [@cwalther](https://github.com/cwalther)
 
 ## 1.23.52
 

--- a/package.json
+++ b/package.json
@@ -4436,7 +4436,7 @@
     "translations-import": "gulp translations-import",
     "package": "vsce package --yarn -o cmake-tools.vsix",
     "pretest": "tsc -p test.tsconfig.json",
-    "pretest-buildfakebin": "cmake -DCMAKE_INSTALL_PREFIX=test/fakebin -DCMAKE_BUILD_TYPE=Release -S test/fakeOutputGenerator -B test/fakeOutputGenerator/build && cmake --build test/fakeOutputGenerator/build && cmake --install test/fakeOutputGenerator/build && cmake -E rm -rf test/fakeOutputGenerator/build",
+    "pretest-buildfakebin": "cmake -DCMAKE_INSTALL_PREFIX=test/fakebin -DCMAKE_BUILD_TYPE=Release -S test/fakeOutputGenerator -B test/fakeOutputGenerator/build && cmake --build test/fakeOutputGenerator/build --config Release && cmake --install test/fakeOutputGenerator/build --config Release && cmake -E rm -rf test/fakeOutputGenerator/build",
     "lint": "gulp lint",
     "smokeTests": "yarn run pretest && node ./out/test/smoke/badProject/runTest.js && node ./out/test/smoke/goodProject/runTest.js && node ./out/test/smoke/noCtest/runTest.js",
     "unitTests": "yarn run pretest && node ./out/test/unit-tests/runTest.js",


### PR DESCRIPTION
## This change is an amendment to item #4620

### This changes the developer experience (but not the user experience)

The following changes are proposed:

- Add `--config` arguments to make `yarn pretest-buildfakebin` work with multi-config generators.
- Use it in CI.

## The purpose of this change

While working on https://github.com/microsoft/vscode-cmake-tools/pull/4627#issuecomment-4380175931, I noticed that the `yarn pretest-buildfakebin` command that I had recently introduced in #4620 did not work on Windows, because it wasn’t prepared for multi-config generators such as the _Visual Studio_ used by default on Windows (I had only tested on Linux, where I think single-config _Unix Makefiles_ is used).

The attached commit fixes that, and to make sure it stays fixed, changes the CI jobs to use that command instead of a dedicated CMake build action. That also reduces some duplication (because those jobs were where I copied the procedure from to begin with).

## Other Notes/Information

By the way, just out of curiosity, I tested this with different CMake versions at https://github.com/indel-ag/vscode-cmake-tools/actions?query=branch%3Abuildfakebin-test – the original 3.18.3/3.31.6 (of which the former skips my new tests from #4627), 3.31.12, and the latest 4.3.2. Just so you know that works in case you ever want to update these versions.