### PR TITLE
add network isolation policy settings to multiple pipeline conf…

### DIFF
--- a/jobs/cg.yml
+++ b/jobs/cg.yml
@@ -63,6 +63,8 @@ extends:
         exclusionsFile: $(Build.SourcesDirectory)\jobs\policheckExclusions.xml
     customBuildTags:
     - ES365AIMigrationTooling
+    settings:
+      networkIsolationPolicy: Permissive,CFSClean,CFSClean2,CFSClean3
     stages:
     - stage: stage
       jobs:

--- a/jobs/loc/TranslationsImportExport.yml
+++ b/jobs/loc/TranslationsImportExport.yml
@@ -40,6 +40,8 @@ extends:
         os: windows
     customBuildTags:
     - ES365AIMigrationTooling
+    settings:
+      networkIsolationPolicy: Permissive,CFSClean,CFSClean2,CFSClean3
     stages:
     - stage: stage
       jobs:

--- a/jobs/prerelease.yml
+++ b/jobs/prerelease.yml
@@ -41,6 +41,8 @@ extends:
         name: VSEng-MicroBuildVSStable
     customBuildTags:
     - ES365AIMigrationTooling
+    settings:
+      networkIsolationPolicy: Permissive,CFSClean,CFSClean2,CFSClean3
 
     stages:
     - stage: verify_parameters

--- a/jobs/release.yml
+++ b/jobs/release.yml
@@ -61,6 +61,8 @@ extends:
         name: VSEng-MicroBuildVSStable
     customBuildTags:
     - ES365AIMigrationTooling
+    settings:
+      networkIsolationPolicy: Permissive,CFSClean,CFSClean2,CFSClean3
     stages:
     - stage: verify_parameters
       jobs:

--- a/jobs/release/prerelease.yml
+++ b/jobs/release/prerelease.yml
@@ -21,6 +21,8 @@ extends:
   parameters:
     pool:
       name: VSEng-MicroBuildVSStable
+    settings:
+      networkIsolationPolicy: Permissive,CFSClean,CFSClean2,CFSClean3
 
     stages:
     - stage: release

--- a/jobs/release/release.yml
+++ b/jobs/release/release.yml
@@ -21,6 +21,8 @@ extends:
   parameters:
     pool:
       name: VSEng-MicroBuildVSStable
+    settings:
+      networkIsolationPolicy: Permissive,CFSClean,CFSClean2,CFSClean3
 
     stages:
     - stage: Validate

--- a/jobs/shared/build.yml
+++ b/jobs/shared/build.yml
@@ -47,7 +47,7 @@ steps:
     script: |
       if "${{parameters.IsPreRelease}}"=="1" (type nul > "insiders.flag") else (type nul > "release.flag")
 - template: /jobs/shared/install-nuget.yml@self
-- script: nuget restore $(Build.SourcesDirectory)\jobs\signing\SignFiles.proj -PackagesDirectory $(Build.SourcesDirectory)\jobs\signing\packages
+- script: nuget restore $(Build.SourcesDirectory)\jobs\signing\SignFiles.proj -PackagesDirectory $(Build.SourcesDirectory)\jobs\signing\packages -ConfigFile $(Build.SourcesDirectory)\jobs\signing\NuGet.config
   displayName: Restore MicroBuild Core
 - task: CmdLine@2
   displayName: Build files

--- a/jobs/signing/NuGet.config
+++ b/jobs/signing/NuGet.config
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="Engineering" value="https://pkgs.dev.azure.com/devdiv/_packaging/MicroBuildToolset/nuget/v3/index.json" />
+  </packageSources>
+</configuration>


### PR DESCRIPTION
This pull request introduces updates to several pipeline YAML files to improve network isolation policy settings and NuGet package restoration reliability. The main changes are the addition of a specific network isolation policy across multiple job definitions and the introduction of a custom NuGet configuration for package restore during the build process.

Pipeline configuration improvements:

* Added a `settings` block with `networkIsolationPolicy: Permissive,CFSClean,CFSClean2,CFSClean3` to the pool configuration in several pipeline files, including `jobs/cg.yml`, `jobs/loc/TranslationsImportExport.yml`, `jobs/prerelease.yml`, `jobs/release.yml`, `jobs/release/prerelease.yml`, and `jobs/release/release.yml`. This standardizes network isolation policies across different build and release pipelines. [[1]](diffhunk://#diff-0ff0dd0c12c1d783f6fa6eb00cd7f378a8bd52e05345189b6e9993470561e427R66-R67) [[2]](diffhunk://#diff-7d5a58aa9e66d6e547c4a5720ea419b80e5ab10499b27d43b9a3ba6f43622fbbR43-R44) [[3]](diffhunk://#diff-e7239a2f6b9a7678d729e5a461a9b585101009f294c1e641bd5b154e16ca28a4R44-R45) [[4]](diffhunk://#diff-8181cd3f960dcc22220250509cb13b8dd9fb0ad180bd92c78c35d8cd5c127c51R64-R65) [[5]](diffhunk://#diff-7b7c10c627921eaeb34e884afad4dd4b7707c9ef1ff15f9451a7af483c9b27dbR24-R25) [[6]](diffhunk://#diff-00a52e9268325fd97bdcd98dd8eeff56e4891b2a83b90d593dfe7dbc14ff3b07R24-R25)

Build reliability enhancements:

* Updated the NuGet restore command in `jobs/shared/build.yml` to use a custom NuGet configuration file (`NuGet.config`), ensuring consistent package source usage during builds.
* Added a new `jobs/signing/NuGet.config` file specifying the `Engineering` package source for MicroBuildToolset, supporting the updated restore command.