### PR TITLE
update node.js version to 22.x in CI pipelines

### DIFF
--- a/jobs/cg.yml
+++ b/jobs/cg.yml
@@ -73,9 +73,9 @@ extends:
           fetchTags: false
 
         - task: UseNode@1
-          displayName: "Use Node 20.x"
+          displayName: "Use Node 22.x"
           inputs:
-            version: "20.x"
+            version: "22.x"
         
         - task: geeklearningio.gl-vsts-tasks-yarn.yarn-installer-task.YarnInstaller@3
           displayName: Use Yarn 1.x

--- a/jobs/languageSupport/sharedCode.yml
+++ b/jobs/languageSupport/sharedCode.yml
@@ -44,9 +44,9 @@ jobs:
     - checkout: self
     - checkout: VS-Platform
     - task: UseNode@1
-      displayName: "Use Node 20.x"
+      displayName: "Use Node 22.x"
       inputs:
-        version: "20.x"
+        version: "22.x"
     - script: npm install
       displayName: "npm install"
       workingDirectory: $(Build.SourcesDirectory)/vscode-cmake-tools/tools/pr-creator

--- a/jobs/loc/TranslationsImportExport.yml
+++ b/jobs/loc/TranslationsImportExport.yml
@@ -52,9 +52,9 @@ extends:
             publishLocation: 'Container'
         steps:
         - task: UseNode@1
-          displayName: "Use Node 20.x"
+          displayName: "Use Node 22.x"
           inputs:
-            version: "20.x"
+            version: "22.x"
 
         - task: CmdLine@2
           inputs:

--- a/jobs/release/prerelease.yml
+++ b/jobs/release/prerelease.yml
@@ -45,9 +45,9 @@ extends:
           ignoreLASTEXITCODE: true
           displayName: 'Set the release name'
         - task: NodeTool@0
-          displayName: 'Use Node 20.x'
+          displayName: 'Use Node 22.x'
           inputs:
-            versionSpec: 20.x
+            versionSpec: 22.x
         - script: npm install -g @vscode/vsce
           displayName: 'install vsce'
         - task: AzureCLI@2

--- a/jobs/release/release.yml
+++ b/jobs/release/release.yml
@@ -69,9 +69,9 @@ extends:
 
         steps:
         - task: NodeTool@0
-          displayName: 'Use Node 20.x'
+          displayName: 'Use Node 22.x'
           inputs:
-            versionSpec: 20.x
+            versionSpec: 22.x
         - script: npm install -g @vscode/vsce
           displayName: 'install vsce'
         - task: AzureCLI@2

--- a/jobs/shared/build.yml
+++ b/jobs/shared/build.yml
@@ -10,9 +10,9 @@ parameters:
 
 steps:
 - task: NodeTool@0
-  displayName: Use Node 20.x
+  displayName: Use Node 22.x
   inputs:
-    versionSpec: 20.x
+    versionSpec: 22.x
 - task: geeklearningio.gl-vsts-tasks-yarn.yarn-installer-task.YarnInstaller@3
   displayName: Use Yarn 1.x
 - task: CmdLine@2


### PR DESCRIPTION
This pull request updates the Node.js version used across multiple CI/CD pipeline YAML files from Node 20.x to Node 22.x. This ensures that all build, test, and release jobs are using the latest LTS version of Node.js, which can provide improved performance, security, and compatibility with modern dependencies.

**CI/CD Pipeline Node.js Version Updates:**

* Updated Node.js version from 20.x to 22.x in the following pipeline files:
  - `jobs/cg.yml` (`UseNode@1` task)
  - `jobs/languageSupport/sharedCode.yml` (`UseNode@1` task)
  - `jobs/loc/TranslationsImportExport.yml` (`UseNode@1` task)
  - `jobs/release/prerelease.yml` (`NodeTool@0` task)
  - `jobs/release/release.yml` (`NodeTool@0` task)
  - `jobs/shared/build.yml` (`NodeTool@0` task)