### PR TITLE
Make localization readiness resilient to a read-only Actions token

### DIFF
--- a/.github/workflows/localization-readiness.yml
+++ b/.github/workflows/localization-readiness.yml
@@ -19,8 +19,11 @@ on:
 
 permissions:
   contents: read
+  # issues + pull-requests write cover the label/comment endpoints (they accept either). In orgs
+  # that cap the Actions token to read-only, these writes fail 403; the workflow degrades to the
+  # failing check plus inline annotations rather than erroring. See tools/localization-readiness.js.
   issues: write
-  pull-requests: read
+  pull-requests: write
 
 concurrency:
   group: localization-readiness-${{ github.event.pull_request.number }}

--- a/test/unit-tests/backend/localization-readiness.test.ts
+++ b/test/unit-tests/backend/localization-readiness.test.ts
@@ -6,11 +6,21 @@ const readiness = require(path.resolve(__dirname, '../../../tools/localization-r
 
 // A minimal in-memory mock of the pieces of the Octokit client the readiness logic uses. It records
 // label state and comments so a test can assert what the workflow would do to a real PR.
-function makeMockGitHub(options: { headSha: string; existingComments?: any[] }) {
+function makeMockGitHub(options: { headSha: string; existingComments?: any[]; writeErrorStatus?: number }) {
     const labels = new Set<string>();
     const comments: any[] = (options.existingComments || []).slice();
     const calls: { method: string; args: any }[] = [];
     let commentIdSeq = 1000;
+
+    // When writeErrorStatus is set, all label/comment mutations reject with that HTTP status — used
+    // to simulate a read-only GITHUB_TOKEN (403 "Resource not accessible by integration").
+    const maybeFail = () => {
+        if (options.writeErrorStatus) {
+            const err: any = new Error('Resource not accessible by integration');
+            err.status = options.writeErrorStatus;
+            throw err;
+        }
+    };
 
     const github: any = {
         rest: {
@@ -23,12 +33,14 @@ function makeMockGitHub(options: { headSha: string; existingComments?: any[] }) 
             issues: {
                 addLabels: async (args: any) => {
                     calls.push({ method: 'addLabels', args });
+                    maybeFail();
                     for (const l of args.labels) {
                         labels.add(l);
                     }
                 },
                 removeLabel: async (args: any) => {
                     calls.push({ method: 'removeLabel', args });
+                    maybeFail();
                     if (!labels.has(args.name)) {
                         const err: any = new Error('Label does not exist');
                         err.status = 404;
@@ -39,10 +51,12 @@ function makeMockGitHub(options: { headSha: string; existingComments?: any[] }) 
                 listComments: async () => comments,
                 createComment: async (args: any) => {
                     calls.push({ method: 'createComment', args });
+                    maybeFail();
                     comments.push({ id: ++commentIdSeq, user: { login: 'github-actions[bot]' }, body: args.body });
                 },
                 updateComment: async (args: any) => {
                     calls.push({ method: 'updateComment', args });
+                    maybeFail();
                     const c = comments.find((x) => x.id === args.comment_id);
                     if (c) {
                         c.body = args.body;
@@ -63,7 +77,11 @@ const context: any = {
     serverUrl: 'https://github.com',
     runId: 42
 };
-const core: any = { notice: () => { /* no-op */ } };
+const core: any = { notice: () => { /* no-op */ }, warning: () => { /* no-op */ } };
+function makeCore() {
+    const warnings: string[] = [];
+    return { core: { notice: () => { /* no-op */ }, warning: (m: string) => warnings.push(m) }, warnings };
+}
 
 const HEAD_SHA = 'abcdef1234567890abcdef1234567890abcdef12';
 
@@ -211,6 +229,52 @@ suite('Localization readiness signal', () => {
             expect([...mock.labels]).to.include(readiness.BLOCKING_LABEL); // re-added
             expect(mock.comments).to.have.length(1);
             expect(mock.comments[0].body).to.contain('NOT READY');
+        });
+    });
+
+    suite('read-only token resilience', () => {
+        test('isPermissionError is true only for a 403', () => {
+            expect(readiness.isPermissionError({ status: 403 })).to.equal(true);
+            expect(readiness.isPermissionError({ status: 404 })).to.equal(false);
+            expect(readiness.isPermissionError({ status: 500 })).to.equal(false);
+            expect(readiness.isPermissionError(undefined)).to.equal(false);
+        });
+
+        test('a 403 on label/comment writes is degraded, not thrown (the #5061 failure mode)', async () => {
+            const mock = makeMockGitHub({ headSha: HEAD_SHA, writeErrorStatus: 403 });
+            const { core: recCore, warnings } = makeCore();
+            let threw = false;
+            let result: any;
+            try {
+                result = await readiness.updateLocalizationReadiness({
+                    github: mock.github, context, core: recCore,
+                    verifyOutcome: 'failure', expectedHeadSha: HEAD_SHA,
+                    verifierOutput: '::error file=i18n/deu/src/presets/preset.i18n.json,title=Verified translation reverted::deu / using.vendor.vs.version: reverted.'
+                });
+            } catch {
+                threw = true;
+            }
+            expect(threw, 'a read-only token must not fail the readiness step').to.equal(false);
+            expect(result.degraded).to.equal(true);
+            expect(warnings.length, 'a warning is logged for each blocked write').to.be.greaterThan(0);
+            // It still attempted both writes (so it works the moment the token gains write access).
+            expect(mock.calls.some((c) => c.method === 'addLabels')).to.equal(true);
+            expect(mock.calls.some((c) => c.method === 'createComment' || c.method === 'updateComment')).to.equal(true);
+        });
+
+        test('a non-permission error (500) still throws', async () => {
+            const mock = makeMockGitHub({ headSha: HEAD_SHA, writeErrorStatus: 500 });
+            const { core: recCore } = makeCore();
+            let threw = false;
+            try {
+                await readiness.updateLocalizationReadiness({
+                    github: mock.github, context, core: recCore,
+                    verifyOutcome: 'failure', expectedHeadSha: HEAD_SHA, verifierOutput: ''
+                });
+            } catch {
+                threw = true;
+            }
+            expect(threw, 'an unexpected server error should not be silently swallowed').to.equal(true);
         });
     });
 });

--- a/tools/localization-readiness.js
+++ b/tools/localization-readiness.js
@@ -111,11 +111,23 @@ async function upsertStickyComment(github, { owner, repo, issue_number, body }) 
 }
 
 /**
+ * Whether an Octokit error is a permission failure. In organizations that restrict the Actions
+ * `GITHUB_TOKEN` to read-only, label/comment writes fail with 403 "Resource not accessible by
+ * integration" even when the workflow requests `issues: write`. The readiness signal degrades to the
+ * failing check plus the verifier's inline annotations in that case, rather than erroring the run.
+ * @param {any} error
+ */
+function isPermissionError(error) {
+    return !!error && error.status === 403;
+}
+
+/**
  * Reconcile the readiness signal (label + sticky comment) for the localization PR against the latest
  * verifier result. A stale run (whose head SHA no longer matches the PR) is skipped so it cannot
- * overwrite a newer run's result.
+ * overwrite a newer run's result. Label/comment writes are best-effort: if the token cannot write
+ * (read-only `GITHUB_TOKEN`), the failure is logged and the run continues so the check still enforces.
  * @param {{ github: any, context: any, core: any, verifyOutcome: string, expectedHeadSha: string, verifierOutput?: string }} args
- * @returns {Promise<{ skipped?: boolean, ready?: boolean }>}
+ * @returns {Promise<{ skipped?: boolean, ready?: boolean, degraded?: boolean }>}
  */
 async function updateLocalizationReadiness({ github, context, core, verifyOutcome, expectedHeadSha, verifierOutput }) {
     const owner = context.repo.owner;
@@ -141,19 +153,43 @@ async function updateLocalizationReadiness({ github, context, core, verifyOutcom
     }
     const issues = parseVerifierAnnotations(output);
 
-    await setReadinessLabel(github, { owner, repo, issue_number, ready });
+    let degraded = false;
+    const permissionHint = "The workflow's GITHUB_TOKEN cannot write to this pull request "
+        + "(read-only token). The failing check and the inline annotations still convey readiness; "
+        + "grant Actions read-write permissions to also get the label and comment.";
+
+    try {
+        await setReadinessLabel(github, { owner, repo, issue_number, ready });
+    } catch (error) {
+        if (isPermissionError(error)) {
+            degraded = true;
+            core.warning(`Could not update the "${BLOCKING_LABEL}" label: ${error.message}. ${permissionHint}`);
+        } else {
+            throw error;
+        }
+    }
 
     const runLink = `${context.serverUrl}/${owner}/${repo}/actions/runs/${context.runId}`;
     const body = buildReadinessComment({ ready, issues, shaShort: expectedHeadSha.slice(0, 7), runLink });
-    await upsertStickyComment(github, { owner, repo, issue_number, body });
+    try {
+        await upsertStickyComment(github, { owner, repo, issue_number, body });
+    } catch (error) {
+        if (isPermissionError(error)) {
+            degraded = true;
+            core.warning(`Could not post the localization readiness comment: ${error.message}. ${permissionHint}`);
+        } else {
+            throw error;
+        }
+    }
 
-    return { ready };
+    return { ready, degraded };
 }
 
 module.exports = {
     BLOCKING_LABEL,
     MARKER,
     OUTPUT_FILE,
+    isPermissionError,
     parseVerifierAnnotations,
     buildReadinessComment,
     setReadinessLabel,


### PR DESCRIPTION
## What

Makes the **Localization Readiness** check resilient when the Actions `GITHUB_TOKEN` is read-only, so it no longer errors while trying to post the label/comment, the failing check and inline annotations still convey readiness.

## Why

On the daily localization PR, the readiness workflow's `actions/github-script` step failed with `403 "Resource not accessible by integration"` when calling `issues.addLabels`, because the organization caps the Actions token to read-only (even though the workflow requests `issues: write`). That turned into an unhandled error in the run.

## How

- `tools/localization-readiness.js`: label and comment writes are now best-effort. A permission error (HTTP 403) is caught, logged with `core.warning`, and the run continues (`degraded: true`); any non-permission error still throws. The stale-head guard, the 404-tolerant label removal, and the recovery/oscillation behavior are unchanged.
- `.github/workflows/localization-readiness.yml`: `permissions` now requests `pull-requests: write` in addition to `issues: write` (the label endpoint accepts either), so the label and comment work automatically wherever the token is permitted to write.
- Tests: added coverage for the degraded path (a 403 degrades instead of throwing and still attempts both writes; a non-403 still throws).

## Enforcement is unchanged

The check's pass/fail is the **job conclusion** (the separate `Enforce` step), which is independent of any API write permission. So a not-ready import still turns the check **red** and the verifier's inline `::error` annotations still list every reverted/broken key, with or without write access. Only the label and sticky comment require write access.

To also get the `localization: not ready` label and the sticky comment (the fuller UX), enable **Settings → Actions → General → Workflow permissions → "Read and write permissions"** for the repo. No workflow change is then needed — it already requests both write scopes.

## Testing

`test/unit-tests/backend/localization-readiness.test.ts` (13 cases) — recovery lifecycle, oscillation, stale-head, 404 tolerance, and the new read-only-token degradation. Full backend suite passes; `tsc` and `eslint` clean.
