### PR TITLE
Fix CFS feeds

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,4 +1,3 @@
 # [OSS Contributors] Delete this .npmrc file to use the npmjs registry instead of the Microsoft Azure Artifacts feed for local development
 
 registry=https://pkgs.dev.azure.com/azure-public/VisualCpp/_packaging/cpp_PublicPackages/npm/registry/                  
-always-auth=true

--- a/jobs/cg.yml
+++ b/jobs/cg.yml
@@ -78,21 +78,11 @@ extends:
           displayName: "Use Node 22.x"
           inputs:
             version: "22.x"
-        
+
         - task: CmdLine@2
           displayName: IF EXIST %SYSTEMDRIVE%\Users\%USERNAME%\.npmrc del %SYSTEMDRIVE%\Users\%USERNAME%\.npmrc
           inputs:
             script: IF EXIST %SYSTEMDRIVE%\Users\%USERNAME%\.npmrc del %SYSTEMDRIVE%\Users\%USERNAME%\.npmrc
-
-        - script: npm install -g yarn@1.22.19
-          displayName: Use Yarn 1.x (from CFS feed)
-          env:
-            npm_config_registry: https://pkgs.dev.azure.com/azure-public/VisualCpp/_packaging/cpp_PublicPackages/npm/registry/
-        
-        - script: npm install -g @vscode/vsce
-          displayName: 'install vsce'
-          env:
-            npm_config_registry: https://pkgs.dev.azure.com/azure-public/VisualCpp/_packaging/cpp_PublicPackages/npm/registry/
 
         - task: CmdLine@2
           displayName: Build files
@@ -107,13 +97,10 @@ extends:
           inputs:
             script: |-
               echo Building VSIX
-              vsce package --yarn -o $(Build.StagingDirectory)\cmake-tools.vsix
+              yarn run vsce package --yarn -o $(Build.StagingDirectory)\cmake-tools.vsix
           env:
             npm_config_registry: https://pkgs.dev.azure.com/azure-public/VisualCpp/_packaging/cpp_PublicPackages/npm/registry/
 
-        - script: npm uninstall -g @vscode/vsce
-          displayName: 'uninstall vsce'
-        
         - task: DeleteFiles@1
           displayName: Remove non-source code
           inputs:

--- a/jobs/loc/TranslationsImportExport.yml
+++ b/jobs/loc/TranslationsImportExport.yml
@@ -63,17 +63,12 @@ extends:
           inputs:
             script: IF EXIST %SYSTEMDRIVE%\Users\%USERNAME%\.npmrc del %SYSTEMDRIVE%\Users\%USERNAME%\.npmrc
 
-        - script: npm install -g yarn@1.22.19
-          displayName: Use Yarn 1.x (from CFS feed)
-          env:
-            npm_config_registry: https://pkgs.dev.azure.com/azure-public/VisualCpp/_packaging/cpp_PublicPackages/npm/registry/
-
         - task: CmdLine@2
           inputs:
             script: 'yarn install'
           env:
             npm_config_registry: https://pkgs.dev.azure.com/azure-public/VisualCpp/_packaging/cpp_PublicPackages/npm/registry/
-        
+
         - task: CmdLine@2
           inputs:
             script: 'yarn run translations-export'

--- a/jobs/release/prerelease.yml
+++ b/jobs/release/prerelease.yml
@@ -56,7 +56,7 @@ extends:
           displayName: IF EXIST %SYSTEMDRIVE%\Users\%USERNAME%\.npmrc del %SYSTEMDRIVE%\Users\%USERNAME%\.npmrc
           inputs:
             script: IF EXIST %SYSTEMDRIVE%\Users\%USERNAME%\.npmrc del %SYSTEMDRIVE%\Users\%USERNAME%\.npmrc
-        - script: npm install -g @vscode/vsce
+        - script: npm install -g @vscode/vsce@3.1.0
           displayName: 'install vsce'
           env:
             npm_config_registry: https://pkgs.dev.azure.com/azure-public/VisualCpp/_packaging/cpp_PublicPackages/npm/registry/

--- a/jobs/release/release.yml
+++ b/jobs/release/release.yml
@@ -80,7 +80,7 @@ extends:
           displayName: IF EXIST %SYSTEMDRIVE%\Users\%USERNAME%\.npmrc del %SYSTEMDRIVE%\Users\%USERNAME%\.npmrc
           inputs:
             script: IF EXIST %SYSTEMDRIVE%\Users\%USERNAME%\.npmrc del %SYSTEMDRIVE%\Users\%USERNAME%\.npmrc
-        - script: npm install -g @vscode/vsce
+        - script: npm install -g @vscode/vsce@3.1.0
           displayName: 'install vsce'
           env:
             npm_config_registry: https://pkgs.dev.azure.com/azure-public/VisualCpp/_packaging/cpp_PublicPackages/npm/registry/

--- a/jobs/shared/build.yml
+++ b/jobs/shared/build.yml
@@ -17,14 +17,6 @@ steps:
   displayName: IF EXIST %SYSTEMDRIVE%\Users\%USERNAME%\.npmrc del %SYSTEMDRIVE%\Users\%USERNAME%\.npmrc
   inputs:
     script: IF EXIST %SYSTEMDRIVE%\Users\%USERNAME%\.npmrc del %SYSTEMDRIVE%\Users\%USERNAME%\.npmrc
