### PR TITLE
Fix release/pre-release vsce install E401 under network isolation

### DIFF
--- a/jobs/release/prerelease.yml
+++ b/jobs/release/prerelease.yml
@@ -56,11 +56,31 @@ extends:
           displayName: IF EXIST %SYSTEMDRIVE%\Users\%USERNAME%\.npmrc del %SYSTEMDRIVE%\Users\%USERNAME%\.npmrc
           inputs:
             script: IF EXIST %SYSTEMDRIVE%\Users\%USERNAME%\.npmrc del %SYSTEMDRIVE%\Users\%USERNAME%\.npmrc
-        - script: npm install -g @vscode/vsce@3.9.1 --include=optional --ignore-scripts=false --force
+        - powershell: |
+            # Release jobs run without a repo checkout, so write clean, token-less npm configs and pass them
+            # via --globalconfig/--userconfig. This overrides any stale agent-injected
+            # //pkgs.dev.azure.com/:_authToken (a DevDiv-org token that is invalid for the cross-org
+            # azure-public cpp_PublicPackages feed), so `npm install -g` reads the feed anonymously,
+            # exactly as the build does. The user-scope delete above does not clear the global scope.
+            # Distinct files are required: npm rejects the same path for both --globalconfig and --userconfig.
+            # The global config preserves the existing prefix so the global install location is unchanged.
+            $registry = 'https://pkgs.dev.azure.com/azure-public/VisualCpp/_packaging/cpp_PublicPackages/npm/registry/'
+            $prefix = (npm config get prefix).Trim()
+            if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($prefix)) {
+              Write-Host "##vso[task.logissue type=error]npm config get prefix failed"; exit 1
+            }
+            $prefix = $prefix -replace '\\','/'
+            $globalNpmrc = Join-Path $env:AGENT_TEMPDIRECTORY 'vsce-global.npmrc'
+            $userNpmrc = Join-Path $env:AGENT_TEMPDIRECTORY 'vsce-user.npmrc'
+            Set-Content -Path $globalNpmrc -Encoding ascii -Value @("prefix=$prefix", "registry=$registry")
+            Set-Content -Path $userNpmrc -Encoding ascii -Value "registry=$registry"
+            Write-Host "Wrote clean npm configs to $globalNpmrc and $userNpmrc (prefix=$prefix)"
+          displayName: 'Create clean npm configs for vsce'
+        - script: npm install -g @vscode/vsce@3.9.1 --include=optional --ignore-scripts=false --force --globalconfig "$(Agent.TempDirectory)\vsce-global.npmrc" --userconfig "$(Agent.TempDirectory)\vsce-user.npmrc"
           displayName: 'Install vsce'
           env:
             npm_config_registry: https://pkgs.dev.azure.com/azure-public/VisualCpp/_packaging/cpp_PublicPackages/npm/registry/
-        - script: npm rebuild -g @vscode/vsce-sign --ignore-scripts=false
+        - script: npm rebuild -g @vscode/vsce-sign --ignore-scripts=false --globalconfig "$(Agent.TempDirectory)\vsce-global.npmrc" --userconfig "$(Agent.TempDirectory)\vsce-user.npmrc"
           displayName: 'Rebuild vsce-sign native binary'
           env:
             npm_config_registry: https://pkgs.dev.azure.com/azure-public/VisualCpp/_packaging/cpp_PublicPackages/npm/registry/

--- a/jobs/release/release.yml
+++ b/jobs/release/release.yml
@@ -80,11 +80,31 @@ extends:
           displayName: IF EXIST %SYSTEMDRIVE%\Users\%USERNAME%\.npmrc del %SYSTEMDRIVE%\Users\%USERNAME%\.npmrc
           inputs:
             script: IF EXIST %SYSTEMDRIVE%\Users\%USERNAME%\.npmrc del %SYSTEMDRIVE%\Users\%USERNAME%\.npmrc
