### PR TITLE
Fix vsce verify step to resolve vsce-sign from module tree

### DIFF
--- a/jobs/release/prerelease.yml
+++ b/jobs/release/prerelease.yml
@@ -66,8 +66,14 @@ extends:
             npm_config_registry: https://pkgs.dev.azure.com/azure-public/VisualCpp/_packaging/cpp_PublicPackages/npm/registry/
         - powershell: |
             $root = npm root -g
-            $sign = Join-Path $root '@vscode\vsce-sign\bin\vsce-sign.exe'
-            if (-not (Test-Path $sign)) { Write-Host "##vso[task.logissue type=error]Missing vsce-sign binary: $sign"; exit 1 }
+            if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($root)) { Write-Host "##vso[task.logissue type=error]npm root -g failed"; exit 1 }
+            $root = $root.Trim()
+            # Resolve the vsce-sign native binary exactly as `vsce publish` does: from @vscode/vsce's own module tree.
+            # In a global install, @vscode/vsce-sign is nested under @vscode/vsce/node_modules (not hoisted to the
+            # global root), so a top-level path check is wrong. This mirrors Node resolution and is layout-agnostic.
+            $sign = node -e "const p=require('path'),fs=require('fs');const vsce=require.resolve('@vscode/vsce',{paths:[process.argv[1]]});const pkg=require.resolve('@vscode/vsce-sign/package.json',{paths:[p.dirname(vsce)]});const cmd=process.platform==='win32'?'vsce-sign.exe':'vsce-sign';const b=p.join(p.dirname(pkg),'bin',cmd);if(!fs.existsSync(b)){process.exit(2);}process.stdout.write(b);" "$root"
+            if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($sign)) { Write-Host "##vso[task.logissue type=error]vsce-sign binary not resolvable from @vscode/vsce under $root"; exit 1 }
+            Write-Host "Found vsce-sign at $($sign.Trim())"
             vsce --version
             if ($LASTEXITCODE -ne 0) { Write-Host "##vso[task.logissue type=error]vsce failed to run"; exit 1 }
           displayName: 'Verify vsce'

--- a/jobs/release/release.yml
+++ b/jobs/release/release.yml
@@ -90,8 +90,14 @@ extends:
             npm_config_registry: https://pkgs.dev.azure.com/azure-public/VisualCpp/_packaging/cpp_PublicPackages/npm/registry/
         - powershell: |
             $root = npm root -g
-            $sign = Join-Path $root '@vscode\vsce-sign\bin\vsce-sign.exe'
-            if (-not (Test-Path $sign)) { Write-Host "##vso[task.logissue type=error]Missing vsce-sign binary: $sign"; exit 1 }
+            if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($root)) { Write-Host "##vso[task.logissue type=error]npm root -g failed"; exit 1 }
+            $root = $root.Trim()
+            # Resolve the vsce-sign native binary exactly as `vsce publish` does: from @vscode/vsce's own module tree.
+            # In a global install, @vscode/vsce-sign is nested under @vscode/vsce/node_modules (not hoisted to the
+            # global root), so a top-level path check is wrong. This mirrors Node resolution and is layout-agnostic.
+            $sign = node -e "const p=require('path'),fs=require('fs');const vsce=require.resolve('@vscode/vsce',{paths:[process.argv[1]]});const pkg=require.resolve('@vscode/vsce-sign/package.json',{paths:[p.dirname(vsce)]});const cmd=process.platform==='win32'?'vsce-sign.exe':'vsce-sign';const b=p.join(p.dirname(pkg),'bin',cmd);if(!fs.existsSync(b)){process.exit(2);}process.stdout.write(b);" "$root"
+            if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($sign)) { Write-Host "##vso[task.logissue type=error]vsce-sign binary not resolvable from @vscode/vsce under $root"; exit 1 }
+            Write-Host "Found vsce-sign at $($sign.Trim())"
             vsce --version
             if ($LASTEXITCODE -ne 0) { Write-Host "##vso[task.logissue type=error]vsce failed to run"; exit 1 }
           displayName: 'Verify vsce'


### PR DESCRIPTION
This pull request updates the way the pipeline locates the `vsce-sign` binary during release and prerelease jobs. Instead of assuming a fixed global path, it now dynamically resolves the binary location based on Node.js module resolution, making the process more robust and layout-agnostic. This change ensures compatibility with different installation structures and prevents errors when the binary is not hoisted to the global root.

Key changes:

**Improved vsce-sign binary resolution:**

* Updated the PowerShell script in both `jobs/release/prerelease.yml` and `jobs/release/release.yml` to resolve the `vsce-sign` binary using Node.js module resolution, mirroring how `vsce publish` locates it, instead of relying on a fixed global path. This prevents failures in environments where the module layout differs from expectations. [[1]](diffhunk://#diff-7b7c10c627921eaeb34e884afad4dd4b7707c9ef1ff15f9451a7af483c9b27dbL69-R76) [[2]](diffhunk://#diff-00a52e9268325fd97bdcd98dd8eeff56e4891b2a83b90d593dfe7dbc14ff3b07L93-R100)
* Added error handling to check if `npm root -g` fails or returns an empty value, and to ensure the resolved `vsce-sign` path is valid before proceeding. [[1]](diffhunk://#diff-7b7c10c627921eaeb34e884afad4dd4b7707c9ef1ff15f9451a7af483c9b27dbL69-R76) [[2]](diffhunk://#diff-00a52e9268325fd97bdcd98dd8eeff56e4891b2a83b90d593dfe7dbc14ff3b07L93-R100)
* Added log output to confirm the resolved location of the `vsce-sign` binary for easier debugging. [[1]](diffhunk://#diff-7b7c10c627921eaeb34e884afad4dd4b7707c9ef1ff15f9451a7af483c9b27dbL69-R76) [[2]](diffhunk://#diff-00a52e9268325fd97bdcd98dd8eeff56e4891b2a83b90d593dfe7dbc14ff3b07L93-R100)