### PR TITLE
Pin GitHub Actions to full-length commit SHAs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    groups:
+      github-actions:
+        patterns: ["*"]
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/build-vsix.yml
+++ b/.github/workflows/build-vsix.yml
@@ -13,10 +13,10 @@ jobs:
 
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3.7.0
 
       - name: Setup Node.js environment
-        uses: actions/setup-node@v2.1.2
+        uses: actions/setup-node@c6fd00ceb9747fb23ffdf72987450a2664414867 # v2.1.2
         with:
           node-version: '22'
           check-latest: true
@@ -40,7 +40,7 @@ jobs:
           yarn run package
 
       - name: Upload Build Artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: cmake-tools.vsix
           path: ./cmake-tools.vsix

--- a/.github/workflows/ci-main-linux.yml
+++ b/.github/workflows/ci-main-linux.yml
@@ -15,10 +15,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Setup Node environment
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 22
           cache: 'yarn'
@@ -29,7 +29,7 @@ jobs:
       # Cache node_modules archive keyed on lockfile + os + arch + node version (keytar.node is arch-specific)
       - name: Restore node_modules cache
         id: node-modules-cache
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: .build/node_modules_cache
           key: node_modules-${{ runner.os }}-${{ runner.arch }}-node22-${{ hashFiles('yarn.lock', 'package.json') }}
@@ -65,7 +65,7 @@ jobs:
       # Cache fakebin to skip rebuild when source unchanged
       - name: Restore fakebin cache
         id: fakebin-cache
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: test/fakebin
           key: fakebin-${{ runner.os }}-${{ hashFiles('test/fakeOutputGenerator/CMakeLists.txt', 'test/fakeOutputGenerator/main.cpp', 'test/fakeOutputGenerator/configfiles/**') }}
@@ -93,7 +93,7 @@ jobs:
             test/fakebin
 
       - name: Upload build outputs
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: build-outputs-${{ runner.os }}
           path: build-outputs.tgz
@@ -119,10 +119,10 @@ jobs:
           - { name: e2e-multi-root,      cmd: 'yarn endToEndTestsMultiRoot-only',        timeout: 25 }
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Setup Node environment
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 22
           cache: 'yarn'
@@ -133,7 +133,7 @@ jobs:
       # Restore the SAME node_modules cache the build job populated (key must match).
       - name: Restore node_modules cache
         id: node-modules-cache
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: .build/node_modules_cache
           key: node_modules-${{ runner.os }}-${{ runner.arch }}-node22-${{ hashFiles('yarn.lock', 'package.json') }}
@@ -149,7 +149,7 @@ jobs:
         run: yarn install --frozen-lockfile
 
       - name: Download build outputs
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: build-outputs-${{ runner.os }}
 
@@ -169,7 +169,7 @@ jobs:
 
       # Cache VS Code download for E2E / smoke / unit / integration tests
       - name: Restore VS Code cache
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: .vscode-test
           key: vscode-test-${{ runner.os }}-1.131.0
@@ -203,7 +203,7 @@ jobs:
 
       - name: Upload test logs if tests failed
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: TestLogs-${{ runner.os }}-${{ matrix.suite.name }}
           path: test/**/log.txt

--- a/.github/workflows/ci-main-mac.yml
+++ b/.github/workflows/ci-main-mac.yml
@@ -15,10 +15,10 @@ jobs:
     runs-on: macos-26
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Setup Node environment
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 22
           cache: 'yarn'
@@ -29,7 +29,7 @@ jobs:
       # Cache node_modules archive keyed on lockfile + os + arch + node version (keytar.node is arch-specific)
       - name: Restore node_modules cache
         id: node-modules-cache
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: .build/node_modules_cache
           key: node_modules-${{ runner.os }}-${{ runner.arch }}-node22-${{ hashFiles('yarn.lock', 'package.json') }}
@@ -67,7 +67,7 @@ jobs:
       # Cache fakebin to skip rebuild when source unchanged
       - name: Restore fakebin cache
         id: fakebin-cache
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: test/fakebin
           key: fakebin-${{ runner.os }}-${{ hashFiles('test/fakeOutputGenerator/CMakeLists.txt', 'test/fakeOutputGenerator/main.cpp', 'test/fakeOutputGenerator/configfiles/**') }}
