### PR TITLE
Fix brace-expansion DoS (CVE-2026-13149): pin patched 1.1.16+

### DIFF
--- a/package.json
+++ b/package.json
@@ -4591,7 +4591,7 @@
     "tmp": "^0.2.7",
     "jws": "^4.0.1",
     "serialize-javascript": "^7.0.4",
-    "**/minimatch/brace-expansion": "^1.1.13"
+    "**/minimatch/brace-expansion": "^1.1.16"
   },
   "packageManager": "yarn@1.22.22"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1616,10 +1616,10 @@ boolbase@^1.0.0:
   resolved "https://pkgs.dev.azure.com/azure-public/VisualCpp/_packaging/cpp_PublicPackages/npm/registry/boolbase/-/boolbase-1.0.0.tgz"
   integrity sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==
 
-brace-expansion@^1.1.13, brace-expansion@^1.1.7, brace-expansion@^2.0.1, brace-expansion@^2.0.2, brace-expansion@^5.0.2:
-  version "1.1.14"
-  resolved "https://pkgs.dev.azure.com/azure-public/VisualCpp/_packaging/cpp_PublicPackages/npm/registry/brace-expansion/-/brace-expansion-1.1.14.tgz#d9de602370d91347cd9ddad1224d4fd701eb348b"
-  integrity sha1-2d5gI3DZE0fNndrRIk1P1wHrNIs=
+brace-expansion@^1.1.16, brace-expansion@^1.1.7, brace-expansion@^2.0.1, brace-expansion@^2.0.2, brace-expansion@^5.0.2:
+  version "1.1.18"
+  resolved "https://pkgs.dev.azure.com/azure-public/VisualCpp/_packaging/cpp_PublicPackages/npm/registry/brace-expansion/-/brace-expansion-1.1.18.tgz#3ce74d89885136be1535341f8c3d4425c29a5cab"
+  integrity sha1-POdNiYhRNr4VNTQfjD1EJcKaXKs=
   dependencies:
     balanced-match "^1.0.0"
     concat-map "0.0.1"


### PR DESCRIPTION
## Change

- Bumps the `**/minimatch/brace-expansion` yarn resolution floor from `^1.1.13` → `^1.1.16` (the patched line), continuing the existing "pin all minimatch's brace-expansion to the 1.x maintenance line" strategy introduced in #4897.
- Regenerated `yarn.lock` against the dedicated Azure Artifacts feed; brace-expansion now resolves to **1.1.18** (patched, `> 1.1.16`) with the integrity hash on the resolved line.

Only `package.json` and `yarn.lock` change.

```
-brace-expansion@^1.1.13, ... : version "1.1.14"
+brace-expansion@^1.1.16, ... : version "1.1.18"
```

## Validation

Performed locally

- `yarn why brace-expansion` → single resolved version **1.1.18** for the entire tree (no vulnerable copy remains).
- `yarn install --frozen-lockfile` → consistent (CI-safe).
- Production webpack build (`compile-production-ci`) succeeds.
- VSIX packaging (`vsce package --yarn`) succeeds — exercises the `vsce → glob → minimatch → brace-expansion` path end-to-end.
- Backend tests: **403 passing**.
- Full VS Code extension-host launch (`unitTests`): extension **activates cleanly, 330 unit tests pass**, exit code 0, no brace-expansion/minimatch/glob errors.
