### PR TITLE
replace Yarn installer task with npm script for consistency across pipelines

### DIFF
--- a/jobs/cg.yml
+++ b/jobs/cg.yml
@@ -79,8 +79,8 @@ extends:
           inputs:
             version: "22.x"
         
-        - task: geeklearningio.gl-vsts-tasks-yarn.yarn-installer-task.YarnInstaller@3
-          displayName: Use Yarn 1.x
+        - script: npm install -g yarn@1.22.19
+          displayName: Use Yarn 1.x (from CFS feed)
         
         - script: npm install -g @vscode/vsce
           displayName: 'install vsce'

--- a/jobs/loc/TranslationsImportExport.yml
+++ b/jobs/loc/TranslationsImportExport.yml
@@ -58,6 +58,9 @@ extends:
           inputs:
             version: "22.x"
 
+        - script: npm install -g yarn@1.22.19
+          displayName: Use Yarn 1.x (from CFS feed)
+
         - task: CmdLine@2
           inputs:
             script: 'yarn install'

--- a/jobs/release/prerelease.yml
+++ b/jobs/release/prerelease.yml
@@ -52,6 +52,8 @@ extends:
             versionSpec: 22.x
         - script: npm install -g @vscode/vsce
           displayName: 'install vsce'
+          env:
+            npm_config_registry: https://pkgs.dev.azure.com/azure-public/VisualCpp/_packaging/cpp_PublicPackages/npm/registry/
         - task: AzureCLI@2
           displayName: 'Generate AAD_TOKEN'
           inputs:

--- a/jobs/release/release.yml
+++ b/jobs/release/release.yml
@@ -76,6 +76,8 @@ extends:
             versionSpec: 22.x
         - script: npm install -g @vscode/vsce
           displayName: 'install vsce'
+          env:
+            npm_config_registry: https://pkgs.dev.azure.com/azure-public/VisualCpp/_packaging/cpp_PublicPackages/npm/registry/
         - task: AzureCLI@2
           displayName: 'Generate AAD_TOKEN'
           inputs:

--- a/jobs/shared/build.yml
+++ b/jobs/shared/build.yml
@@ -13,8 +13,8 @@ steps:
   displayName: Use Node 22.x
   inputs:
     versionSpec: 22.x
-- task: geeklearningio.gl-vsts-tasks-yarn.yarn-installer-task.YarnInstaller@3
-  displayName: Use Yarn 1.x
+- script: npm install -g yarn@1.22.19
+  displayName: Use Yarn 1.x (from CFS feed)
 - task: CmdLine@2
   displayName: IF EXIST %SYSTEMDRIVE%\Users\%USERNAME%\.npmrc del %SYSTEMDRIVE%\Users\%USERNAME%\.npmrc
   inputs:


### PR DESCRIPTION
This pull request updates several CI/CD pipeline YAML files to improve how Yarn and VSCE are installed, standardizing installation methods and ensuring the correct registry is used for certain npm packages. The main changes involve replacing a deprecated Yarn installer task with a direct npm install command and setting the npm registry environment variable for VSCE installation