### PR TITLE
Fix inability to reselect "[Targets In Preset]" build target (CMake Presets)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ Bug Fixes:
 - Fix “Make it easier for a new developer of CMake Tools to run tests” on Windows. [#4932](https://github.com/microsoft/vscode-cmake-tools/pull/4932) [@cwalther](https://github.com/cwalther)
 - Show the CMake Tools activity-bar view immediately with an "initializing" placeholder instead of hiding the entire sidebar until CMake, kit, preset, and Visual Studio developer-environment probing completes. On machines where those probes are intermittently slow (e.g. aggressive antivirus scanning of spawned processes, or extension-host file-handle exhaustion), the sidebar no longer disappears for minutes during activation. Project commands, menus, and status items remain gated on full readiness, so nothing runs against a partially-initialized project. [#5027](https://github.com/microsoft/vscode-cmake-tools/pull/5027)
 - Refresh the open CMake Cache Editor when configuration changes cache values externally. [#3635](https://github.com/microsoft/vscode-cmake-tools/issues/3635)
+- Fix being unable to switch the build target back to "[Targets In Preset]" after selecting a specific target when using CMake Presets. The default build target picker now offers "[Targets In Preset]" in presets mode; choosing it clears the pinned target so builds follow the preset-defined targets (or the default target) again, instead of requiring the persisted state to be edited by hand. [#3587](https://github.com/microsoft/vscode-cmake-tools/issues/3587)
 
 ## 1.23.52
 

--- a/src/buildTargetSelection.ts
+++ b/src/buildTargetSelection.ts
@@ -1,0 +1,59 @@
+/**
+ * Pure helpers for the build-target selector, kept free of the `vscode` API so the
+ * selection/reset logic can be unit-tested directly (see
+ * test/unit-tests/backend/build-target-selection.test.ts).
+ */
+
+/**
+ * Discriminant returned by the target picker when the user chooses to build the targets defined by
+ * the active build preset (the default state) rather than pinning a specific target. A unique
+ * `Symbol` is used instead of a string so it can never collide with a real CMake target name (which
+ * may contain underscores and other characters). It is never persisted.
+ */
+export const presetTargetsReset: unique symbol = Symbol('presetTargetsReset');
+
+/**
+ * Whether the active build preset declares explicit, non-empty targets. An empty `targets: []` is
+ * treated as "no explicit targets" because CMake then builds the default target, so there is no
+ * concrete target list to offer as a one-shot build.
+ */
+export function hasExplicitBuildPresetTargets(targets: string | string[] | undefined): boolean {
+    return typeof targets === 'string' ? targets.length > 0 : Array.isArray(targets) && targets.length > 0;
+}
+
+/**
+ * Whether the build-target picker should offer the "[Targets In Preset]" reset entry.
+ *
+ * Only meaningful in presets mode. When the build preset declares explicit targets, the entry is
+ * always useful because it maps to those targets. When it does not, the reset is only safe for the
+ * persisted default-target picker (`allowPresetReset`), which clears the stored target; the
+ * one-shot build-target picker must not offer it, because with no preset targets it would fall back
+ * to the pinned default target instead of the preset default.
+ */
+export function shouldOfferPresetTargetsReset(useCMakePresets: boolean, allowPresetReset: boolean, hasExplicitPresetTargets: boolean): boolean {
+    return useCMakePresets && (allowPresetReset || hasExplicitPresetTargets);
+}
+
+/**
+ * Resolve the effective build targets from the persisted default target. Mirrors the logic used by
+ * `CMakeProject.getDefaultBuildTargets`, extracted here so it can be unit-tested.
+ *
+ * @param legacyPresetSentinel The localized "[Targets In Preset]" label, which older versions
+ *   persisted as the default target; still recognized for backward compatibility.
+ */
+export function resolveDefaultBuildTargets(
+    useCMakePresets: boolean,
+    defaultTarget: string | null,
+    legacyPresetSentinel: string,
+    buildPresetTargets: string | string[] | undefined,
+    allTargetName: string
+): string[] | undefined {
+    let targets: string | string[] | undefined = defaultTarget || undefined;
+    if (useCMakePresets && (!defaultTarget || defaultTarget === legacyPresetSentinel)) {
+        targets = buildPresetTargets;
+    }
+    if (!useCMakePresets && !defaultTarget) {
+        targets = allTargetName;
+    }
+    return typeof targets === 'string' ? [targets] : targets;
+}

--- a/src/cmakeProject.ts
+++ b/src/cmakeProject.ts
@@ -1,3 +1,4 @@
+import { hasExplicitBuildPresetTargets, presetTargetsReset, resolveDefaultBuildTargets, shouldOfferPresetTargetsReset } from '@cmt/buildTargetSelection';
 import { CMakeCache } from '@cmt/cache';
 import { CMakeExecutable, getCMakeExecutableInformation } from '@cmt/cmakeExecutable';
 import { CompilationDatabase } from '@cmt/compilationDatabase';
@@ -2693,16 +2694,19 @@ export class CMakeProject {
         if (target === null) {
             return -1;
         }
-        let targets: string | string[] | undefined = target;
-        if (target === this.targetsInPresetName) {
+        let targets: string | string[] | undefined;
+        if (target === presetTargetsReset) {
             targets = this.buildPreset?.targets;
+        } else {
+            targets = target;
         }
         return (await this.build(util.isString(targets) ? [targets] : targets)).exitCode;
     }
 
     private readonly targetsInPresetName = localize('targests.in.preset', '[Targets In Preset]');
 
-    async showTargetSelector(): Promise<string | null> {
+    async showTargetSelector(allowPresetReset: boolean = false): Promise<string | typeof presetTargetsReset | null> {
+        type BuildTargetQuickPickItem = vscode.QuickPickItem & { isPresetReset?: boolean };
         const drv = await this.getCMakeDriverInstance();
         if (!drv) {
             void vscode.window.showErrorMessage(localize('set.up.before.selecting.target', 'Set up your CMake project before selecting a target.'));
@@ -2714,11 +2718,6 @@ export class CMakeProject {
         } else {
             const folders: string[] = [];
             const itemsGroup: (RichTarget | NamedTarget | FolderTarget)[] = [];
-
-            // Add special "[Targets In Preset]" option when using presets with defined targets
-            if (this.useCMakePresets && this.buildPreset?.targets) {
-                itemsGroup.push({ type: 'named', name: this.targetsInPresetName });
-            }
 
             // group the data
             drv.uniqueTargets.forEach((t) => {
@@ -2742,7 +2741,7 @@ export class CMakeProject {
                 }
             });
 
-            const choicesGroup = itemsGroup.map((t): vscode.QuickPickItem => {
+            const choicesGroup = itemsGroup.map((t): BuildTargetQuickPickItem => {
                 switch (t.type) {
                     case 'named': {
                         return {
@@ -2759,7 +2758,23 @@ export class CMakeProject {
                 }
             });
 
+            // Offer "[Targets In Preset]" so the user can return to the preset-defined targets (or
+            // the default target) after having pinned a specific one. When the build preset has no
+            // explicit targets this reset only applies to the persisted default-target picker, so
+            // it is gated by allowPresetReset (see shouldOfferPresetTargetsReset).
+            if (shouldOfferPresetTargetsReset(this.useCMakePresets, allowPresetReset, hasExplicitBuildPresetTargets(this.buildPreset?.targets))) {
+                choicesGroup.unshift({
+                    label: this.targetsInPresetName,
+                    description: localize('targets.in.preset.description', 'Build the targets defined by the active build preset'),
+                    isPresetReset: true
+                });
+            }
+
             const selGroup = await vscode.window.showQuickPick(choicesGroup, { placeHolder: localize('select.active.target.tooltip', 'Select the default build target') });
+
+            if (selGroup?.isPresetReset) {
+                return presetTargetsReset;
+            }
 
             // exit if we do not group the folders or if we got something other than a folder
             if (!selGroup || !this.workspaceContext.config.useFolderPropertyInBuildTargetDropdown || selGroup.description !== "FOLDER") {
@@ -3054,21 +3069,15 @@ export class CMakeProject {
     public get defaultBuildTarget(): string | null {
         return this.workspaceContext.state.getDefaultBuildTarget(this.folderName, this.isMultiProjectFolder);
     }
-    private async setDefaultBuildTarget(v: string) {
+    private async setDefaultBuildTarget(v: string | null) {
         await this.workspaceContext.state.setDefaultBuildTarget(this.folderName, v, this.isMultiProjectFolder);
-        this.targetName.set(v);
+        this.targetName.set(v ?? this.targetsInPresetName);
     }
 
     public async getDefaultBuildTargets(): Promise<string[] | undefined> {
         const defaultTarget = this.defaultBuildTarget;
-        let targets: string | string[] | undefined = defaultTarget || undefined;
-        if (this.useCMakePresets && (!defaultTarget || defaultTarget === this.targetsInPresetName)) {
-            targets = this.buildPreset?.targets;
-        }
-        if (!this.useCMakePresets && !defaultTarget) {
-            targets = await this.allTargetName;
-        }
-        return util.isString(targets) ? [targets] : targets;
+        const allTargetName = (!this.useCMakePresets && !defaultTarget) ? await this.allTargetName : '';
+        return resolveDefaultBuildTargets(this.useCMakePresets, defaultTarget, this.targetsInPresetName, this.buildPreset?.targets, allTargetName);
     }
 
     /**
@@ -3077,7 +3086,14 @@ export class CMakeProject {
      */
     async setDefaultTarget(target?: string | null) {
         if (!target) {
-            target = await this.showTargetSelector();
+            const selected = await this.showTargetSelector(true);
+            // "[Targets In Preset]" clears the persisted default so building follows the preset-defined
+            // targets (or the default target) again, rather than a previously pinned target.
+            if (selected === presetTargetsReset) {
+                await this.setDefaultBuildTarget(null);
+                return;
+            }
+            target = selected;
         }
         if (!target) {
             return;

--- a/test/unit-tests/backend/build-target-selection.test.ts
+++ b/test/unit-tests/backend/build-target-selection.test.ts
@@ -1,0 +1,88 @@
+import { expect } from 'chai';
+import { hasExplicitBuildPresetTargets, presetTargetsReset, resolveDefaultBuildTargets, shouldOfferPresetTargetsReset } from '@cmt/buildTargetSelection';
+
+// The localized label older versions persisted as the default build target.
+const presetLabel = '[Targets In Preset]';
+
+suite('Build target selection', () => {
+    suite('presetTargetsReset', () => {
+        test('is a unique symbol that cannot equal any target-name string', () => {
+            expect(typeof presetTargetsReset).to.equal('symbol');
+            expect((presetTargetsReset as unknown) === '__cmake_tools_targets_in_preset__').to.equal(false);
+        });
+    });
+
+    suite('hasExplicitBuildPresetTargets', () => {
+        test('is false when the preset declares no targets', () => {
+            expect(hasExplicitBuildPresetTargets(undefined)).to.equal(false);
+        });
+
+        test('is false for an empty targets array or empty string', () => {
+            expect(hasExplicitBuildPresetTargets([])).to.equal(false);
+            expect(hasExplicitBuildPresetTargets('')).to.equal(false);
+        });
+
+        test('is true when the preset declares one or more targets', () => {
+            expect(hasExplicitBuildPresetTargets('app')).to.equal(true);
+            expect(hasExplicitBuildPresetTargets(['app'])).to.equal(true);
+            expect(hasExplicitBuildPresetTargets(['app', 'lib'])).to.equal(true);
+        });
+    });
+
+    suite('shouldOfferPresetTargetsReset', () => {
+        test('never offers the reset in kits/variants mode', () => {
+            expect(shouldOfferPresetTargetsReset(false, true, true)).to.equal(false);
+            expect(shouldOfferPresetTargetsReset(false, false, true)).to.equal(false);
+            expect(shouldOfferPresetTargetsReset(false, true, false)).to.equal(false);
+        });
+
+        test('default-target picker always offers the reset in presets mode (the #3587 regression)', () => {
+            // Even when the build preset declares no explicit targets, the user must be able to
+            // return to "[Targets In Preset]" after pinning a specific target.
+            expect(shouldOfferPresetTargetsReset(true, true, false)).to.equal(true);
+            expect(shouldOfferPresetTargetsReset(true, true, true)).to.equal(true);
+        });
+
+        test('one-shot build picker only offers the reset when the preset defines targets', () => {
+            // Without explicit preset targets the reset would fall back to the pinned default, so the
+            // one-shot picker (allowPresetReset = false) must not offer it.
+            expect(shouldOfferPresetTargetsReset(true, false, true)).to.equal(true);
+            expect(shouldOfferPresetTargetsReset(true, false, false)).to.equal(false);
+        });
+    });
+
+    suite('resolveDefaultBuildTargets', () => {
+        test('presets: a cleared default builds the preset-defined targets', () => {
+            expect(resolveDefaultBuildTargets(true, null, presetLabel, ['app', 'lib'], '')).to.deep.equal(['app', 'lib']);
+        });
+
+        test('presets: a cleared default with no preset targets builds the default (undefined)', () => {
+            expect(resolveDefaultBuildTargets(true, null, presetLabel, undefined, '')).to.equal(undefined);
+        });
+
+        test('presets: a cleared default with an empty preset targets array builds the default', () => {
+            expect(resolveDefaultBuildTargets(true, null, presetLabel, [], '')).to.deep.equal([]);
+        });
+
+        test('presets: a pinned concrete target is honored', () => {
+            expect(resolveDefaultBuildTargets(true, 'lib', presetLabel, ['app', 'lib'], '')).to.deep.equal(['lib']);
+        });
+
+        test('presets: a legacy persisted "[Targets In Preset]" label maps to the preset targets', () => {
+            expect(resolveDefaultBuildTargets(true, presetLabel, presetLabel, ['app'], '')).to.deep.equal(['app']);
+        });
+
+        test('presets: a single-string preset target is normalized to an array', () => {
+            expect(resolveDefaultBuildTargets(true, null, presetLabel, 'app', '')).to.deep.equal(['app']);
+        });
+
+        test('kits: a cleared default builds the all target', () => {
+            expect(resolveDefaultBuildTargets(false, null, presetLabel, undefined, 'all')).to.deep.equal(['all']);
+            expect(resolveDefaultBuildTargets(false, null, presetLabel, undefined, 'ALL_BUILD')).to.deep.equal(['ALL_BUILD']);
+        });
+
+        test('kits: a pinned concrete target is honored', () => {
+            expect(resolveDefaultBuildTargets(false, 'mylib', presetLabel, undefined, 'all')).to.deep.equal(['mylib']);
+        });
+    });
+});


### PR DESCRIPTION
## What

In CMake Presets mode, once a user selects a specific build target from the **Build Target** picker (status bar / Project Status / Project Outline), there was no way to return to the default **"[Targets In Preset]"** state — building the targets the active build preset defines, or the default target when it defines none.

The persisted default target got stuck, and the only known workaround was to quit VS Code and hand-edit the `activeBuildTarget` key out of VS Code's global-state SQLite database (`state.vscdb`). This PR makes the picker offer **"[Targets In Preset]"** again so the pin can be cleared from the UI.

Fixes #3587

## Why

The special **"[Targets In Preset]"** entry in `CMakeProject.showTargetSelector()` was only added when `buildPreset.targets` was set. That field is **optional** in a CMake build preset and is usually absent (CMake then builds the default target), so in the common case the entry was never offered. After pinning a concrete target, the user could never get back — the status bar kept showing the pinned target and every build used it.

## How

- **Always offer "[Targets In Preset]" from the default-target picker in presets mode.** `showTargetSelector(allowPresetReset)` gains a parameter; `cmake.setDefaultTarget` passes `true`. The one-shot **Build Target** command (`buildWithTarget`) keeps the previous behavior (only offers the entry when the preset declares explicit, non-empty targets) because without preset targets it would fall back to the pinned default.
- **Selecting it clears the persisted target to `null`.** `null` is the pristine default the whole codebase already interprets as "[Targets In Preset]" (status bar, `buildTargetName()`, project outline, `getDefaultBuildTargets()`), so builds follow the preset-defined targets (or the default target) again. This is exactly the state the manual SQLite workaround produced, and it is robust across VS Code UI-language changes (no localized string is persisted).
- **The reset selection uses a unique `Symbol` discriminant**, not a label/string, so it can never collide with a real CMake target name.
- Backward compatible: users who previously persisted the localized `"[Targets In Preset]"` label still resolve to the preset targets.
- Kits/variants mode is unchanged (the reset is never offered there).

The selection/reset decision logic lives in a new, `vscode`-free `src/buildTargetSelection.ts` so it is unit-tested directly.

## Testing

- New backend unit tests: `test/unit-tests/backend/build-target-selection.test.ts` (15 tests) — the gating truth table (kits never; default picker always in presets; one-shot only with explicit non-empty targets, incl. the `targets: []` edge case) and target resolution (cleared/null, legacy label, single-string, empty-array, kits all-target).
- `yarn backendTests` (full suite) passes; `tsc`, `eslint`, and the webpack build are clean.

### Manual verification
1. Open a project that uses CMake Presets with a build preset that has **no** `targets` field. Configure.
2. Build Target shows **[Targets In Preset]**. Set it to a specific target (e.g. a library) via the status bar or Project Status.
3. Open the Build Target picker again → **[Targets In Preset]** is offered at the top. Select it.
4. The build target reverts to **[Targets In Preset]** and a normal build builds the preset default again — no need to edit `state.vscdb`.