### PR TITLE
Fix configureOnOpen deleting CMakeCache.txt in presets mode with no generator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ Bug Fixes:
 - Fix “Make it easier for a new developer of CMake Tools to run tests” on Windows. [#4932](https://github.com/microsoft/vscode-cmake-tools/pull/4932) [@cwalther](https://github.com/cwalther)
 - Show the CMake Tools activity-bar view immediately with an "initializing" placeholder instead of hiding the entire sidebar until CMake, kit, preset, and Visual Studio developer-environment probing completes. On machines where those probes are intermittently slow (e.g. aggressive antivirus scanning of spawned processes, or extension-host file-handle exhaustion), the sidebar no longer disappears for minutes during activation. Project commands, menus, and status items remain gated on full readiness, so nothing runs against a partially-initialized project. [#5027](https://github.com/microsoft/vscode-cmake-tools/pull/5027)
 - Refresh the open CMake Cache Editor when configuration changes cache values externally. [#3635](https://github.com/microsoft/vscode-cmake-tools/issues/3635)
+- Preserve `CMakeCache.txt` on folder open with CMake Presets when the active configure preset specifies no generator, so `cmake.configureOnOpen` performs an incremental configure instead of deleting the cache and reconfiguring from scratch. [#5049](https://github.com/microsoft/vscode-cmake-tools/issues/5049)
 
 ## 1.23.52
 

--- a/src/drivers/cmakeFileApiDriver.ts
+++ b/src/drivers/cmakeFileApiDriver.ts
@@ -10,6 +10,7 @@ import {
     loadIndexFile,
     loadToolchains,
     CMakeDriver,
+    generatorMismatch,
     CMakePreconditionProblemSolver,
     ExecutableTarget,
     Index,
@@ -122,10 +123,13 @@ export class CMakeFileApiDriver extends CMakeDriver {
         // We need to treat this case as if the cache is not present and let a reconfigure
         // refresh the cache information.
         const cacheExists: boolean = await fs.exists(this.cachePath);
-        // When this.generator is null (e.g., __unspec__ kit with CMake >= 3.15 where CMake picks
-        // the default generator), treat it as "no explicit preference" and trust the existing cache
-        // rather than interpreting it as a generator mismatch that requires a clean reconfigure.
-        if (cacheExists && (this.generator === null || this.generator.name === await this.getGeneratorFromCache(this.cachePath))) {
+        // Only treat the existing cache as stale when the deduced generator genuinely differs from
+        // the one recorded in the cache. When this.generator is null/undefined (e.g. a CMake preset
+        // that specifies no generator, or the __unspec__ kit with CMake >= 3.15 where CMake picks
+        // the default generator) there is no explicit preference to conflict with, so the cache is
+        // trusted and configureOnOpen performs an incremental configure instead of deleting it.
+        const cachedGenerator = cacheExists ? await this.getGeneratorFromCache(this.cachePath) : undefined;
+        if (cacheExists && !generatorMismatch(this.generator?.name, cachedGenerator)) {
             await this.loadGeneratorInformationFromCache(this.cachePath);
             const code_model_exist = await this.updateCodeModel();
             if (!code_model_exist && this.config.configureOnOpen) {

--- a/test/unit-tests/generator-mismatch.test.ts
+++ b/test/unit-tests/generator-mismatch.test.ts
@@ -40,6 +40,15 @@ suite('Generator mismatch detection', () => {
         test('Returns true switching from Unix Makefiles to Ninja', () => {
             expect(generatorMismatch('Ninja', 'Unix Makefiles')).to.be.true;
         });
+
+        // #5049: In CMake presets mode a configure preset may omit "generator", leaving
+        // this.generator null/undefined. doInit() must then trust the existing cache (no mismatch)
+        // instead of deleting CMakeCache.txt and forcing a clean configure on every folder open.
+        test('#5049: preset without a generator never mismatches the cached default', () => {
+            expect(generatorMismatch(undefined, 'Unix Makefiles')).to.be.false;
+            expect(generatorMismatch(undefined, 'Ninja Multi-Config')).to.be.false;
+            expect(generatorMismatch(undefined, 'Visual Studio 17 2022')).to.be.false;
+        });
     });
 
     suite('CMakeCache.parseCache integration', () => {


### PR DESCRIPTION
## What
In CMake Presets mode, opening a folder with `cmake.configureOnOpen` enabled deleted `CMakeCache.txt` and did a full clean configure on every open, instead of an incremental configure.

Fixes #5049

## Why
A configure preset may omit the `generator` field, so the driver's deduced `this.generator` is `null` while the on-disk cache records a concrete `CMAKE_GENERATOR` (e.g. the default `Unix Makefiles`). `CMakeFileApiDriver.doInit()` compared these directly (`this.generator?.name === cachedGenerator`), so `undefined === "Unix Makefiles"` was `false` and the cache was deleted on every open.

## How
Route the cache-vs-generator decision in `doInit()` through the existing pure `generatorMismatch()` helper (already used by the kits path via `_hasGeneratorChanged`). It treats an absent generator (or an absent cached value) as "no explicit preference" and trusts the existing cache, while still cleanly reconfiguring when two concrete generators genuinely differ. This unifies the two previously-divergent code paths.

Note: the underlying deletion was already avoided on `main` by #4969 for the `null` generator case; this change hardens that behavior, extends it safely to a cache that lacks `CMAKE_GENERATOR`, and adds direct regression coverage.

## Testing
- Added a `#5049`-named case to `test/unit-tests/generator-mismatch.test.ts` covering a preset with no generator against several cached generators.
- `generator-mismatch` suite runs in the unit-test job; `tsc` and `eslint` pass.