### PR TITLE
route all CI npm/yarn/vsce installs through the CFS feed under network isolation

### DIFF
--- a/jobs/cg.yml
+++ b/jobs/cg.yml
@@ -81,15 +81,21 @@ extends:
         
         - script: npm install -g yarn@1.22.19
           displayName: Use Yarn 1.x (from CFS feed)
+          env:
+            npm_config_registry: https://pkgs.dev.azure.com/azure-public/VisualCpp/_packaging/cpp_PublicPackages/npm/registry/
         
         - script: npm install -g @vscode/vsce
           displayName: 'install vsce'
+          env:
+            npm_config_registry: https://pkgs.dev.azure.com/azure-public/VisualCpp/_packaging/cpp_PublicPackages/npm/registry/
 
         - task: CmdLine@2
           displayName: Build files
           inputs:
             script: |
               yarn compile-production
+          env:
+            npm_config_registry: https://pkgs.dev.azure.com/azure-public/VisualCpp/_packaging/cpp_PublicPackages/npm/registry/
         
         - task: CmdLine@2
           displayName: Run VSCE to package vsix
@@ -97,6 +103,8 @@ extends:
             script: |-
               echo Building VSIX
               vsce package --yarn -o $(Build.StagingDirectory)\cmake-tools.vsix
+          env:
+            npm_config_registry: https://pkgs.dev.azure.com/azure-public/VisualCpp/_packaging/cpp_PublicPackages/npm/registry/
 
         - script: npm uninstall -g @vscode/vsce
           displayName: 'uninstall vsce'

--- a/jobs/loc/TranslationsImportExport.yml
+++ b/jobs/loc/TranslationsImportExport.yml
@@ -60,10 +60,14 @@ extends:
 
         - script: npm install -g yarn@1.22.19
           displayName: Use Yarn 1.x (from CFS feed)
+          env:
+            npm_config_registry: https://pkgs.dev.azure.com/azure-public/VisualCpp/_packaging/cpp_PublicPackages/npm/registry/
 
         - task: CmdLine@2
           inputs:
             script: 'yarn install'
+          env:
+            npm_config_registry: https://pkgs.dev.azure.com/azure-public/VisualCpp/_packaging/cpp_PublicPackages/npm/registry/
         
         - task: CmdLine@2
           inputs:

--- a/jobs/shared/build.yml
+++ b/jobs/shared/build.yml
@@ -15,12 +15,16 @@ steps:
     versionSpec: 22.x
 - script: npm install -g yarn@1.22.19
   displayName: Use Yarn 1.x (from CFS feed)
+  env:
+    npm_config_registry: https://pkgs.dev.azure.com/azure-public/VisualCpp/_packaging/cpp_PublicPackages/npm/registry/
 - task: CmdLine@2
   displayName: IF EXIST %SYSTEMDRIVE%\Users\%USERNAME%\.npmrc del %SYSTEMDRIVE%\Users\%USERNAME%\.npmrc
   inputs:
     script: IF EXIST %SYSTEMDRIVE%\Users\%USERNAME%\.npmrc del %SYSTEMDRIVE%\Users\%USERNAME%\.npmrc
 - script: npm install -g @vscode/vsce
   displayName: 'install vsce'
+  env:
+    npm_config_registry: https://pkgs.dev.azure.com/azure-public/VisualCpp/_packaging/cpp_PublicPackages/npm/registry/
 - task: PowerShell@2
   displayName: Set build name
   inputs:
@@ -54,6 +58,8 @@ steps:
   inputs:
     script: |
       yarn compile-production
+  env:
+    npm_config_registry: https://pkgs.dev.azure.com/azure-public/VisualCpp/_packaging/cpp_PublicPackages/npm/registry/
 - task: MSBuild@1
   displayName: Sign files
   inputs:
@@ -65,6 +71,8 @@ steps:
     script: |
       mkdir $(Build.ArtifactStagingDirectory)\vsix
       if "${{parameters.IsPreRelease}}"=="1" (vsce package --yarn -o $(Build.ArtifactStagingDirectory)\vsix\cmake-tools.vsix --pre-release) else (vsce package --yarn -o $(Build.ArtifactStagingDirectory)\vsix\cmake-tools.vsix)
+  env:
+    npm_config_registry: https://pkgs.dev.azure.com/azure-public/VisualCpp/_packaging/cpp_PublicPackages/npm/registry/
 - task: CmdLine@2
   displayName: Generate Extension Manifest
   inputs:


### PR DESCRIPTION
This pull request updates several CI/CD pipeline YAML files to ensure all npm and yarn commands use a specific Azure DevOps npm registry by setting the `npm_config_registry` environment variable. This helps standardize package installation across the build and localization jobs, ensuring consistency and reliability in dependency management.

Key changes by theme:

**Build and Packaging Pipeline Updates:**
* Added the `npm_config_registry` environment variable to all relevant npm and yarn commands in `jobs/shared/build.yml`, including global installs, compilation, and VSIX packaging steps. [[1]](diffhunk://#diff-6d337f5b2af23d2d3d54b23b6dfb7ed774bb0abb7feeec4ffa949a66f0c14135R18-R27) [[2]](diffhunk://#diff-6d337f5b2af23d2d3d54b23b6dfb7ed774bb0abb7feeec4ffa949a66f0c14135R61-R62) [[3]](diffhunk://#diff-6d337f5b2af23d2d3d54b23b6dfb7ed774bb0abb7feeec4ffa949a66f0c14135R74-R75)
* Applied the same environment variable to npm and yarn steps in `jobs/cg.yml` for consistent registry usage during installation, build, and packaging.

**Localization Pipeline Updates:**
* Ensured that npm and yarn commands in `jobs/loc/TranslationsImportExport.yml` also use the specified Azure DevOps npm registry.