-        - script: npm install -g @vscode/vsce@3.9.1 --include=optional --ignore-scripts=false --force
+        - powershell: |
+            # Release jobs run without a repo checkout, so write clean, token-less npm configs and pass them
+            # via --globalconfig/--userconfig. This overrides any stale agent-injected
+            # //pkgs.dev.azure.com/:_authToken (a DevDiv-org token that is invalid for the cross-org
+            # azure-public cpp_PublicPackages feed), so `npm install -g` reads the feed anonymously,
+            # exactly as the build does. The user-scope delete above does not clear the global scope.
+            # Distinct files are required: npm rejects the same path for both --globalconfig and --userconfig.
+            # The global config preserves the existing prefix so the global install location is unchanged.
+            $registry = 'https://pkgs.dev.azure.com/azure-public/VisualCpp/_packaging/cpp_PublicPackages/npm/registry/'
+            $prefix = (npm config get prefix).Trim()
+            if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($prefix)) {
+              Write-Host "##vso[task.logissue type=error]npm config get prefix failed"; exit 1
+            }
+            $prefix = $prefix -replace '\\','/'
+            $globalNpmrc = Join-Path $env:AGENT_TEMPDIRECTORY 'vsce-global.npmrc'
+            $userNpmrc = Join-Path $env:AGENT_TEMPDIRECTORY 'vsce-user.npmrc'
+            Set-Content -Path $globalNpmrc -Encoding ascii -Value @("prefix=$prefix", "registry=$registry")
+            Set-Content -Path $userNpmrc -Encoding ascii -Value "registry=$registry"
+            Write-Host "Wrote clean npm configs to $globalNpmrc and $userNpmrc (prefix=$prefix)"
+          displayName: 'Create clean npm configs for vsce'
+        - script: npm install -g @vscode/vsce@3.9.1 --include=optional --ignore-scripts=false --force --globalconfig "$(Agent.TempDirectory)\vsce-global.npmrc" --userconfig "$(Agent.TempDirectory)\vsce-user.npmrc"
           displayName: 'Install vsce'
           env:
             npm_config_registry: https://pkgs.dev.azure.com/azure-public/VisualCpp/_packaging/cpp_PublicPackages/npm/registry/
-        - script: npm rebuild -g @vscode/vsce-sign --ignore-scripts=false
+        - script: npm rebuild -g @vscode/vsce-sign --ignore-scripts=false --globalconfig "$(Agent.TempDirectory)\vsce-global.npmrc" --userconfig "$(Agent.TempDirectory)\vsce-user.npmrc"
           displayName: 'Rebuild vsce-sign native binary'
           env:
             npm_config_registry: https://pkgs.dev.azure.com/azure-public/VisualCpp/_packaging/cpp_PublicPackages/npm/registry/


### PR DESCRIPTION
This pull request updates the npm configuration process for installing and rebuilding `@vscode/vsce` and `@vscode/vsce-sign` in both `prerelease.yml` and `release.yml` jobs. The main goal is to ensure that npm commands use clean, token-less configuration files, preventing issues with stale or invalid authentication tokens during release jobs, which run without a repository checkout.

The most important changes are:

**NPM Configuration Improvements:**

* Added a PowerShell step to generate clean, token-less `npmrc` configuration files (`vsce-global.npmrc` and `vsce-user.npmrc`) in the agent's temporary directory. This ensures that npm installs and rebuilds access the correct registry anonymously and do not use any stale agent-injected authentication tokens. [[1]](diffhunk://#diff-7b7c10c627921eaeb34e884afad4dd4b7707c9ef1ff15f9451a7af483c9b27dbL59-R83) [[2]](diffhunk://#diff-00a52e9268325fd97bdcd98dd8eeff56e4891b2a83b90d593dfe7dbc14ff3b07L83-R107)

**Job Step Updates:**

* Updated the `npm install -g @vscode/vsce@3.9.1` and `npm rebuild -g @vscode/vsce-sign` commands to explicitly use the newly created clean npm configuration files via the `--globalconfig` and `--userconfig` options. This guarantees consistent, clean configuration for these steps. [[1]](diffhunk://#diff-7b7c10c627921eaeb34e884afad4dd4b7707c9ef1ff15f9451a7af483c9b27dbL59-R83) [[2]](diffhunk://#diff-00a52e9268325fd97bdcd98dd8eeff56e4891b2a83b90d593dfe7dbc14ff3b07L83-R107)

These changes improve the reliability and security of the release pipeline by ensuring npm always uses valid, clean configuration files during the install and rebuild steps.