-- script: npm install -g yarn@1.22.19
-  displayName: Use Yarn 1.x (from CFS feed)
-  env:
-    npm_config_registry: https://pkgs.dev.azure.com/azure-public/VisualCpp/_packaging/cpp_PublicPackages/npm/registry/
-- script: npm install -g @vscode/vsce
-  displayName: 'install vsce'
-  env:
-    npm_config_registry: https://pkgs.dev.azure.com/azure-public/VisualCpp/_packaging/cpp_PublicPackages/npm/registry/
 - task: PowerShell@2
   displayName: Set build name
   inputs:
@@ -70,14 +62,14 @@ steps:
   inputs:
     script: |
       mkdir $(Build.ArtifactStagingDirectory)\vsix
-      if "${{parameters.IsPreRelease}}"=="1" (vsce package --yarn -o $(Build.ArtifactStagingDirectory)\vsix\cmake-tools.vsix --pre-release) else (vsce package --yarn -o $(Build.ArtifactStagingDirectory)\vsix\cmake-tools.vsix)
+      if "${{parameters.IsPreRelease}}"=="1" (yarn run vsce package --yarn -o $(Build.ArtifactStagingDirectory)\vsix\cmake-tools.vsix --pre-release) else (yarn run vsce package --yarn -o $(Build.ArtifactStagingDirectory)\vsix\cmake-tools.vsix)
   env:
     npm_config_registry: https://pkgs.dev.azure.com/azure-public/VisualCpp/_packaging/cpp_PublicPackages/npm/registry/
 - task: CmdLine@2
   displayName: Generate Extension Manifest
   inputs:
     script: |
-      vsce generate-manifest -i $(Build.ArtifactStagingDirectory)\vsix\cmake-tools.vsix -o $(Build.ArtifactStagingDirectory)\vsix\extension.manifest
+      yarn run vsce generate-manifest -i $(Build.ArtifactStagingDirectory)\vsix\cmake-tools.vsix -o $(Build.ArtifactStagingDirectory)\vsix\extension.manifest
 - task: CmdLine@2
   displayName: Prepare manifest for signing
   inputs:

--- a/package.json
+++ b/package.json
@@ -4562,5 +4562,5 @@
     "serialize-javascript": "^7.0.4",
     "**/minimatch/brace-expansion": "^1.1.13"
   },
-  "packageManager": "yarn@1.22.19"
+  "packageManager": "yarn@1.22.22"
 }

--- a/tools/pr-creator/.npmrc
+++ b/tools/pr-creator/.npmrc
@@ -1,4 +1,3 @@
 # [OSS Contributors] Delete this .npmrc file to use the npmjs registry instead of the Microsoft Azure Artifacts feed for local development
 
 registry=https://pkgs.dev.azure.com/azure-public/VisualCpp/_packaging/cpp_PublicPackages/npm/registry/                  
-always-auth=true


### PR DESCRIPTION
The prior commit a3316fad deleted the user .npmrc and left always-auth=true in the project .npmrc, but neither was the cause of the E401. The actual cause: the azure-public/cpp_PublicPackages CFS feed under CFSClean network isolation only serves package versions that have already been saved to the feed - it does not transparently pull from upstream npmjs. Requests for yarn@1.22.19 return 401 because that tarball is not in the feed; yarn@1.22.22 IS in the feed and IS pre-installed on the 1ESPT-Windows2025 image. The npm error 'authentication token seems to be invalid' is just how npm formats any 401 with a WWW-Authenticate: Bearer header.

This change adopts the working microsoft/vscode-cpptools and microsoft/vscode-makefile-tools loc pipeline pattern:
- Use pre-installed Yarn 1.22.22 (no npm install -g yarn).
- Use @vscode/vsce from devDependencies via 'yarn run vsce' (no npm install -g @vscode/vsce) in pipelines that check out the repo.
- Drop always-auth=true from .npmrc. It is a no-op for anonymous CFS reads in both clients: npm 10 ignores it entirely (removed in v7.11.1, will warn/error in npm 11/12), and Yarn 1 gates the Authorization header behind 'if (authorization)' so it has no effect without a configured credential. Mirrors microsoft/vscode-cpptools#13377.
- Bump the packageManager field to yarn@1.22.22 to match the pre-installed Yarn the signing pipelines now rely on.
- Keep the del %USERPROFILE%\.npmrc cleanup step and the npm_config_registry env on yarn/vsce steps as defense-in-depth. Both are no-ops on the current 1ESPT-Windows2025 image and yarn.lock pinning, but guard against future image changes that inject a scoped .npmrc or a tool that reads npm_config_registry directly.

The release.yml / prerelease.yml release jobs do not check out the repo, so they cannot use the devDependency. They keep 'npm install -g @vscode/vsce' but pin to @3.1.0 - the same version the build pipelines resolve via yarn.lock, verified saved in the CFS feed. Without a pin, npm would resolve 'latest' to 3.9.2, which is NOT saved in the feed and 401s; a3316fad inherited this latent bug from #4086. Pinning to 3.1.0 keeps the package, sign, and publish steps on a single vsce version.

Long-term, the cleaner fix is to bundle vsce into the vsix artifact so release jobs never hit the feed for tooling.