### PR TITLE
Fix the CMake Cache Editor UI not refreshing while open

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ Bug Fixes:
 - Update testing framework to fix bugs when running tests of CMake Tools without a reliable internet connection. [#4891](https://github.com/microsoft/vscode-cmake-tools/pull/4891) [@cwalther](https://github.com/cwalther)
 - Fix GNU LD diagnostic regex incorrectly matching CMake status lines (e.g., Zephyr build output) as linker errors in the Problems panel. [#4910](https://github.com/microsoft/vscode-cmake-tools/issues/4910)
 - Fix “Make it easier for a new developer of CMake Tools to run tests” on Windows. [#4932](https://github.com/microsoft/vscode-cmake-tools/pull/4932) [@cwalther](https://github.com/cwalther)
+- Refresh the open CMake Cache Editor when configuration changes cache values externally. [#3635](https://github.com/microsoft/vscode-cmake-tools/issues/3635)
 
 ## 1.23.52
 

--- a/src/cmakeProject.ts
+++ b/src/cmakeProject.ts
@@ -2662,12 +2662,17 @@ export class CMakeProject {
                 return 1;
             }
 
-            this.cacheEditorWebview = new ConfigurationWebview(drv.cachePath, () => {
-                void this.configureInternal(ConfigureTrigger.commandEditCacheUI, [], ConfigureType.Cache);
+            this.cacheEditorWebview = new ConfigurationWebview(drv.cachePath, async () => {
+                await this.configureInternal(ConfigureTrigger.commandEditCacheUI, [], ConfigureType.Cache);
             });
             await this.cacheEditorWebview.initPanel();
 
+            const refreshCacheEditor = this.onReconfigured(() => rollbar.invokeAsync(
+                localize('refresh.cache.editor.after.configure', 'Refresh the CMake Cache Editor after configure'),
+                async () => this.cacheEditorWebview?.refreshPanel()
+            ));
             this.cacheEditorWebview.panel.onDidDispose(() => {
+                refreshCacheEditor.dispose();
                 this.cacheEditorWebview = undefined;
             });
         } else {

--- a/src/ui/cacheView.ts
+++ b/src/ui/cacheView.ts
@@ -50,7 +50,7 @@ export class ConfigurationWebview {
 
     private options: IOption[] = [];
 
-    constructor(protected cachePath: string, protected save: () => void) {
+    constructor(protected cachePath: string, protected save: () => Promise<void>) {
         this.panel = vscode.window.createWebviewPanel(
             'cmakeConfiguration', // Identifies the type of the webview. Used internally
             this.cmakeCacheEditorText, // Title of the panel displayed to the user
@@ -68,9 +68,8 @@ export class ConfigurationWebview {
             telemetry.logEvent("editCMakeCache", { command: "saveCMakeCacheUI" });
             await this.saveCmakeCache(this.options);
             void vscode.window.showInformationMessage(localize('cmake.cache.saved', 'CMake options have been saved.'));
-            // start configure
-            this.save();
             this.isDirty = false;
+            await this.save();
         }
     }
 

--- a/src/ui/cacheView.ts
+++ b/src/ui/cacheView.ts
@@ -145,12 +145,6 @@ export class ConfigurationWebview {
                 this.options = mergedOptions;
             }
 
-            // The webview needs a re-render also for the "ignore" or "fromUI" cases
-            // to reflect all the unconflicting changes.
-            if (this.panel.visible) {
-                await this.renderWebview(this.panel, false);
-            }
-
             // Keep the unsaved look in case the user decided to ignore the CMake Cache conflicts
             // between the webview and the file on disk.
             if (result !== ignore) {
@@ -158,6 +152,12 @@ export class ConfigurationWebview {
             }
         } else {
             this.options = await this.getConfigurationOptions();
+        }
+
+        // Re-render after both clean and dirty refreshes so external cache changes
+        // are reflected immediately while the editor is visible.
+        if (this.panel.visible) {
+            await this.renderWebview(this.panel, false);
         }
     }
 

--- a/test/unit-tests/backend/cacheView.test.ts
+++ b/test/unit-tests/backend/cacheView.test.ts
@@ -10,7 +10,7 @@ suite('[cacheView]', () => {
         const cachePath = path.join(tempDir, 'CMakeCache.txt');
         try {
             fs.writeFileSync(cachePath, '//A value changed by configure\nDERIVED_MESSAGE:STRING=Old value\n');
-            const webview = new ConfigurationWebview(cachePath, () => {});
+            const webview = new ConfigurationWebview(cachePath, async () => {});
             await webview.renderWebview(webview.panel, true);
             expect(webview.panel.webview.html).to.contain('value="Old value"');
 
@@ -19,6 +19,32 @@ suite('[cacheView]', () => {
 
             expect(webview.panel.webview.html).to.contain('value="Updated value"');
             expect(webview.panel.webview.html).not.to.contain('value="Old value"');
+        } finally {
+            fs.rmSync(tempDir, { recursive: true, force: true });
+        }
+    });
+
+    test('waits for configure so its cache changes can refresh the editor', async () => {
+        const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cmt-cache-view-'));
+        const cachePath = path.join(tempDir, 'CMakeCache.txt');
+        try {
+            fs.writeFileSync(cachePath, '//A value changed by configure\nDERIVED_MESSAGE:STRING=Old value\n');
+            const webview = new ConfigurationWebview(cachePath, async () => {
+                await new Promise(resolve => setTimeout(resolve, 0));
+                expect(webview.isDirty).to.be.false;
+                fs.writeFileSync(cachePath, '//A value changed by configure\nDERIVED_MESSAGE:STRING=Updated by configure\n');
+                await webview.refreshPanel();
+            });
+            await webview.renderWebview(webview.panel, true);
+
+            const options = (webview as unknown as { options: { value: string; dirty: boolean }[] }).options;
+            options[0].value = 'User value';
+            options[0].dirty = true;
+            webview.isDirty = true;
+            await webview.persistCacheEntries();
+
+            expect(webview.panel.webview.html).to.contain('value="Updated by configure"');
+            expect(webview.panel.webview.html).not.to.contain('value="User value"');
         } finally {
             fs.rmSync(tempDir, { recursive: true, force: true });
         }

--- a/test/unit-tests/backend/cacheView.test.ts
+++ b/test/unit-tests/backend/cacheView.test.ts
@@ -1,0 +1,26 @@
+import { expect } from 'chai';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { ConfigurationWebview } from '@cmt/ui/cacheView';
+
+suite('[cacheView]', () => {
+    test('refreshes a visible clean cache editor after external cache changes', async () => {
+        const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cmt-cache-view-'));
+        const cachePath = path.join(tempDir, 'CMakeCache.txt');
+        try {
+            fs.writeFileSync(cachePath, '//A value changed by configure\nDERIVED_MESSAGE:STRING=Old value\n');
+            const webview = new ConfigurationWebview(cachePath, () => {});
+            await webview.renderWebview(webview.panel, true);
+            expect(webview.panel.webview.html).to.contain('value="Old value"');
+
+            fs.writeFileSync(cachePath, '//A value changed by configure\nDERIVED_MESSAGE:STRING=Updated value\n');
+            await webview.refreshPanel();
+
+            expect(webview.panel.webview.html).to.contain('value="Updated value"');
+            expect(webview.panel.webview.html).not.to.contain('value="Old value"');
+        } finally {
+            fs.rmSync(tempDir, { recursive: true, force: true });
+        }
+    });
+});

--- a/test/unit-tests/backend/setup-vscode-mock.ts
+++ b/test/unit-tests/backend/setup-vscode-mock.ts
@@ -26,6 +26,7 @@ const originalLoad = (Module as any)._load;
             Position,
             Range,
             Uri,
+            ViewColumn: { One: 1 },
             workspace: {
                 getConfiguration: () => new Proxy({}, {
                     get: (_target: any, prop: string) => {
@@ -42,6 +43,13 @@ const originalLoad = (Module as any)._load;
             },
             window: {
                 createOutputChannel: () => noopObj,
+                createWebviewPanel: () => ({
+                    title: '',
+                    visible: true,
+                    webview: {
+                        html: ''
+                    }
+                }),
                 showErrorMessage: noop,
                 showWarningMessage: noop,
                 showInformationMessage: noop,
@@ -76,4 +84,3 @@ const originalLoad = (Module as any)._load;
     }
     return originalLoad.call(this, request, parent, isMain);
 };
-


### PR DESCRIPTION
Fixes #3635

**Summary**

Fixes the open CMake Cache Editor so it updates automatically after configuring a project changes cache values.

Previously, the updated values only appeared after closing and reopening the editor.

**Changes**

The Cache Editor now waits for configuration to finish after saving changes. Once configuration completes, it reloads the latest values from  CMakeCache.txt  and updates the open editor.

The refresh listener is removed when the editor closes, and tests cover both direct cache changes and changes produced during configuration.

**Testing**

• Validated locally with a sample project.
• Confirmed values update without reopening the Cache Editor.
• Added a test covering this behavior.