### PR TITLE
Retry yarn install in CI to tolerate transient Azure Artifacts 429 throttling

### DIFF
--- a/.github/scripts/yarn-install.sh
+++ b/.github/scripts/yarn-install.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Run `yarn install` with retries and exponential-ish backoff.
+#
+# CI installs dependencies from the private Azure Artifacts mirror
+# (pkgs.dev.azure.com/azure-public/VisualCpp/_packaging/cpp_PublicPackages). Under load that feed
+# intermittently returns "429 Too Many Requests", which fails an otherwise-healthy build. This only
+# happens on a node_modules cache miss (e.g. a lockfile bump), so retrying the install a few times
+# with backoff lets the transient throttle clear instead of failing the whole job.
+#
+# Any arguments are forwarded verbatim to `yarn install` (e.g. --frozen-lockfile --ignore-scripts).
+# Invoke as: bash ./.github/scripts/yarn-install.sh [yarn install args...]
+set -uo pipefail
+
+attempts="${YARN_INSTALL_ATTEMPTS:-5}"
+sleep_base="${YARN_INSTALL_RETRY_SLEEP_BASE:-15}"
+
+for attempt in $(seq 1 "$attempts"); do
+  if yarn install "$@"; then
+    exit 0
+  fi
+  if [ "$attempt" -ge "$attempts" ]; then
+    echo "::error::yarn install failed after ${attempt} attempts (transient Azure Artifacts feed throttling?)"
+    exit 1
+  fi
+  wait_s=$(( attempt * sleep_base ))
+  echo "::warning::yarn install failed (attempt ${attempt}/${attempts}); retrying in ${wait_s}s..."
+  sleep "$wait_s"
+done

--- a/.github/workflows/build-vsix.yml
+++ b/.github/workflows/build-vsix.yml
@@ -33,9 +33,11 @@ jobs:
           include: "package.json"
           exclude: ".git"
 
+      - name: Install dependencies
+        run: bash ./.github/scripts/yarn-install.sh
+
       - name: Build the VSIX
-        run:  |
-          yarn install
+        run: |
           yarn run compile-production
           yarn run package
 

--- a/.github/workflows/ci-main-linux.yml
+++ b/.github/workflows/ci-main-linux.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Install dependencies
         if: steps.node-modules-cache.outputs.cache-hit != 'true'
-        run: yarn install --frozen-lockfile
+        run: bash ./.github/scripts/yarn-install.sh --frozen-lockfile
 
       - name: Create node_modules archive
         if: steps.node-modules-cache.outputs.cache-hit != 'true'
@@ -156,7 +156,7 @@ jobs:
       # Fallback: install fresh if the build job's cache was evicted between jobs (rare).
       - name: Install dependencies (fallback)
         if: steps.node-modules-cache.outputs.cache-hit != 'true'
-        run: yarn install --frozen-lockfile
+        run: bash ./.github/scripts/yarn-install.sh --frozen-lockfile
 
       - name: Download build outputs
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1

--- a/.github/workflows/ci-main-mac.yml
+++ b/.github/workflows/ci-main-mac.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Install dependencies
         if: steps.node-modules-cache.outputs.cache-hit != 'true'
-        run: yarn install --frozen-lockfile
+        run: bash ./.github/scripts/yarn-install.sh --frozen-lockfile
 
       - name: Create node_modules archive
         if: steps.node-modules-cache.outputs.cache-hit != 'true'
@@ -148,7 +148,7 @@ jobs:
       # Fallback: install fresh if the build job's cache was evicted between jobs (rare).
       - name: Install dependencies (fallback)
         if: steps.node-modules-cache.outputs.cache-hit != 'true'
-        run: yarn install --frozen-lockfile
+        run: bash ./.github/scripts/yarn-install.sh --frozen-lockfile
 
       - name: Download build outputs
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1

--- a/.github/workflows/ci-main.win.yml
+++ b/.github/workflows/ci-main.win.yml
@@ -42,7 +42,21 @@ jobs:
 
       - name: Install dependencies
         if: steps.node-modules-cache.outputs.cache-hit != 'true'
-        run: yarn install --frozen-lockfile
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Continue'
+          $attempts = 5
+          for ($attempt = 1; $attempt -le $attempts; $attempt++) {
+            yarn install --frozen-lockfile
+            if ($LASTEXITCODE -eq 0) { exit 0 }
+            if ($attempt -ge $attempts) {
+              Write-Host "::error::yarn install failed after $attempt attempts (transient Azure Artifacts feed throttling?)"
+              exit 1
+            }
+            $wait = $attempt * 15
+            Write-Host "::warning::yarn install failed (attempt $attempt/$attempts); retrying in ${wait}s..."
+            Start-Sleep -Seconds $wait
+          }
 
       - name: Create node_modules archive
         if: steps.node-modules-cache.outputs.cache-hit != 'true'
