### PR TITLE
Harden Windows e2e tests with retries and improved output timing

### DIFF
--- a/test/end-to-end-tests/successful-build/test/debugger.test.ts
+++ b/test/end-to-end-tests/successful-build/test/debugger.test.ts
@@ -301,13 +301,23 @@ suite('Debug/Launch interface', () => {
             expect(terminal!.creationOptions.name).to.eq(`CMake/Launch - ${executablesTargets[0].name}`);
 
             const start = new Date();
-            // Needed to get launch target result
-            await new Promise(resolve => setTimeout(resolve, 3000));
+            // Poll for the launched executable's output file rather than waiting a single fixed
+            // interval: on loaded CI runners the launch terminal and process startup can take
+            // longer than a few seconds, which made the previous fixed 3s wait racy and flaky on
+            // Windows. We still assert the file must appear, just within a more tolerant window.
+            let exists = false;
+            const timeoutMs = 15000;
+            while ((new Date().getTime() - start.getTime()) < timeoutMs) {
+                if (fs.existsSync(createdFileOnExecution)) {
+                    exists = true;
+                    break;
+                }
+                await new Promise(resolve => setTimeout(resolve, 250));
+            }
 
             const elapsed = (new Date().getTime() - start.getTime()) / 1000;
             console.log(`Waited ${elapsed} seconds for output file to appear`);
 
-            const exists = fs.existsSync(createdFileOnExecution);
             // Check that it is compiled as a new file
             expect(exists).to.be.true;
         } finally {

--- a/test/helpers/cmake/build-directory-helper.ts
+++ b/test/helpers/cmake/build-directory-helper.ts
@@ -5,7 +5,11 @@ export class BuildDirectoryHelper {
     public constructor(private readonly _location: string) {}
 
     public clear() {
-        return fs.rmSync(this._location, {recursive: true, force: true});
+        // Retry on Windows: lingering MSVC helper processes (e.g. mspdbsrv.exe / vctip.exe) can
+        // briefly keep handles on .pdb files in the build directory, so a single rmSync can fail
+        // with ENOTEMPTY/EBUSY. maxRetries/retryDelay lets the delete ride out those transient
+        // locks instead of failing the test's build-directory cleanup hook.
+        return fs.rmSync(this._location, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
     }
 
     public get location(): string {


### PR DESCRIPTION
This pull request improves the reliability of end-to-end tests, especially on Windows, by making test file existence checks more robust and by enhancing build directory cleanup to handle transient file locks. These changes reduce test flakiness caused by timing issues and file handle contention.

**Test reliability improvements:**

* Replaced a fixed 3-second wait with a polling loop (up to 15 seconds) to check for the existence of the launched executable's output file in the `Debug/Launch interface` test, preventing race conditions and flakiness on slower CI runners.

**Build directory cleanup robustness:**

* Updated the `BuildDirectoryHelper.clear()` method to retry directory deletion up to 10 times with a short delay, addressing issues where lingering processes (like MSVC helpers) temporarily lock files and prevent immediate deletion on Windows.