@@ -95,7 +95,7 @@ jobs:
             test/fakebin
 
       - name: Upload build outputs
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: build-outputs-${{ runner.os }}
           path: build-outputs.tgz
@@ -121,10 +121,10 @@ jobs:
           - { name: e2e-multi-root,          cmd: 'yarn endToEndTestsMultiRoot-only',        timeout: 25 }
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Setup Node environment
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 22
           cache: 'yarn'
@@ -135,7 +135,7 @@ jobs:
       # Restore the SAME node_modules cache the build job populated (key must match).
       - name: Restore node_modules cache
         id: node-modules-cache
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: .build/node_modules_cache
           key: node_modules-${{ runner.os }}-${{ runner.arch }}-node22-${{ hashFiles('yarn.lock', 'package.json') }}
@@ -151,7 +151,7 @@ jobs:
         run: yarn install --frozen-lockfile
 
       - name: Download build outputs
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: build-outputs-${{ runner.os }}
 
@@ -177,7 +177,7 @@ jobs:
 
       # Cache VS Code download for E2E / smoke / unit / integration tests
       - name: Restore VS Code cache
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: .vscode-test
           key: vscode-test-${{ runner.os }}-1.131.0
@@ -189,7 +189,7 @@ jobs:
 
       - name: Upload test logs if tests failed
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: TestLogs-${{ runner.os }}-${{ matrix.suite.name }}
           path: test/**/log.txt

--- a/.github/workflows/ci-main.win.yml
+++ b/.github/workflows/ci-main.win.yml
@@ -16,10 +16,10 @@ jobs:
 
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Setup Node environment
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 22
           cache: 'yarn'
@@ -30,7 +30,7 @@ jobs:
       # Cache node_modules archive keyed on lockfile + os + arch + node version (keytar.node is arch-specific)
       - name: Restore node_modules cache
         id: node-modules-cache
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: .build/node_modules_cache
           key: node_modules-${{ runner.os }}-${{ runner.arch }}-node22-${{ hashFiles('yarn.lock', 'package.json') }}
@@ -66,7 +66,7 @@ jobs:
       # Cache fakebin to skip rebuild when source unchanged
       - name: Restore fakebin cache
         id: fakebin-cache
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: test/fakebin
           key: fakebin-${{ runner.os }}-${{ hashFiles('test/fakeOutputGenerator/CMakeLists.txt', 'test/fakeOutputGenerator/main.cpp', 'test/fakeOutputGenerator/configfiles/**') }}
@@ -90,7 +90,7 @@ jobs:
             test/fakebin
 
       - name: Upload build outputs
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: build-outputs-${{ runner.os }}
           path: build-outputs.tgz
@@ -116,10 +116,10 @@ jobs:
           - { name: e2e-multi-root,      cmd: 'yarn endToEndTestsMultiRoot-only',        timeout: 25 }
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Setup Node environment
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 22
           cache: 'yarn'
@@ -130,7 +130,7 @@ jobs:
       # Restore the SAME node_modules cache the build job populated (key must match).
       - name: Restore node_modules cache
         id: node-modules-cache
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: .build/node_modules_cache
           key: node_modules-${{ runner.os }}-${{ runner.arch }}-node22-${{ hashFiles('yarn.lock', 'package.json') }}
@@ -146,7 +146,7 @@ jobs:
         run: yarn install --frozen-lockfile
 
       - name: Download build outputs
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: build-outputs-${{ runner.os }}
 
@@ -162,7 +162,7 @@ jobs:
 
       # Cache VS Code download for E2E / smoke / unit / integration tests
       - name: Restore VS Code cache
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: .vscode-test
           key: vscode-test-${{ runner.os }}-1.131.0
@@ -174,7 +174,7 @@ jobs:
 
       - name: Upload test logs if tests failed
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: TestLogs-${{ runner.os }}-${{ matrix.suite.name }}
           path: test/**/log.txt

--- a/.github/workflows/close-old-issues.yml
+++ b/.github/workflows/close-old-issues.yml
@@ -21,7 +21,7 @@ jobs:
       stale-label: stale-old
       stale-exempt-label: stale-exempt
     steps:
-    - uses: actions/stale@v5.1.0
+    - uses: actions/stale@532554b8a8498a0e006fbcde824b048728c4178f # v5.1.0
       with:
         stale-issue-label: ${{ env.stale-label }}
         exempt-issue-labels: ${{ env.stale-exempt-label }}