@@ -143,7 +157,21 @@ jobs:
       # Fallback: install fresh if the build job's cache was evicted between jobs (rare).
       - name: Install dependencies (fallback)
         if: steps.node-modules-cache.outputs.cache-hit != 'true'
-        run: yarn install --frozen-lockfile
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Continue'
+          $attempts = 5
+          for ($attempt = 1; $attempt -le $attempts; $attempt++) {
+            yarn install --frozen-lockfile
+            if ($LASTEXITCODE -eq 0) { exit 0 }
+            if ($attempt -ge $attempts) {
+              Write-Host "::error::yarn install failed after $attempt attempts (transient Azure Artifacts feed throttling?)"
+              exit 1
+            }
+            $wait = $attempt * 15
+            Write-Host "::warning::yarn install failed (attempt $attempt/$attempts); retrying in ${wait}s..."
+            Start-Sleep -Seconds $wait
+          }
 
       - name: Download build outputs
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1

--- a/.github/workflows/localization-readiness.yml
+++ b/.github/workflows/localization-readiness.yml
@@ -58,7 +58,7 @@ jobs:
 
       - name: Install dependencies
         if: steps.gate.outputs.is_loc == 'true'
-        run: yarn install --frozen-lockfile --ignore-scripts
+        run: bash ./.github/scripts/yarn-install.sh --frozen-lockfile --ignore-scripts
 
       - name: Verify imported translations
         id: verify


### PR DESCRIPTION
## What

Wraps every CI `yarn install` that pulls from the private Azure Artifacts npm mirror in a retry-with-backoff, so a transient "429 Too Many Requests" no longer fails an otherwise-healthy build.

## Why

The mirror (`pkgs.dev.azure.com/azure-public/VisualCpp/_packaging/cpp_PublicPackages`) intermittently returns `429 Too Many Requests` during `yarn install`. It happens only on a `node_modules` cache miss (for example a lockfile bump), and a single 429 kills the whole job — e.g. on 2026-09-08 the build job failed with `argparse-2.0.1.tgz: Request failed "429 Too Many Requests"` while the same commit's Linux build passed. There was no retry anywhere, and `build-vsix.yml` had no dependency cache at all (it always full-installs), so it is the most exposed. Re-running usually cleared it; this lets the pipeline self-heal instead.

## How

- New `.github/scripts/yarn-install.sh`: up to 5 attempts of `yarn install "$@"` with linear backoff (15s × attempt), a `::warning` per retry and a `::error` on exhaustion; exits 0 on success / 1 on failure. Arguments are forwarded verbatim (`--frozen-lockfile`, `--ignore-scripts`). Attempt count and backoff are overridable via env vars (used only for testing).
- `ci-main-linux.yml`, `ci-main-mac.yml`, `localization-readiness.yml`, `build-vsix.yml`: the `yarn install` steps now call that script (bash).
- `ci-main.win.yml` (windows-2022): an equivalent inline **pwsh** loop with `$ErrorActionPreference = 'Continue'`, so a native nonzero exit does not throw before the `$LASTEXITCODE` check.
- `build-vsix.yml`: the install is split into its own "Install dependencies" step (it was previously combined with compile/package in one step).
- `copilot-setup-steps.yml` is intentionally unchanged — it rewrites the registry to the public npm registry, so it never hits the throttled feed.

No install semantics change: on success the install runs exactly once and behaves identically; the retry only engages on failure, and `--frozen-lockfile` keeps it idempotent. A genuine (non-transient) failure still fails the job after the attempts are exhausted.

## Testing

- Verified the retry logic under **real bash** and **real pwsh 7** with a mocked `yarn`: succeeds-first-try runs once (exit 0); fails-twice-then-succeeds runs 3× (exit 0); always-fails exhausts the attempts (exit 1); arguments forward correctly.
- All five changed workflows pass `yaml.safe_load` and `actionlint` 1.7.12 with no new findings.
- The script is committed with LF endings (repo `.gitattributes` is `* eol=lf`).

## Notes

- Engineering / CI-only change; no user-facing behavior, so no `CHANGELOG` entry.
- `actionlint` surfaced a pre-existing, unrelated expression warning in `localization-readiness.yml:42` (a boolean `==` comparison, not shell injection — it already carries an explanatory comment). Left as-is to keep this PR scoped to the 429 fix.
