### PR TITLE
Presets: Fix vsInstanceVersion vendor field ignored when toolset is specified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ Bug Fixes:
 - Show the CMake Tools activity-bar view immediately with an "initializing" placeholder instead of hiding the entire sidebar until CMake, kit, preset, and Visual Studio developer-environment probing completes. On machines where those probes are intermittently slow (e.g. aggressive antivirus scanning of spawned processes, or extension-host file-handle exhaustion), the sidebar no longer disappears for minutes during activation. Project commands, menus, and status items remain gated on full readiness, so nothing runs against a partially-initialized project. [#5027](https://github.com/microsoft/vscode-cmake-tools/pull/5027)
 - Refresh the open CMake Cache Editor when configuration changes cache values externally. [#3635](https://github.com/microsoft/vscode-cmake-tools/issues/3635)
 - Preserve `CMakeCache.txt` on folder open with CMake Presets when the active configure preset specifies no generator, so `cmake.configureOnOpen` performs an incremental configure instead of deleting the cache and reconfiguring from scratch. [#5049](https://github.com/microsoft/vscode-cmake-tools/issues/5049)
+- Fix the `vsInstanceVersion` vendor field being ignored when a configure preset also specifies a `toolset`, causing the developer environment to be bootstrapped from the latest installed Visual Studio instance having the toolset compiler instead of the pinned major version. The pinned version is now applied as a filter before matching the requested toolset. [#5074](https://github.com/microsoft/vscode-cmake-tools/issues/5074)
 
 ## 1.23.52
 

--- a/src/presets/preset.ts
+++ b/src/presets/preset.ts
@@ -941,17 +941,16 @@ async function getVsDevEnv(opts: VsDevEnvOptions): Promise<EnvironmentWithNull |
             // Check for existence of vcvars script to determine whether desired host/target architecture is supported.
             // toolset.host will be set by getToolset.
             if (await getVcVarsBatScript(vs, toolset.host!, arch)) {
+                // If a VS major version is pinned via vendor settings, skip any instance that doesn't match it.
+                if (vendorVsVersion && !vs.installationVersion.startsWith(vendorVsVersion.toString())) {
+                    continue;
+                }
+
                 // If a toolset version is specified then check to make sure this vs instance has it installed.
                 if (toolset.version) {
                     const availableToolsets = await enumerateMsvcToolsets(vs.installationPath, vs.installationVersion);
                     // forcing non-null due to false positive (toolset.version is checked in conditional)
                     if (availableToolsets?.find(t => t.startsWith(toolset.version!))) {
-                        vsInstall = vs;
-                        break;
-                    }
-                } else if (vendorVsVersion) {
-                    // If a VS major version is specified via vendor settings, match against it.
-                    if (vs.installationVersion.startsWith(vendorVsVersion.toString())) {
                         vsInstall = vs;
                         break;
                     }


### PR DESCRIPTION
`vsInstanceVersion` vendor field at configure presets got ignored when `toolset` was specified, too.
This caused the wrong VS developer environment to be loaded.

The pinned version is now applied as a filter before matching the requested toolset, making `vsInstanceVersion` and `toolset` together useful.

Closes #5074.