### PR TITLE
Update Pipeline Images

### DIFF
--- a/jobs/cg.yml
+++ b/jobs/cg.yml
@@ -35,12 +35,12 @@ extends:
   parameters:
     pool:
       name: AzurePipelines-EO
-      image: 1ESPT-Windows2024
+      image: 1ESPT-Windows2025
       os: windows
     sdl:
       sourceAnalysisPool: 
         name: AzurePipelines-EO
-        image: 1ESPT-Windows2024
+        image: 1ESPT-Windows2025
         os: windows
       tsa:
         enabled: true

--- a/jobs/languageSupport/sharedCode.yml
+++ b/jobs/languageSupport/sharedCode.yml
@@ -32,7 +32,7 @@ pr: none
 pool: 
   name: "AzurePipelines-EO"
   demands:
-    - ImageOverride -equals 1ESPT-Windows2022
+    - ImageOverride -equals 1ESPT-Windows2025
 
 name: $(Date:yyMMdd)$(Rev:rrr)
 

--- a/jobs/loc/TranslationsImportExport.yml
+++ b/jobs/loc/TranslationsImportExport.yml
@@ -31,12 +31,12 @@ extends:
   parameters:
     pool:
       name: AzurePipelines-EO
-      image: 1ESPT-Windows2022
+      image: 1ESPT-Windows2025
       os: windows
     sdl:
       sourceAnalysisPool: 
         name: AzurePipelines-EO
-        image: 1ESPT-Windows2022
+        image: 1ESPT-Windows2025
         os: windows
     customBuildTags:
     - ES365AIMigrationTooling


### PR DESCRIPTION
This pull request updates the build and analysis pipeline configurations to use the newer Windows 2025 image across several job definitions. This ensures consistency in the build environment and prepares the pipelines for compatibility with the latest Windows platform.