--- a/.github/workflows/close-stale-issues.yml
+++ b/.github/workflows/close-stale-issues.yml
@@ -13,7 +13,7 @@ jobs:
       stale-exempt-label: stale-exempt
       only-label: more info needed
     steps:
-    - uses: actions/stale@v5.1.0
+    - uses: actions/stale@532554b8a8498a0e006fbcde824b048728c4178f # v5.1.0
       with:
         stale-issue-label: ${{ env.stale-label }}
         exempt-issue-labels: ${{ env.stale-exempt-label }}

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -20,10 +20,10 @@ jobs:
       contents: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Set up Node.js 22
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 22
 

--- a/.github/workflows/generate-docs.yml
+++ b/.github/workflows/generate-docs.yml
@@ -16,10 +16,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3.7.0
 
       - name: Setup Node environment
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3.9.1
         with:
           node-version: 22
 

--- a/.github/workflows/locker.yml
+++ b/.github/workflows/locker.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Actions
-        uses: actions/checkout@v2
+        uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
       - name: Install Actions
         run: cd ./.github/actions && npm install --production && cd ../..
       - name: Run Locker

--- a/.github/workflows/more-info-needed-closer.yml
+++ b/.github/workflows/more-info-needed-closer.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Actions
-        uses: actions/checkout@v2
+        uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
       - name: Install Actions
         run: cd ./.github/actions && npm install --production && cd ../..
       - name: More Info Needed Closer

--- a/.github/workflows/question-closer.yml
+++ b/.github/workflows/question-closer.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Actions
-        uses: actions/checkout@v2
+        uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
       - name: Install Actions
         run: cd ./.github/actions && npm install --production && cd ../..
       - name: Question Closer

--- a/.github/workflows/triage-labels.yml
+++ b/.github/workflows/triage-labels.yml
@@ -14,6 +14,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Add triage label
-        uses: andymckay/labeler@e6c4322d0397f3240f0e7e30a33b5c5df2d39e90
+        uses: andymckay/labeler@e6c4322d0397f3240f0e7e30a33b5c5df2d39e90 # 1.0.4
         with:
           add-labels: triage


### PR DESCRIPTION
## Summary

This PR pins GitHub Actions to full-length commit SHAs for improved security and reproducibility and adds a 7 day cooldown to Dependabot configuration for GitHub Actions. This work is described in more detail at https://aka.ms/action-pinning.

## Why?

Pinning actions to commit SHAs prevents supply-chain attacks where a tag could be moved to point to malicious code. This is a recommended security best practice per the [GitHub Actions security hardening guide](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions).

This change mitigates the risk of tag retargeting to malicious code as seen in incidents like the [tj-actions/changed-files action compromise](https://www.stepsecurity.io/blog/harden-runner-detection-tj-actions-changed-files-action-is-compromised) or [codfish/semantic-release-action compromise](https://www.stepsecurity.io/blog/supply-chain-compromise-codfish-semantic-release-action) and improves the integrity and reproducibility of the CI/CD pipeline.

## What changed?

**Action pinning:** Third-party action references in `.github/workflows/` that used mutable tag-based references (e.g., `actions/checkout@v4`) have been updated to full-length commit SHAs with a version comment (e.g., `actions/checkout@<sha> # v4`) using the [pinact](https://github.com/suzuki-shunsuke/pinact) tool. References that were already pinned to a SHA, or that used immutable release tags, were left unchanged.

**Dependabot configuration:** `.github/dependabot.yml` has been updated to ensure a `github-actions` package-ecosystem section is present with a `cooldown` configuration (`default-days: 7`). If the file did not exist, it was created. If a `github-actions` section already existed, only the `cooldown` block was added or its `default-days` value was increased to 7 if it was lower. The 7-day cooldown provides a window for the community to detect and report compromised releases before they are automatically proposed as updates, reducing exposure to supply-chain attacks via newly published malicious versions.

## Is this safe to merge?

Yes. The pinned SHAs correspond to the same commits that the existing tags pointed to. No behavioral changes in action execution are introduced. You can verify the pinned SHA value using the GitHub REST API (e.g., the commit hash for `actions/checkout@v7` can be found in the `sha` property in the JSON response for `GET https://api.github.com/repos/actions/checkout/commits/v7`).

## Additional Information

For more information, please see https://aka.ms/action-pinning
