### PR TITLE
Fix VS dev env auto-detection for Ninja presets on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Improvements:
 - Pass mandatory compiler arguments from `CMAKE_<LANG>_COMPILER` to cpptools so it can properly determine system include paths and built-in preprocessor macro definitions. Requires CMake 4.3 or newer. [#4627](https://github.com/microsoft/vscode-cmake-tools/pull/4627) [@cwalther](https://github.com/cwalther)
 
 Bug Fixes:
+- Fix Windows presets auto-detection so Ninja configure presets without explicit compiler cache variables can still bootstrap the Visual Studio developer environment when appropriate.
 - Fix `CMAKE_MAKE_PROGRAM` and other cache variables using stale values when presets are edited without restarting VS Code. The `onCodeModelChanged` subscription is now established in `startNewCMakeDriver` so it applies to both initial creation and driver reloads. [#4864](https://github.com/microsoft/vscode-cmake-tools/issues/4864)
 - Fix Windows backslash handling in token splitting to preserve trailing backslashes before whitespace. This caused "Compile Active File" with MSVC + Ninja Multi-Config to merge adjacent flags (e.g., `/Fd<dir>\ /FS`) into a single malformed argument. [#4902](https://github.com/microsoft/vscode-cmake-tools/issues/4902)
 - Fix kit detection returning "unknown vendor" when using clang-cl compiler. [#4638](https://github.com/microsoft/vscode-cmake-tools/issues/4638)

--- a/src/presets/preset.ts
+++ b/src/presets/preset.ts
@@ -861,6 +861,11 @@ export interface VsDevEnvOptions {
     compilerName?: string; // Only will have a value when `useVsDeveloperEnvironmentMode` is "auto"
 }
 
+export interface VsDevEnvAutoDetectionInfo {
+    compilerName?: string;
+    generatorIsNinja: boolean;
+}
+
 /**
  * @param opts Options to control the behavior of obtaining the VS developer environment.
  * @returns Either the VS developer environment or undefined if it could not be obtained.
@@ -961,6 +966,23 @@ async function getVsDevEnv(opts: VsDevEnvOptions): Promise<EnvironmentWithNull |
     }
 }
 
+export function getVsDevEnvAutoDetectionInfo(preset: ConfigurePreset): VsDevEnvAutoDetectionInfo {
+    const cxxCompilerValue = getStringValueFromCacheVar(preset.cacheVariables?.['CMAKE_CXX_COMPILER']);
+    const cCompilerValue = getStringValueFromCacheVar(preset.cacheVariables?.['CMAKE_C_COMPILER']);
+    const cxxCompiler = cxxCompilerValue?.toLowerCase();
+    const cCompiler = cCompilerValue?.toLowerCase();
+    const explicitCompilerName = util.isSupportedCompiler(cxxCompiler) || util.isSupportedCompiler(cCompiler);
+    const hasExplicitCompiler = cxxCompilerValue !== null || cCompilerValue !== null;
+    const generatorIsNinja = preset.generator?.toLowerCase().includes("ninja") ?? false;
+
+    return {
+        // For a Ninja preset with no explicit compiler, probe for cl so auto mode can
+        // bootstrap the VS developer environment on Windows.
+        compilerName: explicitCompilerName || (!hasExplicitCompiler && generatorIsNinja ? 'cl' : undefined),
+        generatorIsNinja
+    };
+}
+
 /**
  * This method tries to apply, based on the useVsDeveloperEnvironment setting value and, in "auto" mode, whether certain preset compilers/generators are used and not found, the VS Dev Env.
  * @param preset Preset to modify the parentEnvironment of. If the developer environment should be applied, the preset.environment is modified by reference.
@@ -979,12 +1001,8 @@ export async function tryApplyVsDevEnv(preset: ConfigurePreset, workspaceFolder:
     // [Windows Only] We only support VS Dev Env on Windows.
     if (!preset.__parentEnvironment && process.platform === "win32") {
         if (useVsDeveloperEnvironmentMode === "auto") {
-            if (preset.cacheVariables) {
-                const cxxCompiler = getStringValueFromCacheVar(preset.cacheVariables['CMAKE_CXX_COMPILER'])?.toLowerCase();
-                const cCompiler = getStringValueFromCacheVar(preset.cacheVariables['CMAKE_C_COMPILER'])?.toLowerCase();
-                // The env variables for the supported compilers are the same.
-                const compilerName: string | undefined = util.isSupportedCompiler(cxxCompiler) || util.isSupportedCompiler(cCompiler);
-
+            const { compilerName, generatorIsNinja } = getVsDevEnvAutoDetectionInfo(preset);
+            if (compilerName || generatorIsNinja) {
                 // find where.exe using process.env since we're on windows.
                 let whereExecutable;
                 // assume in this call that it exists
@@ -1004,7 +1022,7 @@ export async function tryApplyVsDevEnv(preset: ConfigurePreset, workspaceFolder:
                     }
                 }
 
-                if (compilerName && whereExecutable) {
+                if (whereExecutable) {
                     // We need to construct and temporarily expand the environment in order to accurately determine if this preset has the compiler / ninja on PATH.
                     // This puts the preset.environment on top of process.env, then expands with process.env as the penv and preset.environment as the envOverride
                     const env = EnvironmentUtils.mergePreserveNull([process.env, preset.environment]);
@@ -1019,25 +1037,24 @@ export async function tryApplyVsDevEnv(preset: ConfigurePreset, workspaceFolder:
                         }
                     }
 
-                    const compilerLocation = await execute(whereExecutable, [compilerName], null, {
+                    const compilerLocation = compilerName ? await execute(whereExecutable, [compilerName], null, {
                         environment: EnvironmentUtils.create(presetEnv),
                         silent: true,
                         encoding: 'utf8',
                         shell: true
-                    }).result;
+                    }).result : undefined;
 
                     // if ninja isn't on path, try to look for it in a VS install
-                    const ninjaLoc = await execute(whereExecutable, ['ninja'], null, {
+                    const ninjaLoc = generatorIsNinja ? await execute(whereExecutable, ['ninja'], null, {
                         environment: EnvironmentUtils.create(presetEnv),
                         silent: true,
                         encoding: 'utf8',
                         shell: true
-                    }).result;
+                    }).result : undefined;
 
-                    const generatorIsNinja = preset.generator?.toLowerCase().includes("ninja");
-                    const shouldInterrogateForNinja = (generatorIsNinja ?? false) && !ninjaLoc.stdout;
+                    const shouldInterrogateForNinja = generatorIsNinja && !ninjaLoc?.stdout;
 
-                    if (!compilerLocation.stdout || shouldInterrogateForNinja) {
+                    if ((compilerName && !compilerLocation?.stdout) || shouldInterrogateForNinja) {
                         developerEnvironment = await getVsDevEnv({
                             preset,
                             shouldInterrogateForNinja,

--- a/test/unit-tests/presets/presets.test.ts
+++ b/test/unit-tests/presets/presets.test.ts
@@ -1,4 +1,4 @@
-import { buildArgs, Condition, configureArgs, evaluateCondition, getArchitecture, getToolset } from '@cmt/presets/preset';
+import { buildArgs, Condition, configureArgs, evaluateCondition, getArchitecture, getToolset, getVsDevEnvAutoDetectionInfo } from '@cmt/presets/preset';
 import { expect } from '@test/util';
 import * as os from "os";
 
@@ -273,5 +273,41 @@ suite('Preset tests', () => {
         const args = buildArgs(preset, undefined, undefined, 0);
         expect(args).to.include('-j');
         expect(args).to.not.include('--parallel');
+    });
+
+    test('VS dev env auto-detection probes cl for Ninja presets without explicit compilers', () => {
+        const autoDetection = getVsDevEnvAutoDetectionInfo({
+            name: 'test',
+            generator: 'Ninja'
+        });
+
+        expect(autoDetection.compilerName).to.eq('cl');
+        expect(autoDetection.generatorIsNinja).to.eq(true);
+    });
+
+    test('VS dev env auto-detection preserves explicit supported compilers', () => {
+        const autoDetection = getVsDevEnvAutoDetectionInfo({
+            name: 'test',
+            generator: 'Ninja',
+            cacheVariables: {
+                CMAKE_CXX_COMPILER: 'clang-cl.exe'
+            }
+        });
+
+        expect(autoDetection.compilerName).to.eq('clang-cl');
+        expect(autoDetection.generatorIsNinja).to.eq(true);
+    });
+
+    test('VS dev env auto-detection does not override explicit unsupported compilers', () => {
+        const autoDetection = getVsDevEnvAutoDetectionInfo({
+            name: 'test',
+            generator: 'Ninja',
+            cacheVariables: {
+                CMAKE_C_COMPILER: 'gcc'
+            }
+        });
+
+        expect(autoDetection.compilerName).to.eq(undefined);
+        expect(autoDetection.generatorIsNinja).to.eq(true);
     });
 });


### PR DESCRIPTION
Allow Windows configure presets that use Ninja to probe the Visual Studio developer environment even when CMAKE_C_COMPILER/CMAKE_CXX_COMPILER are not explicitly set.

Add unit tests covering Ninja presets without explicit compilers and update the changelog.

This fix issue #4937

<!-- Thanks for your contribution! To make things easier, please fill out the template below. -->

<!-- Please delete any unused sections. -->

<!-- Delete the following heading if there is no corresponding issue -->
## This change addresses item #[[put issue number here to generate a link]]

### This changes [[visible behavior/performance/documentation/etc.]]

The following changes are proposed:

- <!-- Put something here -->
- <!-- And maybe here -->
- <!-- Add or remove bullets as you need -->

## The purpose of this change

<!-- If not linked to an issue, describe the purpose of this change. Otherwise,
delete this section. -->

## Other Notes/Information

<!-- Write whatever you feel is relevant -->
